### PR TITLE
Add sorting function for receptions in packet detail view

### DIFF
--- a/src/malla/routes/packet_routes.py
+++ b/src/malla/routes/packet_routes.py
@@ -27,22 +27,39 @@ def sort_receptions_for_display(receptions: list[dict[str, Any]]) -> list[dict[s
     Ordering:
     - First by hop_count (ascending), with unknown hop_count at the end
     - Then by receiving gateway_id (alphabetically, with None/unknown last)
-    - Then by relay_node value (ascending) for stable ordering
+    - Then by relay_node value (ascending), with unknown relay_node at the end
+    - Finally by timestamp (ascending), with unknown timestamp at the end
     """
 
-    def _sort_key(reception: dict[str, Any]) -> tuple[int, str, int, float]:
+    def _sort_key(
+        reception: dict[str, Any],
+    ) -> tuple[bool, int, bool, str, bool, int, bool, float]:
         hop_count = reception.get("hop_count")
-        # Place unknown hop counts at the end
-        hop_sort = hop_count if isinstance(hop_count, int) else 9999
+        hop_is_unknown = not isinstance(hop_count, int)
+        hop_sort = hop_count if isinstance(hop_count, int) else 0
 
         gateway_id = reception.get("gateway_id")
-        # Normalize gateway_id so that None/empty sorts after real IDs
-        gateway_sort = gateway_id if isinstance(gateway_id, str) and gateway_id else "~~~~"
+        gateway_is_unknown = not (isinstance(gateway_id, str) and gateway_id)
+        gateway_sort = gateway_id if isinstance(gateway_id, str) and gateway_id else ""
 
-        relay_node = reception.get("relay_node") or 0
-        timestamp = float(reception.get("timestamp") or 0.0)
+        relay_node = reception.get("relay_node")
+        relay_is_unknown = not isinstance(relay_node, int)
+        relay_sort = relay_node if isinstance(relay_node, int) else 0
 
-        return (hop_sort, gateway_sort, int(relay_node), timestamp)
+        timestamp = reception.get("timestamp")
+        timestamp_is_unknown = not isinstance(timestamp, (int, float))
+        timestamp_sort = float(timestamp) if isinstance(timestamp, (int, float)) else 0.0
+
+        return (
+            hop_is_unknown,
+            hop_sort,
+            gateway_is_unknown,
+            gateway_sort,
+            relay_is_unknown,
+            relay_sort,
+            timestamp_is_unknown,
+            timestamp_sort,
+        )
 
     return sorted(receptions, key=_sort_key)
 

--- a/src/malla/routes/packet_routes.py
+++ b/src/malla/routes/packet_routes.py
@@ -21,6 +21,32 @@ logger = logging.getLogger(__name__)
 packet_bp = Blueprint("packet", __name__)
 
 
+def sort_receptions_for_display(receptions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Sort receptions for display on the packet detail page.
+
+    Ordering:
+    - First by hop_count (ascending), with unknown hop_count at the end
+    - Then by receiving gateway_id (alphabetically, with None/unknown last)
+    - Then by relay_node value (ascending) for stable ordering
+    """
+
+    def _sort_key(reception: dict[str, Any]) -> tuple[int, str, int, float]:
+        hop_count = reception.get("hop_count")
+        # Place unknown hop counts at the end
+        hop_sort = hop_count if isinstance(hop_count, int) else 9999
+
+        gateway_id = reception.get("gateway_id")
+        # Normalize gateway_id so that None/empty sorts after real IDs
+        gateway_sort = gateway_id if isinstance(gateway_id, str) and gateway_id else "~~~~"
+
+        relay_node = reception.get("relay_node") or 0
+        timestamp = float(reception.get("timestamp") or 0.0)
+
+        return (hop_sort, gateway_sort, int(relay_node), timestamp)
+
+    return sorted(receptions, key=_sort_key)
+
+
 def get_packet_details(packet_id: int) -> dict[str, Any] | None:
     """Get comprehensive details for a specific packet including all receptions."""
     logger.info(f"Getting packet details for packet {packet_id}")
@@ -110,8 +136,7 @@ def get_packet_details(packet_id: int) -> dict[str, Any] | None:
             packet["relay_candidates"] = []
 
         # Find all receptions of the same packet using mesh_packet_id (preferred) or fallback to time-based
-        receptions = []
-
+        receptions: list[dict[str, Any]] = []
         if packet["mesh_packet_id"] is not None:
             # Use mesh_packet_id for accurate correlation
             cursor.execute(
@@ -200,6 +225,10 @@ def get_packet_details(packet_id: int) -> dict[str, Any] | None:
             else:
                 reception["relay_hex"] = None
                 reception["relay_candidates"] = []
+
+        # Sort receptions for nicer presentation on the packet detail page
+        if receptions:
+            receptions = sort_receptions_for_display(receptions)
 
         # Execute batched relay candidate query
         if relay_requests:

--- a/src/malla/templates/components/receptions.html
+++ b/src/malla/templates/components/receptions.html
@@ -117,8 +117,28 @@
                         </td>
                     </tr>
 
-                    <!-- Other receptions -->
+                    <!-- Other receptions, grouped by hop count -->
+                    {% if other_receptions %}
+                    {% set ns = namespace(current_hop = None) %}
                     {% for reception in other_receptions %}
+                    {% set hop_value = reception.hop_count if reception.hop_count is not none else 'Unknown' %}
+                    {% if ns.current_hop != hop_value %}
+                    {% set ns.current_hop = hop_value %}
+                    <tr class="table-secondary">
+                        <td colspan="9">
+                            {% if hop_value == 'Unknown' %}
+                                <strong>Unknown hop count</strong>
+                                <small class="text-muted ms-2">Receptions without hop information</small>
+                            {% elif hop_value == 0 %}
+                                <strong>0 hops (direct receptions)</strong>
+                                <small class="text-muted ms-2">Gateways that heard the packet directly from the source</small>
+                            {% else %}
+                                <strong>{{ hop_value }} hops</strong>
+                                <small class="text-muted ms-2">Gateways that received this packet after {{ hop_value }} hops</small>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    {% endif %}
                     <tr>
                         <td>
                             {% if reception.gateway_id and reception.gateway_id != "Unknown Gateway" %}
@@ -186,8 +206,7 @@
                         </td>
                     </tr>
                     {% endfor %}
-
-                    {% if not other_receptions %}
+                    {% else %}
                     <tr>
                         <td colspan="9" class="text-center text-muted">
                             <i class="bi bi-info-circle"></i>

--- a/src/malla/templates/components/receptions.html
+++ b/src/malla/templates/components/receptions.html
@@ -133,8 +133,9 @@
                                 <strong>0 hops (direct receptions)</strong>
                                 <small class="text-muted ms-2">Gateways that heard the packet directly from the source</small>
                             {% else %}
-                                <strong>{{ hop_value }} hops</strong>
-                                <small class="text-muted ms-2">Gateways that received this packet after {{ hop_value }} hops</small>
+                                {% set hop_label = 'hop' if hop_value == 1 else 'hops' %}
+                                <strong>{{ hop_value }} {{ hop_label }}</strong>
+                                <small class="text-muted ms-2">Gateways that received this packet after {{ hop_value }} {{ hop_label }}</small>
                             {% endif %}
                         </td>
                     </tr>

--- a/tests/unit/test_packet_reception_sorting.py
+++ b/tests/unit/test_packet_reception_sorting.py
@@ -1,6 +1,10 @@
 """Tests for reception sorting on the packet detail page."""
 
+import pytest
+
 from malla.routes.packet_routes import sort_receptions_for_display
+
+pytestmark = pytest.mark.unit
 
 
 def test_sort_receptions_for_display_orders_by_hop_then_gateway_then_relay():
@@ -65,4 +69,3 @@ def test_sort_receptions_for_display_handles_missing_fields_gracefully():
 
     # Known hop_count (0) should come before unknown
     assert [r["id"] for r in sorted_receptions] == [2, 1]
-

--- a/tests/unit/test_packet_reception_sorting.py
+++ b/tests/unit/test_packet_reception_sorting.py
@@ -1,0 +1,68 @@
+"""Tests for reception sorting on the packet detail page."""
+
+from malla.routes.packet_routes import sort_receptions_for_display
+
+
+def test_sort_receptions_for_display_orders_by_hop_then_gateway_then_relay():
+    receptions = [
+        {
+            "id": 3,
+            "timestamp": 300.0,
+            "hop_count": 2,
+            "gateway_id": "!BBBBBBBB",
+            "relay_node": 0x12340002,
+        },
+        {
+            "id": 1,
+            "timestamp": 100.0,
+            "hop_count": 1,
+            "gateway_id": "!CCCCCCCC",
+            "relay_node": 0x12340003,
+        },
+        {
+            "id": 4,
+            "timestamp": 400.0,
+            "hop_count": None,
+            "gateway_id": "!AAAAAAA0",
+            "relay_node": 0x12340004,
+        },
+        {
+            "id": 2,
+            "timestamp": 200.0,
+            "hop_count": 1,
+            "gateway_id": "!BBBBBBBB",
+            "relay_node": 0x12340001,
+        },
+    ]
+
+    sorted_receptions = sort_receptions_for_display(receptions)
+
+    # Expected order:
+    # - hop_count 1 first, then 2, then None (unknown)
+    # - within hop_count 1: by gateway_id, then relay_node
+    assert [r["id"] for r in sorted_receptions] == [2, 1, 3, 4]
+
+
+def test_sort_receptions_for_display_handles_missing_fields_gracefully():
+    receptions = [
+        {
+            "id": 1,
+            "timestamp": None,
+            "hop_count": None,
+            "gateway_id": None,
+            "relay_node": None,
+        },
+        {
+            "id": 2,
+            # No timestamp key at all
+            "hop_count": 0,
+            "gateway_id": "!11111111",
+            # No relay_node key at all
+        },
+    ]
+
+    sorted_receptions = sort_receptions_for_display(receptions)
+
+    # Known hop_count (0) should come before unknown
+    assert [r["id"] for r in sorted_receptions] == [2, 1]
+


### PR DESCRIPTION
- Implemented `sort_receptions_for_display` to order receptions by hop count, gateway ID, and relay node for better presentation.
- Updated `get_packet_details` to utilize the new sorting function.
- Added unit tests to verify sorting behavior and handling of missing fields.

This enhances the user experience on the packet detail page by providing a clearer display of reception data.