### PR TITLE
Removed fixed username for connection with MQTT broker

### DIFF
--- a/src/malla/mqtt_capture.py
+++ b/src/malla/mqtt_capture.py
@@ -1234,9 +1234,7 @@ def main() -> None:
     load_node_cache()
 
     # Initialize MQTT Client
-    mqtt_client = mqtt.Client(
-        CallbackAPIVersion.VERSION2, client_id="meshtastic_sqlite_capture"
-    )
+    mqtt_client = mqtt.Client(CallbackAPIVersion.VERSION2)
 
     if MQTT_USERNAME:
         mqtt_client.username_pw_set(MQTT_USERNAME, MQTT_PASSWORD)


### PR DESCRIPTION
Fixes issue #21
When connecting to a MQTT-broker with the same username the already active connection gets dropped.
When not providing a username paho.mqtt wil generate a random name upon connecting.