### PR TITLE
Add composite index for chat messages filtered by channel

### DIFF
--- a/src/malla/database/schema.py
+++ b/src/malla/database/schema.py
@@ -93,6 +93,11 @@ INDEX_SPECS: tuple[tuple[str, str, str], ...] = (
         "CREATE INDEX IF NOT EXISTS idx_packet_history_channel_id ON packet_history(channel_id) WHERE channel_id IS NOT NULL AND channel_id != ''",
     ),
     (
+        "idx_packet_history_chat_channel",
+        "packet_history",
+        "CREATE INDEX IF NOT EXISTS idx_packet_history_chat_channel ON packet_history(portnum_name, channel_id, id DESC) WHERE raw_payload IS NOT NULL AND payload_length > 0",
+    ),
+    (
         "idx_node_hex_id",
         "node_info",
         "CREATE INDEX IF NOT EXISTS idx_node_hex_id ON node_info(hex_id)",


### PR DESCRIPTION
## Summary

- Adds a partial composite index `idx_packet_history_chat_channel` on `(portnum_name, channel_id, id DESC)` with `WHERE raw_payload IS NOT NULL AND payload_length > 0`
- Fixes slow `ORDER BY id DESC` query in `/api/chat/messages?channel=X` endpoint when filtering by sparse channels (e.g. "Test")

Without this index, SQLite must scan the entire `packet_history` table to find rows matching the channel filter. The composite index lets SQLite jump directly to the matching `(portnum_name, channel_id)` slice and walk `id DESC` for the limit — returning instantly for channels with few or no messages.