### PR TITLE
fix: remove ambiguous node_id conversion in `convert_node_id`

### DIFF
--- a/src/malla/utils/node_utils.py
+++ b/src/malla/utils/node_utils.py
@@ -391,20 +391,9 @@ def convert_node_id(node_id: int | str) -> int:
         elif node_id.startswith("0x"):
             # Hex format with 0x prefix
             return int(node_id, 16)
-        elif len(node_id) == 8 and all(c in "0123456789abcdefABCDEF" for c in node_id):
-            # 8-character hex string (typical Meshtastic node ID format)
-            # This is the format used by API routes like /api/node/{node_id:08x}/info
-            # Always treat as hex since that's what the API route expects
-            return int(node_id, 16)
-
-        # Try decimal first, then hex as fallback
-        try:
+        else:
+            # All other strings are treated as decimal
             return int(node_id, 10)
-        except ValueError:
-            try:
-                return int(node_id, 16)
-            except ValueError as err:
-                raise ValueError(f"Cannot convert '{node_id}' to integer") from err
 
     raise ValueError(f"Cannot convert {type(node_id)} to integer")
 

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -627,7 +627,7 @@ class TestDataConsistency:
             node_id = nodes_data["nodes"][0]["node_id"]
 
             # Get detailed info for the same node
-            info_response = client.get(f"/api/node/{node_id:08x}/info")
+            info_response = client.get(f"/api/node/{node_id}/info")
             info_data = info_response.get_json()
 
             # Verify the response structure

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -246,12 +246,12 @@ class TestTracerouteEndpoints:
     def test_traceroute_related_nodes_not_found(self, client):
         """Test traceroute related nodes endpoint with non-existent node."""
         # Test with a node ID that doesn't exist
-        # Note: "99999999" is treated as hex by convert_node_id, so 0x99999999 = 2576980377
+        # Note: "99999999" is now treated as decimal by convert_node_id
         response = client.get("/api/traceroute/related-nodes/99999999")
         assert response.status_code == 200
 
         data = response.get_json()
-        assert data["node_id"] == 2576980377  # 0x99999999 in decimal
+        assert data["node_id"] == 99999999  # Decimal value
         assert data["related_nodes"] == []
         assert data["total_count"] == 0
 

--- a/tests/unit/test_node_utils.py
+++ b/tests/unit/test_node_utils.py
@@ -189,7 +189,9 @@ class TestNodeUtilsOtherFunctions:
         # Strings with ! prefix should be treated as hex
         assert convert_node_id("!ABCDEF12") == int("ABCDEF12", 16)  # Hex
         assert convert_node_id("!12ABCDEF") == int("12ABCDEF", 16)  # Hex
-        assert convert_node_id("!0177dca1") == 24632481  # Hex representation of decimal 24632481
+        assert (
+            convert_node_id("!0177dca1") == 24632481
+        )  # Hex representation of decimal 24632481
 
         # Strings without ! prefix should be treated as decimal
         assert convert_node_id("99999999") == 99999999  # Decimal


### PR DESCRIPTION
If a node ID in an URL parameter was a 8-char _number_, it got treated as an hex node ID instead of a node ID. This was breaking the receptions API for nodes with decimal IDs that were 8-char long instead of 9-char/10-char.

This updates the conversion function to only convert the node IDs if they begin with ! or 0x - otherwise they will always be treated as decimal node IDs.