### PR TITLE
Add partial index on packet_history.channel_id

### DIFF
--- a/src/malla/database/schema.py
+++ b/src/malla/database/schema.py
@@ -88,6 +88,11 @@ INDEX_SPECS: tuple[tuple[str, str, str], ...] = (
         "CREATE INDEX IF NOT EXISTS idx_packet_mesh_id ON packet_history(mesh_packet_id)",
     ),
     (
+        "idx_packet_history_channel_id",
+        "packet_history",
+        "CREATE INDEX IF NOT EXISTS idx_packet_history_channel_id ON packet_history(channel_id) WHERE channel_id IS NOT NULL AND channel_id != ''",
+    ),
+    (
         "idx_node_hex_id",
         "node_info",
         "CREATE INDEX IF NOT EXISTS idx_node_hex_id ON node_info(hex_id)",

--- a/tests/fixtures/database_fixtures.py
+++ b/tests/fixtures/database_fixtures.py
@@ -151,6 +151,9 @@ class DatabaseFixtures:
         cursor.execute(
             "CREATE INDEX IF NOT EXISTS idx_mesh_packet_id ON packet_history(mesh_packet_id)"
         )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_packet_history_channel_id ON packet_history(channel_id) WHERE channel_id IS NOT NULL AND channel_id != ''"
+        )
 
     def create_sample_nodes(self) -> list[dict[str, Any]]:
         """Create test node data with variety of node types."""


### PR DESCRIPTION
## Summary

- Adds a partial index `idx_packet_history_channel_id` on `packet_history(channel_id)` with `WHERE channel_id IS NOT NULL AND channel_id != ''`
- Fixes slow `SELECT DISTINCT channel_id` full-table scan in the `/api/meshtastic/packet-channels` endpoint introduced in #82

The partial index is tiny (only covers non-empty values) and lets SQLite satisfy the `DISTINCT` query entirely from the index without touching the main table.