### PR TITLE
Split packet channel filters from node primary channels

### DIFF
--- a/src/malla/database/repositories.py
+++ b/src/malla/database/repositories.py
@@ -3001,6 +3001,22 @@ class NodeRepository:
             logger.error(f"Error getting unique primary channels: {e}")
             return []
 
+    @staticmethod
+    def get_unique_packet_channels() -> list[str]:
+        """Return list of distinct observed packet channel IDs."""
+        try:
+            conn = get_db_connection()
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT DISTINCT channel_id FROM packet_history WHERE channel_id IS NOT NULL AND channel_id != '' ORDER BY channel_id"
+            )
+            rows = cursor.fetchall()
+            conn.close()
+            return [row[0] for row in rows]
+        except Exception as e:
+            logger.error(f"Error getting unique packet channels: {e}")
+            return []
+
 
 class TracerouteRepository:
     """Repository for traceroute operations."""
@@ -3174,7 +3190,7 @@ class TracerouteRepository:
                 query = f"""
                     SELECT
                         id, timestamp, from_node_id, to_node_id, gateway_id,
-                        hop_start, hop_limit, rssi, snr, payload_length, raw_payload,
+                        channel_id, hop_start, hop_limit, rssi, snr, payload_length, raw_payload,
                         processed_successfully, mesh_packet_id,
                         datetime(timestamp, 'unixepoch') as timestamp_str
                     FROM packet_history
@@ -3254,6 +3270,7 @@ class TracerouteRepository:
                         "timestamp_str": base_packet["timestamp_str"],
                         "from_node_id": base_packet["from_node_id"],
                         "to_node_id": base_packet["to_node_id"],
+                        "channel_id": base_packet.get("channel_id"),
                         "mesh_packet_id": base_packet["mesh_packet_id"],
                         "gateway_count": len(unique_gateways),
                         "gateway_list": ",".join(unique_gateways),
@@ -3493,7 +3510,7 @@ class TracerouteRepository:
                 query = f"""
                     SELECT
                         id, timestamp, from_node_id, to_node_id, gateway_id,
-                        hop_start, hop_limit, rssi, snr, payload_length, raw_payload,
+                        channel_id, hop_start, hop_limit, rssi, snr, payload_length, raw_payload,
                         processed_successfully, mesh_packet_id,
                         datetime(timestamp, 'unixepoch') as timestamp_str,
                         (hop_start - hop_limit) AS hop_count

--- a/src/malla/routes/api_routes.py
+++ b/src/malla/routes/api_routes.py
@@ -1917,6 +1917,7 @@ def api_traceroute_data():
                 "route_names": route_names,  # Node names/displays in the route
                 "gateway": gateway_display,
                 "gateway_sort_value": gateway_sort_value,
+                "channel": tr.get("channel_id") or "Unknown",
                 "rssi": rssi_display,
                 "snr": snr_display,
                 "hops": hops_display,
@@ -1963,6 +1964,18 @@ def api_channels():
         return jsonify({"channels": channels})
     except Exception as e:
         logger.error(f"Error in API channels: {e}")
+        return jsonify({"error": str(e), "channels": []}), 500
+
+
+@api_bp.route("/meshtastic/packet-channels")
+def api_packet_channels():
+    """API endpoint for distinct observed packet channel IDs."""
+    logger.info("API packet channels endpoint accessed")
+    try:
+        channels = NodeRepository.get_unique_packet_channels()
+        return jsonify({"channels": channels})
+    except Exception as e:
+        logger.error(f"Error in API packet channels: {e}")
         return jsonify({"error": str(e), "channels": []}), 500
 
 

--- a/src/malla/static/js/chat.js
+++ b/src/malla/static/js/chat.js
@@ -726,7 +726,7 @@
 
     async function loadChannels() {
         try {
-            var resp = await fetch('/api/meshtastic/channels');
+            var resp = await fetch('/api/meshtastic/packet-channels');
             if (!resp.ok) return;
             var data = await resp.json();
             (data.channels || []).forEach(function (ch) {

--- a/src/malla/templates/packets.html
+++ b/src/malla/templates/packets.html
@@ -210,9 +210,6 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // Load observed packet channels for select
-    loadPrimaryChannels();
-
     async function loadPrimaryChannels() {
         try {
             const response = await fetch('/api/meshtastic/packet-channels');
@@ -238,6 +235,7 @@ document.addEventListener('DOMContentLoaded', function() {
     async function initializePageWithFilters() {
         // Load packet types first
         await loadPacketTypes();
+        await loadPrimaryChannels();
 
         // Small delay to ensure DOM is updated
         await new Promise(resolve => setTimeout(resolve, 100));

--- a/src/malla/templates/packets.html
+++ b/src/malla/templates/packets.html
@@ -112,7 +112,7 @@
                 </div>
             </div>
             <div class="col-12">
-                <label for="primary_channel" class="form-label">Primary Channel</label>
+                <label for="primary_channel" class="form-label">Channel</label>
                 <select class="form-select form-select-sm" id="primary_channel" name="primary_channel">
                     <option value="">All Channels</option>
                     <!-- Options will be loaded dynamically -->
@@ -210,12 +210,12 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // Load primary channels for select
+    // Load observed packet channels for select
     loadPrimaryChannels();
 
     async function loadPrimaryChannels() {
         try {
-            const response = await fetch('/api/meshtastic/channels');
+            const response = await fetch('/api/meshtastic/packet-channels');
             const data = await response.json();
             if (data.channels) {
                 const select = document.getElementById('primary_channel');

--- a/src/malla/templates/traceroute.html
+++ b/src/malla/templates/traceroute.html
@@ -82,7 +82,7 @@
                 </div>
             </div>
             <div class="col-12">
-                <label for="primary_channel" class="form-label">Primary Channel</label>
+                <label for="primary_channel" class="form-label">Channel</label>
                 <select class="form-select form-select-sm" id="primary_channel" name="primary_channel">
                     <option value="">All Channels</option>
                     <!-- Options will be loaded dynamically -->
@@ -128,12 +128,12 @@ document.addEventListener('DOMContentLoaded', function() {
     // Initialize URL filter manager AFTER sidebar content is moved
     const urlManager = new URLFilterManager();
 
-    // Load primary channels for filter select
+    // Load observed packet channels for filter select
     loadPrimaryChannels();
 
     async function loadPrimaryChannels() {
         try {
-            const response = await fetch('/api/meshtastic/channels');
+            const response = await fetch('/api/meshtastic/packet-channels');
             const data = await response.json();
             if (data.channels) {
                 const select = document.getElementById('primary_channel');

--- a/src/malla/templates/traceroute_graph.html
+++ b/src/malla/templates/traceroute_graph.html
@@ -104,7 +104,7 @@
                     </div>
                 </div>
                 <div class="mb-3">
-                    <label for="primary_channel" class="form-label">Primary Channel</label>
+                    <label for="primary_channel" class="form-label">Channel</label>
                     <select class="form-select form-select-sm" id="primary_channel" name="primary_channel">
                         <option value="">All Channels</option>
                         <!-- Options will be loaded dynamically -->
@@ -1882,7 +1882,7 @@ function applyHopFilter() {
 
 async function loadPrimaryChannels() {
     try {
-        const response = await fetch('/api/meshtastic/channels');
+        const response = await fetch('/api/meshtastic/packet-channels');
         const data = await response.json();
         if (data.channels) {
             const select = document.getElementById('primary_channel');

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -192,6 +192,54 @@ class TestTracerouteEndpoints:
         data = response.get_json()
         assert isinstance(data, dict)
 
+
+class TestChannelsEndpoint:
+    """Test channel option endpoints."""
+
+    @pytest.mark.integration
+    @pytest.mark.api
+    def test_primary_channels_endpoint_returns_node_info_channels(self, client):
+        """Primary channel endpoint should reflect node_info.primary_channel values."""
+        response = client.get("/api/meshtastic/channels")
+        assert response.status_code == 200
+
+        data = response.get_json()
+        assert "channels" in data
+        assert "LongFast" in data["channels"]
+
+    @pytest.mark.integration
+    @pytest.mark.api
+    def test_packet_channels_endpoint_returns_observed_packet_channels(self, client):
+        """Packet channel endpoint should reflect distinct packet_history.channel_id values."""
+        response = client.get("/api/meshtastic/packet-channels")
+        assert response.status_code == 200
+
+        data = response.get_json()
+        assert "channels" in data
+        assert "LongFast" in data["channels"]
+
+    @pytest.mark.integration
+    @pytest.mark.api
+    def test_packets_data_filters_by_observed_packet_channel(self, client):
+        """Packets data filter should match packet_history.channel_id values."""
+        response = client.get("/api/packets/data?primary_channel=LongFast&limit=25")
+        assert response.status_code == 200
+
+        data = response.get_json()
+        for packet in data["data"]:
+            assert packet.get("channel") == "LongFast"
+
+    @pytest.mark.integration
+    @pytest.mark.api
+    def test_traceroute_data_filters_by_observed_packet_channel(self, client):
+        """Traceroute data filter should match traceroute packet channel_id values."""
+        response = client.get("/api/traceroute/data?primary_channel=LongFast&limit=25")
+        assert response.status_code == 200
+
+        data = response.get_json()
+        for packet in data["data"]:
+            assert packet.get("channel") == "LongFast"
+
     @pytest.mark.integration
     @pytest.mark.api
     def test_traceroute_related_nodes_endpoint(self, client):

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -226,6 +226,7 @@ class TestChannelsEndpoint:
         assert response.status_code == 200
 
         data = response.get_json()
+        assert data["data"]
         for packet in data["data"]:
             assert packet.get("channel") == "LongFast"
 
@@ -237,6 +238,7 @@ class TestChannelsEndpoint:
         assert response.status_code == 200
 
         data = response.get_json()
+        assert data["data"]
         for packet in data["data"]:
             assert packet.get("channel") == "LongFast"
 


### PR DESCRIPTION
## Summary
- add a packet-channel endpoint backed by distinct `packet_history.channel_id` values
- switch chat, packets, and traceroute channel selectors to use observed packet channels while leaving node primary channels unchanged
- carry traceroute `channel_id` through repository results and cover the split with integration tests

## Testing
- `uv run pytest -n0 tests/integration/test_api_endpoints.py -q`