### PR TITLE
Optimize startup indexes and hot graph queries

### DIFF
--- a/src/malla/database/connection.py
+++ b/src/malla/database/connection.py
@@ -9,6 +9,8 @@ import sqlite3
 # Prefer configuration loader over environment variables
 from malla.config import get_config
 
+from .schema import ensure_startup_schema
+
 logger = logging.getLogger(__name__)
 
 
@@ -55,14 +57,6 @@ def get_db_connection() -> sqlite3.Connection:
         cursor.execute("PRAGMA cache_size=10000")  # 10MB cache
         cursor.execute("PRAGMA temp_store=MEMORY")
 
-        # ------------------------------------------------------------------
-        # Lightweight schema migrations – run once per connection.
-        # ------------------------------------------------------------------
-        try:
-            _ensure_schema_migrations(cursor)
-        except Exception as e:
-            logger.warning(f"Schema migration check failed: {e}")
-
         return conn
     except Exception as e:
         logger.error(f"Failed to connect to database: {e}")
@@ -93,6 +87,8 @@ def init_database() -> None:
 
         # Test a simple query to verify the database is accessible
         cursor = conn.cursor()
+        ensure_startup_schema(cursor)
+        conn.commit()
         cursor.execute("SELECT COUNT(*) FROM sqlite_master WHERE type='table'")
         table_count = cursor.fetchone()[0]
 
@@ -110,53 +106,3 @@ def init_database() -> None:
         logger.error(f"Database initialization failed: {e}")
         # Don't raise the exception - let the app start anyway
         # The database might not exist yet or be created by another process
-
-
-# ----------------------------------------------------------------------
-# Internal helpers
-# ----------------------------------------------------------------------
-
-
-_SCHEMA_MIGRATIONS_DONE: set[str] = set()
-
-
-def _ensure_schema_migrations(cursor: sqlite3.Cursor) -> None:
-    """Run any idempotent schema updates that the application depends on.
-
-    Currently this checks that ``node_info`` has a ``primary_channel`` column
-    (added in April 2024) so queries that reference it do not fail when the
-    database was created with an older version of the schema.
-
-    The function is **safe** to run repeatedly – it will only attempt each
-    migration once per Python process and each individual migration is
-    guarded with a try/except that ignores the *duplicate column* error.
-    """
-
-    global _SCHEMA_MIGRATIONS_DONE  # pylint: disable=global-statement
-
-    # Quickly short-circuit if we've already handled migrations in this process
-    if "primary_channel" in _SCHEMA_MIGRATIONS_DONE:
-        return
-
-    try:
-        # Check whether the column already exists
-        cursor.execute("PRAGMA table_info(node_info)")
-        columns = [row[1] for row in cursor.fetchall()]
-
-        if "primary_channel" not in columns:
-            cursor.execute("ALTER TABLE node_info ADD COLUMN primary_channel TEXT")
-            cursor.execute(
-                "CREATE INDEX IF NOT EXISTS idx_node_primary_channel ON node_info(primary_channel)"
-            )
-            logging.info(
-                "Added primary_channel column to node_info table via auto-migration"
-            )
-
-        _SCHEMA_MIGRATIONS_DONE.add("primary_channel")
-    except sqlite3.OperationalError as exc:
-        # Ignore errors about duplicate columns in race situations – another
-        # process may have altered the table first.
-        if "duplicate column name" in str(exc).lower():
-            _SCHEMA_MIGRATIONS_DONE.add("primary_channel")
-        else:
-            raise

--- a/src/malla/database/repositories.py
+++ b/src/malla/database/repositories.py
@@ -24,20 +24,6 @@ logger = logging.getLogger(__name__)
 RELAY_CANDIDATE_CACHE_TTL_SECONDS = 1800
 RELAY_CANDIDATE_CACHE_MAX_ENTRIES = 4096
 _relay_candidate_cache: dict[tuple[int, int], tuple[float, list[dict[str, Any]]]] = {}
-_relay_candidate_indexes_ready: set[str] = set()
-
-
-def _get_db_identity(cursor) -> str:
-    try:
-        cursor.execute("PRAGMA database_list")
-        row = cursor.fetchone()
-        if row and len(row) >= 3:
-            return f"db:{row[2] or ':memory:'}"
-    except Exception:
-        pass
-
-    connection = getattr(cursor, "connection", None)
-    return f"connection:{id(connection) if connection is not None else id(cursor)}"
 
 
 def _prune_relay_candidate_cache(now: float) -> None:
@@ -84,34 +70,6 @@ def _store_relay_candidates(
         now,
         [candidate.copy() for candidate in candidates],
     )
-
-
-def _ensure_relay_candidate_indexes(cursor) -> None:
-    cache_key = _get_db_identity(cursor)
-    if cache_key in _relay_candidate_indexes_ready:
-        return
-
-    cursor.execute(
-        """CREATE INDEX IF NOT EXISTS idx_packet_history_direct_gateway_from
-           ON packet_history(gateway_id, from_node_id)
-           WHERE hop_start = hop_limit AND from_node_id IS NOT NULL"""
-    )
-    cursor.execute(
-        """CREATE INDEX IF NOT EXISTS idx_packet_history_direct_gateway_lastbyte
-           ON packet_history(gateway_id, (from_node_id & 255))
-           WHERE hop_start = hop_limit AND from_node_id IS NOT NULL"""
-    )
-    cursor.execute(
-        """CREATE INDEX IF NOT EXISTS idx_packet_history_direct_from_gateway
-           ON packet_history(from_node_id, gateway_id)
-           WHERE hop_start = hop_limit AND gateway_id IS NOT NULL"""
-    )
-    cursor.execute(
-        """CREATE INDEX IF NOT EXISTS idx_packet_history_direct_from_gateway_suffix
-           ON packet_history(from_node_id, lower(substr(gateway_id, -2)))
-           WHERE hop_start = hop_limit AND gateway_id IS NOT NULL"""
-    )
-    _relay_candidate_indexes_ready.add(cache_key)
 
 
 class DashboardRepository:
@@ -1278,40 +1236,56 @@ class NodeRepository:
             if node_id <= 0:
                 return None
 
-            # Get basic node information from packet_history with node_info join
-            query = """
-            SELECT
-                p.from_node_id as node_id,
-                COALESCE(n.long_name, n.short_name, 'Node ' || p.from_node_id) as node_name,
-                n.long_name,
-                n.short_name,
-                n.hw_model,
-                n.role,
-                n.primary_channel,
-                COUNT(*) as total_packets,
-                MAX(p.timestamp) as last_seen,
-                MIN(p.timestamp) as first_seen,
-                COUNT(DISTINCT p.to_node_id) as unique_destinations,
-                COUNT(DISTINCT p.gateway_id) as unique_gateways,
-                AVG(CASE WHEN (p.hop_start IS NULL OR p.hop_limit IS NULL OR (p.hop_start - p.hop_limit) = 0)
-                     THEN CAST(p.rssi AS FLOAT) END) as avg_rssi,
-                AVG(CASE WHEN (p.hop_start IS NULL OR p.hop_limit IS NULL OR (p.hop_start - p.hop_limit) = 0)
-                     THEN CAST(p.snr AS FLOAT) END) as avg_snr,
-                AVG(CASE WHEN p.hop_start IS NOT NULL AND p.hop_limit IS NOT NULL
-                    THEN (p.hop_start - p.hop_limit) ELSE NULL END) as avg_hops
-            FROM packet_history p
-            LEFT JOIN node_info n ON p.from_node_id = n.node_id
-            WHERE p.from_node_id = ?
-            GROUP BY p.from_node_id, n.long_name, n.short_name, n.hw_model, n.role, n.primary_channel
-            """
+            # Aggregate only packet_history here so SQLite can use the sender-focused index.
+            cursor.execute(
+                """
+                SELECT
+                    COUNT(*) as total_packets,
+                    MAX(timestamp) as last_seen,
+                    MIN(timestamp) as first_seen,
+                    COUNT(DISTINCT to_node_id) as unique_destinations,
+                    COUNT(DISTINCT gateway_id) as unique_gateways,
+                    AVG(CASE WHEN hop_start IS NULL OR hop_limit IS NULL OR hop_start = hop_limit
+                         THEN CAST(rssi AS FLOAT) END) as avg_rssi,
+                    AVG(CASE WHEN hop_start IS NULL OR hop_limit IS NULL OR hop_start = hop_limit
+                         THEN CAST(snr AS FLOAT) END) as avg_snr,
+                    AVG(CASE WHEN hop_start IS NOT NULL AND hop_limit IS NOT NULL
+                        THEN (hop_start - hop_limit) ELSE NULL END) as avg_hops
+                FROM packet_history
+                WHERE from_node_id = ?
+                """,
+                (node_id,),
+            )
+            node_stats_row = cursor.fetchone()
 
-            cursor.execute(query, (node_id,))
-            node_row = cursor.fetchone()
+            cursor.execute(
+                """
+                SELECT
+                    node_id,
+                    long_name,
+                    short_name,
+                    hw_model,
+                    role,
+                    primary_channel
+                FROM node_info
+                WHERE node_id = ?
+                """,
+                (node_id,),
+            )
+            node_info_row = cursor.fetchone()
 
-            if not node_row:
+            if (
+                node_info_row is None
+                and node_stats_row
+                and "node_id" in node_stats_row.keys()
+            ):
+                node_info_row = node_stats_row
+
+            if not node_stats_row or "total_packets" not in node_stats_row.keys():
+                node_stats_row = None
+
+            if not node_stats_row or node_stats_row["total_packets"] == 0:
                 # Check if node exists in node_info but has no packets
-                cursor.execute("SELECT * FROM node_info WHERE node_id = ?", (node_id,))
-                node_info_row = cursor.fetchone()
                 if not node_info_row:
                     conn.close()
                     return None
@@ -1348,41 +1322,43 @@ class NodeRepository:
                 }
 
             # Convert Unix timestamps to UTC datetimes to avoid local timezone drift
-            last_seen = datetime.fromtimestamp(node_row["last_seen"], UTC)
-            first_seen = datetime.fromtimestamp(node_row["first_seen"], UTC)
+            last_seen = datetime.fromtimestamp(node_stats_row["last_seen"], UTC)
+            first_seen = datetime.fromtimestamp(node_stats_row["first_seen"], UTC)
 
             # Use proper hex formatting for node name
             proper_node_name = (
-                node_row["long_name"] or node_row["short_name"] or f"!{node_id:08x}"
+                (node_info_row["long_name"] if node_info_row else None)
+                or (node_info_row["short_name"] if node_info_row else None)
+                or f"!{node_id:08x}"
             )
 
             node_info = {
-                "node_id": node_row["node_id"],
+                "node_id": node_id,
                 "hex_id": f"!{node_id:08x}",
                 "node_name": proper_node_name,
-                "long_name": node_row["long_name"],
-                "short_name": node_row["short_name"],
-                "hw_model": node_row["hw_model"],
-                "role": node_row["role"],
-                "primary_channel": node_row["primary_channel"]
-                if "primary_channel" in node_row.keys()
+                "long_name": node_info_row["long_name"] if node_info_row else None,
+                "short_name": node_info_row["short_name"] if node_info_row else None,
+                "hw_model": node_info_row["hw_model"] if node_info_row else None,
+                "role": node_info_row["role"] if node_info_row else None,
+                "primary_channel": node_info_row["primary_channel"]
+                if node_info_row and "primary_channel" in node_info_row.keys()
                 else None,
-                "total_packets": node_row["total_packets"],
+                "total_packets": node_stats_row["total_packets"],
                 "last_seen": last_seen.strftime("%Y-%m-%d %H:%M:%S UTC"),
                 "last_seen_timestamp": last_seen.timestamp(),  # Raw Unix timestamp for client-side formatting
                 "first_seen": first_seen.strftime("%Y-%m-%d %H:%M:%S UTC"),
                 "first_seen_timestamp": first_seen.timestamp(),  # Raw Unix timestamp for client-side formatting
                 "last_seen_relative": format_time_ago(last_seen),
-                "unique_destinations": node_row["unique_destinations"],
-                "unique_gateways": node_row["unique_gateways"],
-                "avg_rssi": round(node_row["avg_rssi"], 1)
-                if node_row["avg_rssi"]
+                "unique_destinations": node_stats_row["unique_destinations"],
+                "unique_gateways": node_stats_row["unique_gateways"],
+                "avg_rssi": round(node_stats_row["avg_rssi"], 1)
+                if node_stats_row["avg_rssi"]
                 else None,
-                "avg_snr": round(node_row["avg_snr"], 1)
-                if node_row["avg_snr"]
+                "avg_snr": round(node_stats_row["avg_snr"], 1)
+                if node_stats_row["avg_snr"]
                 else None,
-                "avg_hops": round(node_row["avg_hops"], 1)
-                if node_row["avg_hops"]
+                "avg_hops": round(node_stats_row["avg_hops"], 1)
+                if node_stats_row["avg_hops"]
                 else None,
             }
 
@@ -1763,7 +1739,19 @@ class NodeRepository:
                 )
 
             # Get received gateways information (gateways that have received packets from this node)
-            gateways_query = """
+            gateways_query = f"""
+            WITH top_gateways AS (
+                SELECT
+                    p.gateway_id,
+                    COUNT(*) as direct_packet_count
+                FROM packet_history p INDEXED BY idx_packet_history_direct_from_gateway
+                WHERE p.from_node_id = ?
+                  AND p.gateway_id IS NOT NULL
+                  AND p.hop_start = p.hop_limit
+                GROUP BY p.gateway_id
+                ORDER BY direct_packet_count DESC
+                LIMIT 15
+            )
             SELECT
                 p.gateway_id,
                 COUNT(*) as packet_count,
@@ -1776,20 +1764,20 @@ class NodeRepository:
                     THEN (p.hop_start - p.hop_limit) ELSE NULL END) as max_hops,
                 AVG(CASE WHEN p.hop_start IS NOT NULL AND p.hop_limit IS NOT NULL
                     THEN (p.hop_start - p.hop_limit) ELSE NULL END) as avg_hops,
-                -- Get RSSI/SNR for direct connections (hops = 0) separately
-                AVG(CASE WHEN (p.hop_start - p.hop_limit) = 0
+                AVG(CASE WHEN p.hop_start = p.hop_limit
                     THEN CAST(p.rssi AS FLOAT) ELSE NULL END) as direct_rssi,
-                AVG(CASE WHEN (p.hop_start - p.hop_limit) = 0
+                AVG(CASE WHEN p.hop_start = p.hop_limit
                     THEN CAST(p.snr AS FLOAT) ELSE NULL END) as direct_snr,
-                COUNT(CASE WHEN (p.hop_start - p.hop_limit) = 0 THEN 1 END) as direct_packet_count
-            FROM packet_history p
-            WHERE p.from_node_id = ? AND p.gateway_id IS NOT NULL
+                MAX(tg.direct_packet_count) as direct_packet_count
+            FROM top_gateways tg
+            JOIN packet_history p INDEXED BY idx_packet_history_from_time_desc
+              ON p.gateway_id = tg.gateway_id
+            WHERE p.from_node_id = ?
             GROUP BY p.gateway_id
-            ORDER BY (direct_packet_count > 0) DESC, packet_count DESC
-            LIMIT 15
+            ORDER BY direct_packet_count DESC, packet_count DESC
             """
 
-            cursor.execute(gateways_query, (node_id,))
+            cursor.execute(gateways_query, (node_id, node_id))
             try:
                 gateways_raw = cursor.fetchall()
             except StopIteration:
@@ -2048,8 +2036,6 @@ class NodeRepository:
             if not gateway_node_ids or not relay_last_bytes:
                 return {}
 
-            _ensure_relay_candidate_indexes(cursor)
-
             now = time.time()
             _prune_relay_candidate_cache(now)
 
@@ -2217,8 +2203,6 @@ class NodeRepository:
             unique_pairs = sorted(set(relay_pairs))
             if not unique_pairs:
                 return {}
-
-            _ensure_relay_candidate_indexes(cursor)
 
             now = time.time()
             _prune_relay_candidate_cache(now)
@@ -2609,7 +2593,7 @@ class NodeRepository:
                   AND p.from_node_id != ?
                   AND p.hop_start IS NOT NULL
                   AND p.hop_limit IS NOT NULL
-                  AND (p.hop_start - p.hop_limit) = 0
+                  AND p.hop_start = p.hop_limit
                 GROUP BY p.from_node_id, ni.long_name, ni.short_name
                 ORDER BY packet_count DESC
             """
@@ -2631,7 +2615,7 @@ class NodeRepository:
                   AND p.from_node_id != ?
                   AND p.hop_start IS NOT NULL
                   AND p.hop_limit IS NOT NULL
-                  AND (p.hop_start - p.hop_limit) = 0
+                  AND p.hop_start = p.hop_limit
                 ORDER BY p.timestamp
             """
 
@@ -2747,7 +2731,7 @@ class NodeRepository:
                       AND p.from_node_id != ?
                       AND p.hop_start IS NOT NULL
                       AND p.hop_limit IS NOT NULL
-                      AND (p.hop_start - p.hop_limit) = 0
+                      AND p.hop_start = p.hop_limit
                     GROUP BY p.from_node_id, ni.long_name, ni.short_name
                     ORDER BY packet_count DESC
                     LIMIT ?
@@ -2767,15 +2751,43 @@ class NodeRepository:
                       AND p.from_node_id != ?
                       AND p.hop_start IS NOT NULL
                       AND p.hop_limit IS NOT NULL
-                      AND (p.hop_start - p.hop_limit) = 0
+                      AND p.hop_start = p.hop_limit
                     ORDER BY p.timestamp
                 """
 
                 cursor.execute(stats_query, (gateway_hex_id, node_id, limit))
                 stats_rows = cursor.fetchall()
 
-                cursor.execute(packets_query, (gateway_hex_id, node_id))
-                packet_rows = cursor.fetchall()
+                selected_node_ids = [
+                    stats_row["from_node_id"]
+                    for stats_row in stats_rows
+                    if stats_row["from_node_id"] is not None
+                ]
+
+                if selected_node_ids:
+                    placeholders = ",".join(["?"] * len(selected_node_ids))
+                    packets_query = f"""
+                        SELECT
+                            p.id AS packet_id,
+                            p.timestamp,
+                            p.from_node_id,
+                            p.rssi,
+                            p.snr
+                        FROM packet_history p
+                        WHERE p.gateway_id = ?
+                          AND p.from_node_id IS NOT NULL
+                          AND p.from_node_id != ?
+                          AND p.hop_start IS NOT NULL
+                          AND p.hop_limit IS NOT NULL
+                          AND p.hop_start = p.hop_limit
+                          AND p.from_node_id IN ({placeholders})
+                        ORDER BY p.timestamp
+                    """
+                    cursor.execute(
+                        packets_query,
+                        (gateway_hex_id, node_id, *selected_node_ids),
+                    )
+                    packet_rows = cursor.fetchall()
 
                 # Build result with both stats and packet data for received direction
                 for stats_row in stats_rows:
@@ -2850,7 +2862,7 @@ class NodeRepository:
                       AND p.gateway_id != ?
                       AND p.hop_start IS NOT NULL
                       AND p.hop_limit IS NOT NULL
-                      AND (p.hop_start - p.hop_limit) = 0
+                      AND p.hop_start = p.hop_limit
                     GROUP BY p.gateway_id
                     ORDER BY packet_count DESC
                     LIMIT ?
@@ -2870,7 +2882,7 @@ class NodeRepository:
                       AND p.gateway_id != ?
                       AND p.hop_start IS NOT NULL
                       AND p.hop_limit IS NOT NULL
-                      AND (p.hop_start - p.hop_limit) = 0
+                      AND p.hop_start = p.hop_limit
                     ORDER BY p.timestamp
                 """
 
@@ -2995,6 +3007,59 @@ class NodeRepository:
 
 class TracerouteRepository:
     """Repository for traceroute operations."""
+
+    @staticmethod
+    def get_traceroute_packets_for_graph(
+        limit: int = 5000,
+        filters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Get minimal traceroute packet fields for network graph extraction."""
+        if filters is None:
+            filters = {}
+
+        try:
+            conn = get_db_connection()
+            cursor = conn.cursor()
+
+            where_conditions = ["portnum_name = 'TRACEROUTE_APP'"]
+            params: list[Any] = []
+
+            if filters.get("start_time"):
+                where_conditions.append("timestamp >= ?")
+                params.append(filters["start_time"])
+
+            if filters.get("end_time"):
+                where_conditions.append("timestamp <= ?")
+                params.append(filters["end_time"])
+
+            if filters.get("gateway_id"):
+                where_conditions.append("gateway_id = ?")
+                params.append(filters["gateway_id"])
+
+            if filters.get("processed_successfully_only"):
+                where_conditions.append("processed_successfully = 1")
+
+            where_clause = "WHERE " + " AND ".join(where_conditions)
+            query = f"""
+                SELECT
+                    id,
+                    timestamp,
+                    from_node_id,
+                    to_node_id,
+                    raw_payload
+                FROM packet_history
+                {where_clause}
+                ORDER BY timestamp DESC
+                LIMIT ?
+            """
+
+            cursor.execute(query, [*params, limit])
+            rows = [dict(row) for row in cursor.fetchall()]
+            conn.close()
+            return rows
+        except Exception as e:
+            logger.error(f"Error getting traceroute packets for graph: {e}")
+            raise
 
     @staticmethod
     def get_traceroute_packets(
@@ -3608,6 +3673,22 @@ class LocationRepository:
                     node_ids_clause = f"AND from_node_id IN ({placeholders})"
                     node_ids_params = node_ids_int
 
+            extra_conditions: list[str] = []
+            extra_params: list[Any] = []
+            if filters.get("start_time"):
+                extra_conditions.append("timestamp >= ?")
+                extra_params.append(filters["start_time"])
+            if filters.get("end_time"):
+                extra_conditions.append("timestamp <= ?")
+                extra_params.append(filters["end_time"])
+            if filters.get("gateway_id"):
+                extra_conditions.append("gateway_id = ?")
+                extra_params.append(filters["gateway_id"])
+
+            extra_where = ""
+            if extra_conditions:
+                extra_where = "AND " + " AND ".join(extra_conditions)
+
             # Optimized query using window function instead of correlated subquery
             query = f"""
                 WITH max_timestamps AS (
@@ -3619,6 +3700,7 @@ class LocationRepository:
                     AND raw_payload IS NOT NULL
                     AND from_node_id IS NOT NULL
                     {node_ids_clause}
+                    {extra_where}
                     GROUP BY from_node_id
                 )
                 SELECT
@@ -3640,18 +3722,8 @@ class LocationRepository:
                 ORDER BY ph.timestamp DESC
             """
 
-            # Ensure we have optimal indexes for this query
-            try:
-                cursor.execute("""
-                    CREATE INDEX IF NOT EXISTS idx_packet_history_position_lookup
-                    ON packet_history(portnum, from_node_id, timestamp DESC)
-                    WHERE portnum = 3 AND raw_payload IS NOT NULL
-                """)
-            except Exception as e:
-                logger.debug(f"Index creation skipped or failed: {e}")
-
             query_start = time.time()
-            cursor.execute(query, node_ids_params)
+            cursor.execute(query, [*node_ids_params, *extra_params])
             raw_rows = cursor.fetchall()
             timing_breakdown["sql_query"] = time.time() - query_start
 

--- a/src/malla/database/repositories.py
+++ b/src/malla/database/repositories.py
@@ -1733,13 +1733,13 @@ class NodeRepository:
             WITH top_gateways AS (
                 SELECT
                     p.gateway_id,
-                    COUNT(*) as direct_packet_count
-                FROM packet_history p INDEXED BY idx_packet_history_direct_from_gateway
+                    SUM(CASE WHEN p.hop_start = p.hop_limit THEN 1 ELSE 0 END) as direct_packet_count,
+                    COUNT(*) as packet_count
+                FROM packet_history p INDEXED BY idx_packet_history_from_time_desc
                 WHERE p.from_node_id = ?
                   AND p.gateway_id IS NOT NULL
-                  AND p.hop_start = p.hop_limit
                 GROUP BY p.gateway_id
-                ORDER BY direct_packet_count DESC
+                ORDER BY direct_packet_count DESC, packet_count DESC
                 LIMIT 15
             )
             SELECT
@@ -3043,6 +3043,9 @@ class TracerouteRepository:
                     timestamp,
                     from_node_id,
                     to_node_id,
+                    gateway_id,
+                    hop_start,
+                    hop_limit,
                     raw_payload
                 FROM packet_history
                 {where_clause}

--- a/src/malla/database/repositories.py
+++ b/src/malla/database/repositories.py
@@ -37,9 +37,9 @@ def _prune_relay_candidate_cache(now: float) -> None:
 
     overflow = len(_relay_candidate_cache) - RELAY_CANDIDATE_CACHE_MAX_ENTRIES
     if overflow > 0:
-        oldest_keys = sorted(_relay_candidate_cache.items(), key=lambda item: item[1][0])[
-            :overflow
-        ]
+        oldest_keys = sorted(
+            _relay_candidate_cache.items(), key=lambda item: item[1][0]
+        )[:overflow]
         for key, _ in oldest_keys:
             _relay_candidate_cache.pop(key, None)
 
@@ -2060,7 +2060,9 @@ class NodeRepository:
             if not missing_pairs:
                 return result
 
-            missing_gateway_ids = sorted({gateway_id for gateway_id, _ in missing_pairs})
+            missing_gateway_ids = sorted(
+                {gateway_id for gateway_id, _ in missing_pairs}
+            )
             missing_last_bytes = sorted({last_byte for _, last_byte in missing_pairs})
 
             # Convert gateway IDs to hex format
@@ -2104,7 +2106,9 @@ class NodeRepository:
             # Process part 1 results (direct receptions by gateways)
             gateway_hex_to_id = {
                 hex_id: gw_id
-                for gw_id, hex_id in zip(missing_gateway_ids, gateway_hex_ids, strict=True)
+                for gw_id, hex_id in zip(
+                    missing_gateway_ids, gateway_hex_ids, strict=True
+                )
             }
             for row in part1_results:
                 gateway_hex = row["gateway_id"]
@@ -2312,7 +2316,10 @@ class NodeRepository:
                 else {}
             )
 
-            for (gateway_id, last_byte), candidate_ids in limited_candidates_by_pair.items():
+            for (
+                gateway_id,
+                last_byte,
+            ), candidate_ids in limited_candidates_by_pair.items():
                 candidates = []
                 for candidate_id in candidate_ids:
                     hex_id = f"!{candidate_id:08x}"

--- a/src/malla/database/repositories.py
+++ b/src/malla/database/repositories.py
@@ -1274,16 +1274,6 @@ class NodeRepository:
             )
             node_info_row = cursor.fetchone()
 
-            if (
-                node_info_row is None
-                and node_stats_row
-                and "node_id" in node_stats_row.keys()
-            ):
-                node_info_row = node_stats_row
-
-            if not node_stats_row or "total_packets" not in node_stats_row.keys():
-                node_stats_row = None
-
             if not node_stats_row or node_stats_row["total_packets"] == 0:
                 # Check if node exists in node_info but has no packets
                 if not node_info_row:
@@ -1739,7 +1729,7 @@ class NodeRepository:
                 )
 
             # Get received gateways information (gateways that have received packets from this node)
-            gateways_query = f"""
+            gateways_query = """
             WITH top_gateways AS (
                 SELECT
                     p.gateway_id,

--- a/src/malla/database/schema.py
+++ b/src/malla/database/schema.py
@@ -1,0 +1,141 @@
+"""Shared startup schema and index helpers."""
+
+import logging
+import sqlite3
+
+logger = logging.getLogger(__name__)
+
+
+INDEX_SPECS: tuple[tuple[str, str, str], ...] = (
+    (
+        "idx_packet_history_stats",
+        "packet_history",
+        "CREATE INDEX IF NOT EXISTS idx_packet_history_stats ON packet_history(timestamp, from_node_id)",
+    ),
+    (
+        "idx_packet_history_gateway_stats",
+        "packet_history",
+        "CREATE INDEX IF NOT EXISTS idx_packet_history_gateway_stats ON packet_history(timestamp, gateway_id)",
+    ),
+    (
+        "idx_packet_history_portnum_time",
+        "packet_history",
+        "CREATE INDEX IF NOT EXISTS idx_packet_history_portnum_time ON packet_history(timestamp, portnum_name)",
+    ),
+    (
+        "idx_packet_history_direct_hops",
+        "packet_history",
+        "CREATE INDEX IF NOT EXISTS idx_packet_history_direct_hops ON packet_history(timestamp, from_node_id, gateway_id, hop_start, hop_limit) WHERE hop_start = hop_limit",
+    ),
+    (
+        "idx_packet_history_direct_gateway_from",
+        "packet_history",
+        "CREATE INDEX IF NOT EXISTS idx_packet_history_direct_gateway_from ON packet_history(gateway_id, from_node_id) WHERE hop_start = hop_limit AND from_node_id IS NOT NULL",
+    ),
+    (
+        "idx_packet_history_direct_gateway_lastbyte",
+        "packet_history",
+        "CREATE INDEX IF NOT EXISTS idx_packet_history_direct_gateway_lastbyte ON packet_history(gateway_id, (from_node_id & 255)) WHERE hop_start = hop_limit AND from_node_id IS NOT NULL",
+    ),
+    (
+        "idx_packet_history_direct_from_gateway",
+        "packet_history",
+        "CREATE INDEX IF NOT EXISTS idx_packet_history_direct_from_gateway ON packet_history(from_node_id, gateway_id) WHERE hop_start = hop_limit AND gateway_id IS NOT NULL",
+    ),
+    (
+        "idx_packet_history_direct_from_gateway_suffix",
+        "packet_history",
+        "CREATE INDEX IF NOT EXISTS idx_packet_history_direct_from_gateway_suffix ON packet_history(from_node_id, lower(substr(gateway_id, -2))) WHERE hop_start = hop_limit AND gateway_id IS NOT NULL",
+    ),
+    (
+        "idx_packet_history_direct_from_gateway_time_desc",
+        "packet_history",
+        "CREATE INDEX IF NOT EXISTS idx_packet_history_direct_from_gateway_time_desc ON packet_history(from_node_id, gateway_id, timestamp DESC) WHERE hop_start = hop_limit AND from_node_id IS NOT NULL AND gateway_id IS NOT NULL",
+    ),
+    (
+        "idx_packet_history_from_time_desc",
+        "packet_history",
+        "CREATE INDEX IF NOT EXISTS idx_packet_history_from_time_desc ON packet_history(from_node_id, timestamp DESC)",
+    ),
+    (
+        "idx_packet_history_gateway_time_desc",
+        "packet_history",
+        "CREATE INDEX IF NOT EXISTS idx_packet_history_gateway_time_desc ON packet_history(gateway_id, timestamp DESC) WHERE gateway_id IS NOT NULL",
+    ),
+    (
+        "idx_packet_history_gateway_relay",
+        "packet_history",
+        "CREATE INDEX IF NOT EXISTS idx_packet_history_gateway_relay ON packet_history(gateway_id, relay_node) WHERE gateway_id IS NOT NULL AND relay_node IS NOT NULL AND relay_node != 0",
+    ),
+    (
+        "idx_packet_history_gateway_relay_time_desc",
+        "packet_history",
+        "CREATE INDEX IF NOT EXISTS idx_packet_history_gateway_relay_time_desc ON packet_history(gateway_id, relay_node, timestamp DESC) WHERE gateway_id IS NOT NULL AND relay_node IS NOT NULL AND relay_node != 0",
+    ),
+    (
+        "idx_packet_history_relay_time",
+        "packet_history",
+        "CREATE INDEX IF NOT EXISTS idx_packet_history_relay_time ON packet_history(timestamp, relay_node) WHERE relay_node IS NOT NULL AND relay_node != 0",
+    ),
+    (
+        "idx_packet_history_position_lookup_time",
+        "packet_history",
+        "CREATE INDEX IF NOT EXISTS idx_packet_history_position_lookup_time ON packet_history(portnum, timestamp DESC, from_node_id) WHERE portnum = 3 AND raw_payload IS NOT NULL AND from_node_id IS NOT NULL",
+    ),
+    (
+        "idx_packet_mesh_id",
+        "packet_history",
+        "CREATE INDEX IF NOT EXISTS idx_packet_mesh_id ON packet_history(mesh_packet_id)",
+    ),
+    (
+        "idx_node_hex_id",
+        "node_info",
+        "CREATE INDEX IF NOT EXISTS idx_node_hex_id ON node_info(hex_id)",
+    ),
+    (
+        "idx_node_primary_channel",
+        "node_info",
+        "CREATE INDEX IF NOT EXISTS idx_node_primary_channel ON node_info(primary_channel)",
+    ),
+)
+
+LEGACY_INDEX_NAMES: tuple[str, ...] = (
+    "idx_packet_timestamp",
+    "idx_packet_from_node",
+)
+
+
+def _get_existing_tables(cursor: sqlite3.Cursor) -> set[str]:
+    cursor.execute("SELECT name FROM sqlite_master WHERE type = 'table' AND name IS NOT NULL")
+    return {row[0] for row in cursor.fetchall()}
+
+
+def _get_existing_indexes(cursor: sqlite3.Cursor) -> set[str]:
+    cursor.execute("SELECT name FROM sqlite_master WHERE type = 'index' AND name IS NOT NULL")
+    return {row[0] for row in cursor.fetchall()}
+
+
+def ensure_startup_schema(
+    cursor: sqlite3.Cursor, *, drop_legacy_indexes: bool = False
+) -> None:
+    """Ensure shared schema columns and startup indexes exist."""
+
+    existing_tables = _get_existing_tables(cursor)
+    existing_indexes = _get_existing_indexes(cursor)
+
+    if "node_info" in existing_tables:
+        cursor.execute("PRAGMA table_info(node_info)")
+        node_info_columns = {row[1] for row in cursor.fetchall()}
+        if "primary_channel" not in node_info_columns:
+            cursor.execute("ALTER TABLE node_info ADD COLUMN primary_channel TEXT")
+            logger.info("Added primary_channel column to node_info table")
+
+    for index_name, table_name, sql in INDEX_SPECS:
+        if table_name not in existing_tables or index_name in existing_indexes:
+            continue
+        cursor.execute(sql)
+        existing_indexes.add(index_name)
+
+    if drop_legacy_indexes and "packet_history" in existing_tables:
+        for index_name in LEGACY_INDEX_NAMES:
+            cursor.execute(f"DROP INDEX IF EXISTS {index_name}")

--- a/src/malla/database/schema.py
+++ b/src/malla/database/schema.py
@@ -106,12 +106,16 @@ LEGACY_INDEX_NAMES: tuple[str, ...] = (
 
 
 def _get_existing_tables(cursor: sqlite3.Cursor) -> set[str]:
-    cursor.execute("SELECT name FROM sqlite_master WHERE type = 'table' AND name IS NOT NULL")
+    cursor.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name IS NOT NULL"
+    )
     return {row[0] for row in cursor.fetchall()}
 
 
 def _get_existing_indexes(cursor: sqlite3.Cursor) -> set[str]:
-    cursor.execute("SELECT name FROM sqlite_master WHERE type = 'index' AND name IS NOT NULL")
+    cursor.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND name IS NOT NULL"
+    )
     return {row[0] for row in cursor.fetchall()}
 
 

--- a/src/malla/mqtt_capture.py
+++ b/src/malla/mqtt_capture.py
@@ -1378,10 +1378,15 @@ def main() -> None:
     logging.info("Initializing database...")
     startup_step_start = time.time()
     init_database()
-    logging.info("Database initialization step finished in %.3fs", time.time() - startup_step_start)
+    logging.info(
+        "Database initialization step finished in %.3fs",
+        time.time() - startup_step_start,
+    )
     startup_step_start = time.time()
     load_node_cache()
-    logging.info("Node cache load step finished in %.3fs", time.time() - startup_step_start)
+    logging.info(
+        "Node cache load step finished in %.3fs", time.time() - startup_step_start
+    )
 
     # Initialize MQTT Client
     mqtt_client = mqtt.Client(

--- a/src/malla/mqtt_capture.py
+++ b/src/malla/mqtt_capture.py
@@ -367,9 +367,6 @@ def init_database() -> None:
         )
     """)
 
-    cursor.execute("PRAGMA table_info(node_info)")
-    node_info_columns = {row[1] for row in cursor.fetchall()}
-
     ensure_startup_schema(cursor, drop_legacy_indexes=True)
 
     # Backfill primary_channel only when there are actually missing values.

--- a/src/malla/mqtt_capture.py
+++ b/src/malla/mqtt_capture.py
@@ -56,6 +56,8 @@ from paho.mqtt.enums import CallbackAPIVersion
 # ---------------------------------------------------------------------------
 from malla.config import get_config  # Import here to avoid circular import issues
 
+from .database.schema import ensure_startup_schema
+
 # Load the singleton configuration once at module import time.  This ensures the
 # capture tool honours the same YAML + optional environment override mechanism
 # as the web-UI and the rest of the application stack.
@@ -275,6 +277,7 @@ def try_decrypt_mesh_packet(
 # --- Database Functions ---
 def init_database() -> None:
     """Initialize SQLite database with required tables."""
+    init_start = time.time()
     conn = sqlite3.connect(DATABASE_FILE, timeout=30.0)
     conn.row_factory = sqlite3.Row
     cursor = conn.cursor()
@@ -313,15 +316,14 @@ def init_database() -> None:
         )
     """)
 
+    cursor.execute("PRAGMA table_info(packet_history)")
+    packet_history_columns = {row[1] for row in cursor.fetchall()}
+
     # Add mesh_packet_id column if it doesn't exist (for existing databases)
-    try:
+    if "mesh_packet_id" not in packet_history_columns:
         cursor.execute("ALTER TABLE packet_history ADD COLUMN mesh_packet_id INTEGER")
         logging.info("Added mesh_packet_id column to packet_history table")
-    except sqlite3.OperationalError as e:
-        if "duplicate column name" in str(e).lower():
-            logging.debug("mesh_packet_id column already exists")
-        else:
-            logging.warning(f"Could not add mesh_packet_id column: {e}")
+        packet_history_columns.add("mesh_packet_id")
 
     # Add new MeshPacket fields if they don't exist (for existing databases)
     new_columns = [
@@ -341,16 +343,12 @@ def init_database() -> None:
     ]
 
     for column_name, column_type in new_columns:
-        try:
+        if column_name not in packet_history_columns:
             cursor.execute(
                 f"ALTER TABLE packet_history ADD COLUMN {column_name} {column_type}"
             )
             logging.info(f"Added {column_name} column to packet_history table")
-        except sqlite3.OperationalError as e:
-            if "duplicate column name" in str(e).lower():
-                logging.debug(f"{column_name} column already exists")
-            else:
-                logging.warning(f"Could not add {column_name} column: {e}")
+            packet_history_columns.add(column_name)
 
     # Table for node information cache
     cursor.execute("""
@@ -369,100 +367,56 @@ def init_database() -> None:
         )
     """)
 
-    # Composite indexes for /api/nodes aggregation queries (96% faster than single-column indexes)
-    # These covering indexes allow SQLite to perform aggregations using only the index
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_packet_history_stats ON packet_history(timestamp, from_node_id)"
-    )
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_packet_history_gateway_stats ON packet_history(timestamp, gateway_id)"
-    )
+    cursor.execute("PRAGMA table_info(node_info)")
+    node_info_columns = {row[1] for row in cursor.fetchall()}
 
-    # Additional proven performance indexes (20-40% improvements, cache-aware benchmarked)
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_packet_history_portnum_time ON packet_history(timestamp, portnum_name)"
-    )
-    cursor.execute(
-        """CREATE INDEX IF NOT EXISTS idx_packet_history_direct_hops
-           ON packet_history(timestamp, from_node_id, gateway_id, hop_start, hop_limit)
-           WHERE hop_start = hop_limit"""
-    )
-    cursor.execute(
-        """CREATE INDEX IF NOT EXISTS idx_packet_history_direct_gateway_from
-           ON packet_history(gateway_id, from_node_id)
-           WHERE hop_start = hop_limit AND from_node_id IS NOT NULL"""
-    )
-    cursor.execute(
-        """CREATE INDEX IF NOT EXISTS idx_packet_history_direct_gateway_lastbyte
-           ON packet_history(gateway_id, (from_node_id & 255))
-           WHERE hop_start = hop_limit AND from_node_id IS NOT NULL"""
-    )
-    cursor.execute(
-        """CREATE INDEX IF NOT EXISTS idx_packet_history_direct_from_gateway
-           ON packet_history(from_node_id, gateway_id)
-           WHERE hop_start = hop_limit AND gateway_id IS NOT NULL"""
-    )
-    cursor.execute(
-        """CREATE INDEX IF NOT EXISTS idx_packet_history_direct_from_gateway_suffix
-           ON packet_history(from_node_id, lower(substr(gateway_id, -2)))
-           WHERE hop_start = hop_limit AND gateway_id IS NOT NULL"""
-    )
-    cursor.execute(
-        """CREATE INDEX IF NOT EXISTS idx_packet_history_relay_time
-           ON packet_history(timestamp, relay_node)
-           WHERE relay_node IS NOT NULL AND relay_node != 0"""
-    )
+    ensure_startup_schema(cursor, drop_legacy_indexes=True)
 
-    # Keep mesh_packet_id index (used for packet lookups)
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_packet_mesh_id ON packet_history(mesh_packet_id)"
-    )
-
-    # Drop old redundant indexes (composite indexes above can serve the same queries via leftmost prefix)
-    cursor.execute("DROP INDEX IF EXISTS idx_packet_timestamp")
-    cursor.execute("DROP INDEX IF EXISTS idx_packet_from_node")
-
-    cursor.execute("CREATE INDEX IF NOT EXISTS idx_node_hex_id ON node_info(hex_id)")
-
-    # Ensure primary_channel column exists for legacy databases
-    try:
-        cursor.execute("ALTER TABLE node_info ADD COLUMN primary_channel TEXT")
-        logging.info("Added primary_channel column to node_info table")
-    except sqlite3.OperationalError as e:
-        if "duplicate column name" in str(e).lower():
-            logging.debug("primary_channel column already exists")
-        else:
-            logging.warning(f"Could not add primary_channel column: {e}")
-
-    # Index for faster channel filtering
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_node_primary_channel ON node_info(primary_channel)"
-    )
-
-    # Backfill primary_channel using last NODEINFO packets if missing
+    # Backfill primary_channel only when there are actually missing values.
     try:
         cursor.execute(
-            """
-            UPDATE node_info
-            SET primary_channel = (
-                SELECT ph.channel_id
-                FROM packet_history ph
-                WHERE ph.from_node_id = node_info.node_id
-                  AND ph.portnum_name = 'NODEINFO_APP'
-                  AND ph.channel_id IS NOT NULL AND ph.channel_id != ''
-                ORDER BY ph.timestamp DESC
-                LIMIT 1
-            )
-            WHERE (primary_channel IS NULL OR primary_channel = '')
-        """
+            "SELECT COUNT(*) FROM node_info WHERE primary_channel IS NULL OR primary_channel = ''"
         )
-        logging.info("Backfilled primary_channel values in node_info table")
+        missing_primary_channel_count = cursor.fetchone()[0]
+        if missing_primary_channel_count > 0:
+            cursor.execute(
+                """
+                UPDATE node_info
+                SET primary_channel = (
+                    SELECT ph.channel_id
+                    FROM packet_history ph
+                    WHERE ph.from_node_id = node_info.node_id
+                      AND ph.portnum_name = 'NODEINFO_APP'
+                      AND ph.channel_id IS NOT NULL AND ph.channel_id != ''
+                    ORDER BY ph.timestamp DESC
+                    LIMIT 1
+                )
+                WHERE (primary_channel IS NULL OR primary_channel = '')
+                  AND EXISTS (
+                    SELECT 1
+                    FROM packet_history ph
+                    WHERE ph.from_node_id = node_info.node_id
+                      AND ph.portnum_name = 'NODEINFO_APP'
+                      AND ph.channel_id IS NOT NULL AND ph.channel_id != ''
+                  )
+            """
+            )
+            logging.info(
+                "Backfilled primary_channel values for %s nodes",
+                cursor.rowcount,
+            )
+        else:
+            logging.debug("primary_channel backfill not needed")
     except Exception as e:
         logging.warning(f"Could not backfill primary_channel column: {e}")
 
     conn.commit()
     conn.close()
-    logging.info(f"Database initialized: {DATABASE_FILE}")
+    logging.info(
+        "Database initialized: %s (%.3fs)",
+        DATABASE_FILE,
+        time.time() - init_start,
+    )
 
 
 def load_node_cache() -> None:
@@ -1422,8 +1376,12 @@ def main() -> None:
 
     # Initialize database and load node cache
     logging.info("Initializing database...")
+    startup_step_start = time.time()
     init_database()
+    logging.info("Database initialization step finished in %.3fs", time.time() - startup_step_start)
+    startup_step_start = time.time()
     load_node_cache()
+    logging.info("Node cache load step finished in %.3fs", time.time() - startup_step_start)
 
     # Initialize MQTT Client
     mqtt_client = mqtt.Client(

--- a/src/malla/routes/api_routes.py
+++ b/src/malla/routes/api_routes.py
@@ -2171,7 +2171,9 @@ def api_chat_relay_filters():
     """Resolve narrow relay candidates for exact gateway/last-byte chat pairs."""
     try:
         parsed_pairs: list[tuple[int, int]] = []
-        for raw_pair in request.args.getlist("pair")[:CHAT_RELAY_CANDIDATE_LOOKUP_LIMIT]:
+        for raw_pair in request.args.getlist("pair")[
+            :CHAT_RELAY_CANDIDATE_LOOKUP_LIMIT
+        ]:
             gateway_part, separator, relay_part = raw_pair.partition(":")
             if not separator:
                 continue

--- a/src/malla/services/location_service.py
+++ b/src/malla/services/location_service.py
@@ -14,12 +14,31 @@ logger = logging.getLogger(__name__)
 
 _PACKET_LINKS_CACHE: dict[str, tuple[float, list[dict[str, Any]]]] = {}
 _PACKET_LINKS_CACHE_TTL_SECONDS = 60
+_PACKET_LINKS_CACHE_MAX_ENTRIES = 32
 
 
 def _cache_key_from_filters(filters: dict[str, Any] | None) -> str:
     if not filters:
         return ""
     return repr(sorted(filters.items()))
+
+
+def _prune_packet_links_cache(now: float) -> None:
+    expired_keys = [
+        key
+        for key, (cached_at, _) in _PACKET_LINKS_CACHE.items()
+        if now - cached_at > _PACKET_LINKS_CACHE_TTL_SECONDS
+    ]
+    for key in expired_keys:
+        _PACKET_LINKS_CACHE.pop(key, None)
+
+    overflow = len(_PACKET_LINKS_CACHE) - _PACKET_LINKS_CACHE_MAX_ENTRIES
+    if overflow > 0:
+        oldest_keys = sorted(_PACKET_LINKS_CACHE.items(), key=lambda item: item[1][0])[
+            :overflow
+        ]
+        for key, _ in oldest_keys:
+            _PACKET_LINKS_CACHE.pop(key, None)
 
 
 class LocationService:
@@ -871,10 +890,11 @@ class LocationService:
 
         cache_key = _cache_key_from_filters(filters)
         now = time.time()
+        _prune_packet_links_cache(now)
         cached = _PACKET_LINKS_CACHE.get(cache_key)
         if cached and now - cached[0] < _PACKET_LINKS_CACHE_TTL_SECONDS:
             logger.debug("Returning cached packet links for filters: %s", filters)
-            return cached[1]
+            return [link.copy() for link in cached[1]]
 
         logger.info(
             "Getting packet-based RF links for map visualisation with filters: %s",
@@ -1034,7 +1054,7 @@ class LocationService:
             logger.info("Generated %d packet-based RF links", len(link_map))
             result = list(link_map.values())
             _PACKET_LINKS_CACHE[cache_key] = (time.time(), result)
-            return result
+            return [link.copy() for link in result]
 
         except Exception as e:
             logger.error("Error getting packet links: %s", e)

--- a/src/malla/services/location_service.py
+++ b/src/malla/services/location_service.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 _PACKET_LINKS_CACHE: dict[str, tuple[float, list[dict[str, Any]]]] = {}
 _PACKET_LINKS_CACHE_TTL_SECONDS = 60
-_PACKET_LINKS_CACHE_MAX_ENTRIES = 32
+_PACKET_LINKS_CACHE_MAX_ENTRIES = 64
 
 
 def _cache_key_from_filters(filters: dict[str, Any] | None) -> str:

--- a/src/malla/services/location_service.py
+++ b/src/malla/services/location_service.py
@@ -12,6 +12,15 @@ from ..database.repositories import LocationRepository
 
 logger = logging.getLogger(__name__)
 
+_PACKET_LINKS_CACHE: dict[str, tuple[float, list[dict[str, Any]]]] = {}
+_PACKET_LINKS_CACHE_TTL_SECONDS = 60
+
+
+def _cache_key_from_filters(filters: dict[str, Any] | None) -> str:
+    if not filters:
+        return ""
+    return repr(sorted(filters.items()))
+
 
 class LocationService:
     """Service for location-related operations and calculations."""
@@ -860,6 +869,13 @@ class LocationService:
         if filters is None:
             filters = {}
 
+        cache_key = _cache_key_from_filters(filters)
+        now = time.time()
+        cached = _PACKET_LINKS_CACHE.get(cache_key)
+        if cached and now - cached[0] < _PACKET_LINKS_CACHE_TTL_SECONDS:
+            logger.debug("Returning cached packet links for filters: %s", filters)
+            return cached[1]
+
         logger.info(
             "Getting packet-based RF links for map visualisation with filters: %s",
             filters,
@@ -880,8 +896,6 @@ class LocationService:
             where_clauses: list[str] = [
                 "from_node_id IS NOT NULL",
                 "gateway_id IS NOT NULL",
-                "hop_start IS NOT NULL",
-                "hop_limit IS NOT NULL",
                 "hop_start = hop_limit",  # 0-hop packets only (index-friendly)
             ]
             params: list[Any] = []
@@ -914,8 +928,8 @@ class LocationService:
                     from_node_id,
                     gateway_id,
                     COUNT(*)               AS packet_count,
-                    AVG(CAST(rssi AS FLOAT)) AS avg_rssi,
-                    AVG(CAST(snr  AS FLOAT)) AS avg_snr,
+                    AVG(rssi) AS avg_rssi,
+                    AVG(snr) AS avg_snr,
                     MAX(timestamp)         AS last_seen
                 FROM packet_history
                 {where_sql}
@@ -1018,7 +1032,9 @@ class LocationService:
                     link_map[key] = link_payload
 
             logger.info("Generated %d packet-based RF links", len(link_map))
-            return list(link_map.values())
+            result = list(link_map.values())
+            _PACKET_LINKS_CACHE[cache_key] = (time.time(), result)
+            return result
 
         except Exception as e:
             logger.error("Error getting packet links: %s", e)

--- a/src/malla/services/traceroute_service.py
+++ b/src/malla/services/traceroute_service.py
@@ -1207,11 +1207,16 @@ class TracerouteService:
                     )
                     continue
 
+            node_ids = list(nodes.keys())
+            node_names = get_bulk_node_names(node_ids) if node_ids else {}
+
+            for node_id, node_data in nodes.items():
+                node_data["name"] = node_names.get(node_id, node_data["name"])
+
             # Get location data for all nodes in the graph
             # Import here to avoid circular dependencies
             from ..database.repositories import LocationRepository
 
-            node_ids = list(nodes.keys())
             logger.info(f"Fetching location data for {len(node_ids)} nodes")
 
             try:

--- a/src/malla/services/traceroute_service.py
+++ b/src/malla/services/traceroute_service.py
@@ -27,6 +27,27 @@ from ..utils.traceroute_utils import parse_traceroute_payload
 
 logger = logging.getLogger(__name__)
 
+_NETWORK_GRAPH_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
+_NETWORK_GRAPH_CACHE_TTL_SECONDS = 60
+
+
+def _network_graph_cache_key(
+    hours: int,
+    min_snr: float,
+    include_indirect: bool,
+    limit_packets: int,
+    filters: dict[str, Any] | None,
+) -> str:
+    return repr(
+        (
+            hours,
+            min_snr,
+            include_indirect,
+            limit_packets,
+            sorted((filters or {}).items()),
+        )
+    )
+
 
 class TracerouteService:
     """Service for traceroute analysis and management."""
@@ -977,6 +998,23 @@ class TracerouteService:
             f"Building network graph data for {hours} hours (min_snr={min_snr}dB)"
         )
 
+        cache_key = _network_graph_cache_key(
+            hours=hours,
+            min_snr=min_snr,
+            include_indirect=include_indirect,
+            limit_packets=limit_packets,
+            filters=filters,
+        )
+        now = time.time()
+        cached = _NETWORK_GRAPH_CACHE.get(cache_key)
+        if cached and now - cached[0] < _NETWORK_GRAPH_CACHE_TTL_SECONDS:
+            logger.debug(
+                "Returning cached network graph data for %sh filters=%s",
+                hours,
+                filters,
+            )
+            return cached[1]
+
         try:
             # Build filters for traceroute data
             if filters is None:
@@ -997,10 +1035,9 @@ class TracerouteService:
             filters["processed_successfully_only"] = True
 
             # Get traceroute data
-            result = TracerouteRepository.get_traceroute_packets(
+            packets = TracerouteRepository.get_traceroute_packets_for_graph(
                 limit=limit_packets,
                 filters=filters,
-                group_packets=False,  # Disable grouping to avoid payload corruption
             )
 
             # Track nodes and links
@@ -1010,7 +1047,7 @@ class TracerouteService:
 
             # Statistics
             stats = {
-                "packets_analyzed": len(result["packets"]),
+                "packets_analyzed": len(packets),
                 "packets_with_rf_hops": 0,
                 "total_rf_hops": 0,
                 "links_found": 0,
@@ -1019,14 +1056,14 @@ class TracerouteService:
             }
 
             # Process each traceroute packet
-            for tr_data in result["packets"]:
+            for tr_data in packets:
                 if not tr_data["raw_payload"]:
                     continue
 
                 try:
                     # Create TraceroutePacket object for analysis
                     tr_packet = TraceroutePacket(
-                        packet_data=tr_data, resolve_names=True
+                        packet_data=tr_data, resolve_names=False
                     )
 
                     # Get RF hops (actual radio transmissions)
@@ -1241,7 +1278,7 @@ class TracerouteService:
 
                 processed_nodes.append(node_info)
 
-            return {
+            result = {
                 "nodes": processed_nodes,
                 "links": processed_links,
                 "indirect_connections": processed_indirect,
@@ -1252,6 +1289,8 @@ class TracerouteService:
                     "include_indirect": include_indirect,
                 },
             }
+            _NETWORK_GRAPH_CACHE[cache_key] = (time.time(), result)
+            return result
 
         except Exception as e:
             logger.error(f"Error building network graph data: {e}")

--- a/src/malla/services/traceroute_service.py
+++ b/src/malla/services/traceroute_service.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 
 _NETWORK_GRAPH_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
 _NETWORK_GRAPH_CACHE_TTL_SECONDS = 60
+_NETWORK_GRAPH_CACHE_MAX_ENTRIES = 32
 
 
 def _network_graph_cache_key(
@@ -47,6 +48,37 @@ def _network_graph_cache_key(
             sorted((filters or {}).items()),
         )
     )
+
+
+def _copy_network_graph_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        **payload,
+        "nodes": [node.copy() for node in payload.get("nodes", [])],
+        "links": [link.copy() for link in payload.get("links", [])],
+        "indirect_connections": [
+            connection.copy() for connection in payload.get("indirect_connections", [])
+        ],
+        "stats": payload.get("stats", {}).copy(),
+        "metadata": payload.get("metadata", {}).copy(),
+    }
+
+
+def _prune_network_graph_cache(now: float) -> None:
+    expired_keys = [
+        key
+        for key, (cached_at, _) in _NETWORK_GRAPH_CACHE.items()
+        if now - cached_at > _NETWORK_GRAPH_CACHE_TTL_SECONDS
+    ]
+    for key in expired_keys:
+        _NETWORK_GRAPH_CACHE.pop(key, None)
+
+    overflow = len(_NETWORK_GRAPH_CACHE) - _NETWORK_GRAPH_CACHE_MAX_ENTRIES
+    if overflow > 0:
+        oldest_keys = sorted(_NETWORK_GRAPH_CACHE.items(), key=lambda item: item[1][0])[
+            :overflow
+        ]
+        for key, _ in oldest_keys:
+            _NETWORK_GRAPH_CACHE.pop(key, None)
 
 
 class TracerouteService:
@@ -1006,6 +1038,7 @@ class TracerouteService:
             filters=filters,
         )
         now = time.time()
+        _prune_network_graph_cache(now)
         cached = _NETWORK_GRAPH_CACHE.get(cache_key)
         if cached and now - cached[0] < _NETWORK_GRAPH_CACHE_TTL_SECONDS:
             logger.debug(
@@ -1013,7 +1046,7 @@ class TracerouteService:
                 hours,
                 filters,
             )
-            return cached[1]
+            return _copy_network_graph_payload(cached[1])
 
         try:
             # Build filters for traceroute data
@@ -1290,7 +1323,7 @@ class TracerouteService:
                 },
             }
             _NETWORK_GRAPH_CACHE[cache_key] = (time.time(), result)
-            return result
+            return _copy_network_graph_payload(result)
 
         except Exception as e:
             logger.error(f"Error building network graph data: {e}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,11 +57,11 @@ class TestFlaskApp:
             debug=False,
         )
 
-        # Create the real Flask app with injected config
-        self.app = create_app(self._cfg)
-
         # Set up test data
         self._setup_test_data()
+
+        # Create the real Flask app with injected config
+        self.app = create_app(self._cfg)
 
         # Add test-specific API routes
         self._setup_test_routes()
@@ -255,13 +255,13 @@ def test_client():
     cfg = AppConfig(database_file=temp_db.name)
 
     try:
-        # Create the app with injected config
-        app = create_app(cfg)
-        app.config["TESTING"] = True
-
         # Set up test data
         db_fixtures = DatabaseFixtures()
         db_fixtures.create_test_database(temp_db.name)
+
+        # Create the app with injected config
+        app = create_app(cfg)
+        app.config["TESTING"] = True
 
         with app.test_client() as client:
             yield client
@@ -308,13 +308,13 @@ def app():
     cfg = AppConfig(database_file=temp_db.name)
 
     try:
-        # Create the app with injected config
-        app = create_app(cfg)
-        app.config["TESTING"] = True
-
         # Set up test data
         db_fixtures = DatabaseFixtures()
         db_fixtures.create_test_database(temp_db.name)
+
+        # Create the app with injected config
+        app = create_app(cfg)
+        app.config["TESTING"] = True
 
         yield app
     finally:

--- a/tests/unit/test_node_repository.py
+++ b/tests/unit/test_node_repository.py
@@ -55,12 +55,6 @@ class TestNodeRepository:
         # Mock the location query
         mock_cursor.fetchone.side_effect = [
             {
-                "node_id": 1128074276,
-                "node_name": "Test Gateway Alpha",
-                "long_name": "Test Gateway Alpha",
-                "short_name": "TGA",
-                "hw_model": "TBEAM",
-                "role": "ROUTER",
                 "total_packets": 50,
                 "last_seen": 1640995200.0,
                 "first_seen": 1640908800.0,
@@ -69,6 +63,14 @@ class TestNodeRepository:
                 "avg_rssi": -75.5,
                 "avg_snr": 8.2,
                 "avg_hops": 1.5,
+            },
+            {
+                "node_id": 1128074276,
+                "long_name": "Test Gateway Alpha",
+                "short_name": "TGA",
+                "hw_model": "TBEAM",
+                "role": "ROUTER",
+                "primary_channel": "LongFast",
             },
             None,  # location query
         ]


### PR DESCRIPTION
## Summary
- centralize schema and index creation in a shared startup helper used by both web and capture, and remove repository-side index creation
- optimize hot node-detail and direct-hop queries around startup-managed indexes and align tests with startup-time database initialization
- reduce repeated work in graph/map paths with lighter traceroute fetches, SQL filter pushdown, and short-lived service caches

## Testing
- uv run python -m py_compile src/malla/database/schema.py src/malla/database/connection.py src/malla/database/repositories.py src/malla/mqtt_capture.py src/malla/services/location_service.py src/malla/services/traceroute_service.py tests/conftest.py
- uv run pytest -n0 tests/unit/test_traceroute_service.py tests/integration/test_node_routes.py tests/integration/test_direct_receptions_e2e.py tests/unit/test_node_repository.py tests/integration/test_data_cleanup.py -q