### PR TITLE
Refactor reverse proxy config to trusted proxy IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,12 +303,18 @@ The following keys are recognised:
 | `mqtt_client_id`    | str | `""`                                     | MQTT client ID. Leave empty for a randomly generated ID (recommended). | `MALLA_MQTT_CLIENT_ID` |
 | `default_channel_key` | str | `"1PG7OiApB1nwvP+rz05pAQ=="`         | Default channel key(s) for decryption (base64). Supports comma-separated list of keys - each will be tried in order until successful. | `MALLA_DEFAULT_CHANNEL_KEY` |
 | `data_retention_hours` | int | `0`                                     | Number of hours after which to delete old data (0 = never delete). Automatically cleans up packet_history and node_info records older than specified hours. | `MALLA_DATA_RETENTION_HOURS` |
-| `reverse_proxy_xff_count` | int | `null`                              | Number of trusted reverse proxy layers. When set, applies ProxyFix so `request.remote_addr` reflects the real client IP. | `MALLA_REVERSE_PROXY_XFF_COUNT` |
+| `trusted_proxy_ips` | str | `null`                              | Comma-separated IPs of trusted reverse proxies. Enables ProxyFix with one trusted hop. When running via Gunicorn, these same IPs are passed to `forwarded_allow_ips` so only those peers can forward headers. | `MALLA_TRUSTED_PROXY_IPS` |
 | `otlp_endpoint` | str    | `null`                              | OpenTelemetry endpoint for sending traces (e.g. `http://localhost:4317`). | `MALLA_OTLP_ENDPOINT` |
 | `gunicorn_workers` | int | `null` | Number of Gunicorn worker processes. `null` means auto-detect based on CPU cores. | `MALLA_GUNICORN_WORKERS` |
 | `gunicorn_threads` | int | `1` | Number of threads per Gunicorn worker. Increase this for better concurrency, especially on I/O bound tasks. | `MALLA_GUNICORN_THREADS` |
 
 Environment variables **always override** values coming from YAML file.
+
+When `trusted_proxy_ips` is set, Malla always enables `ProxyFix` with a single
+trusted forwarded hop. If you run via `malla-web-gunicorn`, the same exact IPs
+are also passed to Gunicorn's `forwarded_allow_ips` so forwarded headers are
+only accepted from those proxy peers. When not using Gunicorn, only `ProxyFix`
+is configured; no additional server-level proxy trust is opened.
 
 ### Data Cleanup
 

--- a/README.md
+++ b/README.md
@@ -303,18 +303,21 @@ The following keys are recognised:
 | `mqtt_client_id`    | str | `""`                                     | MQTT client ID. Leave empty for a randomly generated ID (recommended). | `MALLA_MQTT_CLIENT_ID` |
 | `default_channel_key` | str | `"1PG7OiApB1nwvP+rz05pAQ=="`         | Default channel key(s) for decryption (base64). Supports comma-separated list of keys - each will be tried in order until successful. | `MALLA_DEFAULT_CHANNEL_KEY` |
 | `data_retention_hours` | int | `0`                                     | Number of hours after which to delete old data (0 = never delete). Automatically cleans up packet_history and node_info records older than specified hours. | `MALLA_DATA_RETENTION_HOURS` |
-| `trusted_proxy_ips` | str | `null`                              | Comma-separated IPs of trusted reverse proxies. Enables ProxyFix with one trusted hop. When running via Gunicorn, these same IPs are passed to `forwarded_allow_ips` so only those peers can forward headers. | `MALLA_TRUSTED_PROXY_IPS` |
+| `trusted_proxy_ips` | str | `null`                              | Comma-separated IPs of trusted reverse proxies. Malla only trusts the configured client-IP header from these exact peers. When running via Gunicorn, these same IPs are passed to `forwarded_allow_ips` so only those peers can forward headers. | `MALLA_TRUSTED_PROXY_IPS` |
+| `trusted_proxy_client_ip_header` | str | `"X-Forwarded-For"`         | Header used to derive the real client IP from a trusted proxy. Recommended for Anubis: `X-Real-IP`. | `MALLA_TRUSTED_PROXY_CLIENT_IP_HEADER` |
 | `otlp_endpoint` | str    | `null`                              | OpenTelemetry endpoint for sending traces (e.g. `http://localhost:4317`). | `MALLA_OTLP_ENDPOINT` |
 | `gunicorn_workers` | int | `null` | Number of Gunicorn worker processes. `null` means auto-detect based on CPU cores. | `MALLA_GUNICORN_WORKERS` |
 | `gunicorn_threads` | int | `1` | Number of threads per Gunicorn worker. Increase this for better concurrency, especially on I/O bound tasks. | `MALLA_GUNICORN_THREADS` |
 
 Environment variables **always override** values coming from YAML file.
 
-When `trusted_proxy_ips` is set, Malla always enables `ProxyFix` with a single
-trusted forwarded hop. If you run via `malla-web-gunicorn`, the same exact IPs
-are also passed to Gunicorn's `forwarded_allow_ips` so forwarded headers are
-only accepted from those proxy peers. When not using Gunicorn, only `ProxyFix`
-is configured; no additional server-level proxy trust is opened.
+When `trusted_proxy_ips` is set, Malla rewrites `REMOTE_ADDR` from
+`trusted_proxy_client_ip_header`, but only when the immediate peer is one of
+those trusted proxy IPs. This is the recommended setup for Anubis using
+`X-Real-IP`. `ProxyFix` is still used for forwarded protocol handling. If you
+run via `malla-web-gunicorn`, the same exact IPs are also passed to Gunicorn's
+`forwarded_allow_ips` so forwarded headers are only accepted from those peers.
+When not using Gunicorn, no additional server-level proxy trust is opened.
 
 ### Data Cleanup
 

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -51,11 +51,12 @@ debug: false
 # default_channel_key: "1PG7OiApB1nwvP+rz05pAQ=="
 
 # Reverse proxy settings
-# Number of trusted reverse proxy layers in X-Forwarded-* headers.
-# Set to 1 when behind a single reverse proxy (e.g. nginx, anubis) so that
-# request.remote_addr reflects the real client IP. Increase for multi-hop.
-# Corresponding env var: MALLA_REVERSE_PROXY_XFF_COUNT
-# reverse_proxy_xff_count: 1
+# Comma-separated IPs of trusted reverse proxies.
+# When set, ProxyFix trusts one X-Forwarded-* hop so request.remote_addr
+# reflects the real client IP. When running via Gunicorn, these same IPs are
+# passed to forwarded_allow_ips so only those proxy peers can forward headers.
+# Corresponding env var: MALLA_TRUSTED_PROXY_IPS
+# trusted_proxy_ips: "10.89.0.90"
 
 # Number of hours after which to delete old data (0 = never delete)
 # data_retention_hours: 0

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -52,9 +52,12 @@ debug: false
 
 # Reverse proxy settings
 # Comma-separated IPs of trusted reverse proxies.
-# When set, ProxyFix trusts one X-Forwarded-* hop so request.remote_addr
-# reflects the real client IP. When running via Gunicorn, these same IPs are
-# passed to forwarded_allow_ips so only those proxy peers can forward headers.
+# When set, Malla trusts the configured client IP header from those exact proxy
+# peers. Recommended for Anubis: X-Real-IP
+# trusted_proxy_client_ip_header: "X-Real-IP"
+# ProxyFix is still used for X-Forwarded-Proto when enabled. When running via
+# Gunicorn, these same IPs are passed to forwarded_allow_ips so only those
+# proxy peers can forward headers.
 # Corresponding env var: MALLA_TRUSTED_PROXY_IPS
 # trusted_proxy_ips: "10.89.0.90"
 

--- a/env.example
+++ b/env.example
@@ -66,9 +66,11 @@ MALLA_MQTT_TOPIC_SUFFIX=/+/+/+/#
 # MALLA_MQTT_CLIENT_ID=
 
 # Reverse proxy settings
-# Number of trusted reverse proxy layers in X-Forwarded-* headers.
-# Set to 1 when behind a single reverse proxy (e.g. nginx, anubis).
-# MALLA_REVERSE_PROXY_XFF_COUNT=1
+# Comma-separated IPs of trusted reverse proxies.
+# When set, Malla enables ProxyFix with a single trusted X-Forwarded-* hop.
+# When running via malla-web-gunicorn, the same IPs are passed to Gunicorn's
+# forwarded_allow_ips so forwarded headers are only accepted from those peers.
+# MALLA_TRUSTED_PROXY_IPS=10.89.0.90
 
 # Default channel key for decrypting secondary channels (base64, optional)
 # MALLA_DEFAULT_CHANNEL_KEY=1PG7OiApB1nwvP+rz05pAQ==

--- a/env.example
+++ b/env.example
@@ -67,10 +67,13 @@ MALLA_MQTT_TOPIC_SUFFIX=/+/+/+/#
 
 # Reverse proxy settings
 # Comma-separated IPs of trusted reverse proxies.
-# When set, Malla enables ProxyFix with a single trusted X-Forwarded-* hop.
+# When set, Malla trusts the configured client IP header only from those peers.
+# Recommended for Anubis: X-Real-IP
+# MALLA_TRUSTED_PROXY_CLIENT_IP_HEADER=X-Real-IP
+# MALLA_TRUSTED_PROXY_IPS=10.89.0.90
+# ProxyFix is still used for X-Forwarded-Proto when enabled.
 # When running via malla-web-gunicorn, the same IPs are passed to Gunicorn's
 # forwarded_allow_ips so forwarded headers are only accepted from those peers.
-# MALLA_TRUSTED_PROXY_IPS=10.89.0.90
 
 # Default channel key for decrypting secondary channels (base64, optional)
 # MALLA_DEFAULT_CHANNEL_KEY=1PG7OiApB1nwvP+rz05pAQ==

--- a/src/malla/config.py
+++ b/src/malla/config.py
@@ -52,12 +52,11 @@ class AppConfig:
     data_retention_hours: int = 0
 
     # Reverse proxy settings
-    # Number of trusted reverse proxy layers in X-Forwarded-* headers.
-    # Set to 1 when behind a single reverse proxy (common case), 2 behind two,
-    # etc. When set, ProxyFix middleware is applied so that request.remote_addr
-    # reflects the real client IP from X-Forwarded-For.
-    # Corresponding env var: MALLA_REVERSE_PROXY_XFF_COUNT
-    reverse_proxy_xff_count: int | None = None
+    # Comma-separated IPs of trusted reverse proxies. When set, ProxyFix trusts
+    # one X-Forwarded-* hop, and Gunicorn is configured to accept forwarded
+    # headers only from these exact proxy IPs.
+    # Corresponding env var: MALLA_TRUSTED_PROXY_IPS
+    trusted_proxy_ips: str | None = None
 
     # OpenTelemetry settings
     otlp_endpoint: str | None = None

--- a/src/malla/config.py
+++ b/src/malla/config.py
@@ -53,10 +53,15 @@ class AppConfig:
 
     # Reverse proxy settings
     # Comma-separated IPs of trusted reverse proxies. When set, ProxyFix trusts
-    # one X-Forwarded-* hop, and Gunicorn is configured to accept forwarded
+    # one trusted proto hop, and Gunicorn is configured to accept forwarded
     # headers only from these exact proxy IPs.
     # Corresponding env var: MALLA_TRUSTED_PROXY_IPS
     trusted_proxy_ips: str | None = None
+
+    # Header carrying the original client IP from a trusted reverse proxy.
+    # Common values are X-Forwarded-For, X-Real-IP, or CF-Connecting-IP.
+    # Corresponding env var: MALLA_TRUSTED_PROXY_CLIENT_IP_HEADER
+    trusted_proxy_client_ip_header: str = "X-Forwarded-For"
 
     # OpenTelemetry settings
     otlp_endpoint: str | None = None

--- a/src/malla/config.py
+++ b/src/malla/config.py
@@ -177,7 +177,7 @@ def load_config(config_path: str | os.PathLike | None = None) -> AppConfig:  # n
     config = AppConfig(**data)  # type: ignore[arg-type]
     config._config_path = yaml_path if yaml_path.is_file() else None
 
-    logger.debug("Loaded application configuration")
+    logger.debug("Loaded application configuration: %s", config)
     return config
 
 

--- a/src/malla/config.py
+++ b/src/malla/config.py
@@ -177,7 +177,7 @@ def load_config(config_path: str | os.PathLike | None = None) -> AppConfig:  # n
     config = AppConfig(**data)  # type: ignore[arg-type]
     config._config_path = yaml_path if yaml_path.is_file() else None
 
-    logger.debug("Loaded application configuration: %s", config)
+    logger.debug("Loaded application configuration")
     return config
 
 

--- a/src/malla/web_ui.py
+++ b/src/malla/web_ui.py
@@ -40,6 +40,28 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+class TrustedProxyClientIPMiddleware:
+    """Rewrite REMOTE_ADDR from a trusted proxy-provided header."""
+
+    def __init__(self, app, trusted_proxy_ips: str, client_ip_header: str):  # noqa: ANN001
+        self.app = app
+        self.trusted_proxy_ips = {
+            ip.strip() for ip in trusted_proxy_ips.split(",") if ip.strip()
+        }
+        self.client_ip_header = f"HTTP_{client_ip_header.upper().replace('-', '_')}"
+
+    def __call__(self, environ, start_response):  # noqa: ANN001
+        remote_addr = environ.get("REMOTE_ADDR")
+        forwarded_ip = environ.get(self.client_ip_header)
+
+        if remote_addr in self.trusted_proxy_ips and forwarded_ip:
+            # Preserve the original peer IP for troubleshooting.
+            environ["trusted_proxy.orig_remote_addr"] = remote_addr
+            environ["REMOTE_ADDR"] = forwarded_ip.split(",", 1)[0].strip()
+
+        return self.app(environ, start_response)
+
+
 def make_json_safe(obj):
     """
     Recursively convert an object to be JSON-serializable by handling bytes objects.
@@ -109,13 +131,18 @@ def create_app(cfg: AppConfig | None = None):  # noqa: D401
     if cfg.trusted_proxy_ips:
         from werkzeug.middleware.proxy_fix import ProxyFix
 
+        app.wsgi_app = TrustedProxyClientIPMiddleware(
+            app.wsgi_app,
+            cfg.trusted_proxy_ips,
+            cfg.trusted_proxy_client_ip_header,
+        )
         app.wsgi_app = ProxyFix(
             app.wsgi_app,
-            x_for=1,
             x_proto=1,
         )
         logger.info(
-            "ProxyFix middleware applied for trusted proxy configuration"
+            "Trusted proxy middleware applied for header %s",
+            cfg.trusted_proxy_client_ip_header,
         )
 
     # Mirror a few frequently-used values to top-level keys for backwards

--- a/src/malla/web_ui.py
+++ b/src/malla/web_ui.py
@@ -106,18 +106,16 @@ def create_app(cfg: AppConfig | None = None):  # noqa: D401
         setup_telemetry(app, cfg.otlp_endpoint)
 
     # Apply ProxyFix after other WSGI middleware so they see rewritten values.
-    if cfg.reverse_proxy_xff_count is not None:
+    if cfg.trusted_proxy_ips:
         from werkzeug.middleware.proxy_fix import ProxyFix
 
         app.wsgi_app = ProxyFix(
             app.wsgi_app,
-            x_for=cfg.reverse_proxy_xff_count,
-            x_proto=cfg.reverse_proxy_xff_count,
+            x_for=1,
+            x_proto=1,
         )
         logger.info(
-            "ProxyFix middleware applied (x_for=%d, x_proto=%d)",
-            cfg.reverse_proxy_xff_count,
-            cfg.reverse_proxy_xff_count,
+            "ProxyFix middleware applied for trusted proxy configuration"
         )
 
     # Mirror a few frequently-used values to top-level keys for backwards

--- a/src/malla/web_ui.py
+++ b/src/malla/web_ui.py
@@ -140,10 +140,6 @@ def create_app(cfg: AppConfig | None = None):  # noqa: D401
             app.wsgi_app,
             x_proto=1,
         )
-        logger.info(
-            "Trusted proxy middleware applied for header %s",
-            cfg.trusted_proxy_client_ip_header,
-        )
 
     # Mirror a few frequently-used values to top-level keys for backwards
     # compatibility with the existing code base. Over time we should migrate

--- a/src/malla/wsgi.py
+++ b/src/malla/wsgi.py
@@ -22,6 +22,34 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+def _build_gunicorn_config(cfg):
+    worker_class = "gthread" if cfg.gunicorn_threads > 1 else "sync"
+
+    gunicorn_config = {
+        "bind": f"{cfg.host}:{cfg.port}",
+        "workers": cfg.gunicorn_workers,
+        "threads": cfg.gunicorn_threads,
+        "worker_class": worker_class,
+        "worker_connections": 1000,
+        "max_requests": 1000,
+        "max_requests_jitter": 50,
+        "timeout": 30,
+        "keepalive": 2,
+        "preload_app": True,
+        "access_log_format": '%({REMOTE_ADDR}e)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(D)s',
+        "accesslog": "-",
+        "errorlog": "-",
+        "loglevel": "info",
+        "capture_output": True,
+        "enable_stdio_inheritance": True,
+    }
+
+    if cfg.trusted_proxy_ips:
+        gunicorn_config["forwarded_allow_ips"] = cfg.trusted_proxy_ips
+
+    return gunicorn_config
+
+
 def create_wsgi_app():
     """Create and return the WSGI application."""
     logger.info("Creating WSGI application for Gunicorn")
@@ -69,28 +97,7 @@ def main():
         print("=" * 60)
         print()
 
-        # Determine worker class based on threads
-        worker_class = "gthread" if cfg.gunicorn_threads > 1 else "sync"
-
-        # Configure Gunicorn
-        gunicorn_config = {
-            "bind": f"{cfg.host}:{cfg.port}",
-            "workers": cfg.gunicorn_workers,
-            "threads": cfg.gunicorn_threads,
-            "worker_class": worker_class,
-            "worker_connections": 1000,
-            "max_requests": 1000,
-            "max_requests_jitter": 50,
-            "timeout": 30,
-            "keepalive": 2,
-            "preload_app": True,
-            "access_log_format": '%({REMOTE_ADDR}e)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(D)s',
-            "accesslog": "-",  # Log to stdout
-            "errorlog": "-",  # Log to stderr
-            "loglevel": "info",
-            "capture_output": True,
-            "enable_stdio_inheritance": True,
-        }
+        gunicorn_config = _build_gunicorn_config(cfg)
 
         # Create Gunicorn application
         class MallaWSGIApplication(WSGIApplication):

--- a/tests/unit/test_reverse_proxy.py
+++ b/tests/unit/test_reverse_proxy.py
@@ -10,7 +10,7 @@ from src.malla.wsgi import _build_gunicorn_config
 
 
 class TestTrustedProxyConfig:
-    """Test trusted_proxy_ips in AppConfig."""
+    """Test trusted proxy settings in AppConfig."""
 
     def test_default_is_none(self):
         cfg = AppConfig()
@@ -20,24 +20,31 @@ class TestTrustedProxyConfig:
         cfg = AppConfig(trusted_proxy_ips="10.89.0.90")
         assert cfg.trusted_proxy_ips == "10.89.0.90"
 
+    def test_client_ip_header_default(self):
+        cfg = AppConfig()
+        assert cfg.trusted_proxy_client_ip_header == "X-Forwarded-For"
+
     def test_env_override(self, monkeypatch):
         from src.malla.config import _clear_config_cache, load_config
 
         _clear_config_cache()
         monkeypatch.setenv("MALLA_TRUSTED_PROXY_IPS", "10.89.0.90,10.89.0.91")
+        monkeypatch.setenv("MALLA_TRUSTED_PROXY_CLIENT_IP_HEADER", "X-Real-IP")
         cfg = load_config(config_path=None)
         assert cfg.trusted_proxy_ips == "10.89.0.90,10.89.0.91"
+        assert cfg.trusted_proxy_client_ip_header == "X-Real-IP"
 
 
 class TestProxyFixMiddleware:
     """Test that ProxyFix is applied when trusted_proxy_ips is configured."""
 
-    def _make_app(self, trusted_proxy_ips=None):
+    def _make_app(self, trusted_proxy_ips=None, client_ip_header="X-Forwarded-For"):
         temp_db = tempfile.NamedTemporaryFile(delete=False, suffix=".db")
         temp_db.close()
         cfg = AppConfig(
             database_file=temp_db.name,
             trusted_proxy_ips=trusted_proxy_ips,
+            trusted_proxy_client_ip_header=client_ip_header,
         )
         app = create_app(cfg)
         return app, temp_db.name
@@ -64,14 +71,13 @@ class TestProxyFixMiddleware:
         app, db_path = self._make_app(trusted_proxy_ips="10.89.0.90")
         try:
             assert isinstance(app.wsgi_app, ProxyFix)
-            assert app.wsgi_app.x_for == 1
             assert app.wsgi_app.x_proto == 1
         finally:
             import os
 
             os.unlink(db_path)
 
-    def test_proxy_fix_respects_x_forwarded_for(self):
+    def test_trusted_proxy_rewrites_remote_addr_from_x_forwarded_for(self):
         app, db_path = self._make_app(trusted_proxy_ips="10.89.0.90")
         try:
 
@@ -87,9 +93,64 @@ class TestProxyFixMiddleware:
                     headers={
                         "X-Forwarded-For": "1.2.3.4",
                     },
+                    environ_base={"REMOTE_ADDR": "10.89.0.90"},
                 )
                 data = response.get_json()
                 assert data["remote_addr"] == "1.2.3.4"
+        finally:
+            import os
+
+            os.unlink(db_path)
+
+    def test_trusted_proxy_rewrites_remote_addr_from_configured_header(self):
+        app, db_path = self._make_app(
+            trusted_proxy_ips="10.89.0.90", client_ip_header="X-Real-IP"
+        )
+        try:
+
+            @app.route("/__test_real_ip")
+            def test_real_ip():
+                from flask import request
+
+                return {"remote_addr": request.remote_addr}
+
+            with app.test_client() as client:
+                response = client.get(
+                    "/__test_real_ip",
+                    headers={
+                        "X-Real-IP": "5.6.7.8",
+                    },
+                    environ_base={"REMOTE_ADDR": "10.89.0.90"},
+                )
+                data = response.get_json()
+                assert data["remote_addr"] == "5.6.7.8"
+        finally:
+            import os
+
+            os.unlink(db_path)
+
+    def test_untrusted_peer_does_not_rewrite_remote_addr(self):
+        app, db_path = self._make_app(
+            trusted_proxy_ips="10.89.0.90", client_ip_header="X-Real-IP"
+        )
+        try:
+
+            @app.route("/__test_untrusted_ip")
+            def test_untrusted_ip():
+                from flask import request
+
+                return {"remote_addr": request.remote_addr}
+
+            with app.test_client() as client:
+                response = client.get(
+                    "/__test_untrusted_ip",
+                    headers={
+                        "X-Real-IP": "5.6.7.8",
+                    },
+                    environ_base={"REMOTE_ADDR": "10.89.0.91"},
+                )
+                data = response.get_json()
+                assert data["remote_addr"] == "10.89.0.91"
         finally:
             import os
 

--- a/tests/unit/test_reverse_proxy.py
+++ b/tests/unit/test_reverse_proxy.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for reverse_proxy_xff_count configuration and ProxyFix middleware.
-"""
+"""Unit tests for trusted proxy configuration and middleware wiring."""
 
 import tempfile
 
@@ -8,43 +6,44 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 
 from src.malla.config import AppConfig
 from src.malla.web_ui import create_app
+from src.malla.wsgi import _build_gunicorn_config
 
 
-class TestReverseProxyConfig:
-    """Test reverse_proxy_xff_count in AppConfig."""
+class TestTrustedProxyConfig:
+    """Test trusted_proxy_ips in AppConfig."""
 
     def test_default_is_none(self):
         cfg = AppConfig()
-        assert cfg.reverse_proxy_xff_count is None
+        assert cfg.trusted_proxy_ips is None
 
-    def test_from_int(self):
-        cfg = AppConfig(reverse_proxy_xff_count=2)
-        assert cfg.reverse_proxy_xff_count == 2
+    def test_from_string(self):
+        cfg = AppConfig(trusted_proxy_ips="10.89.0.90")
+        assert cfg.trusted_proxy_ips == "10.89.0.90"
 
     def test_env_override(self, monkeypatch):
         from src.malla.config import _clear_config_cache, load_config
 
         _clear_config_cache()
-        monkeypatch.setenv("MALLA_REVERSE_PROXY_XFF_COUNT", "1")
+        monkeypatch.setenv("MALLA_TRUSTED_PROXY_IPS", "10.89.0.90,10.89.0.91")
         cfg = load_config(config_path=None)
-        assert cfg.reverse_proxy_xff_count == 1
+        assert cfg.trusted_proxy_ips == "10.89.0.90,10.89.0.91"
 
 
 class TestProxyFixMiddleware:
-    """Test that ProxyFix is applied when reverse_proxy_xff_count is configured."""
+    """Test that ProxyFix is applied when trusted_proxy_ips is configured."""
 
-    def _make_app(self, xff_count=None):
+    def _make_app(self, trusted_proxy_ips=None):
         temp_db = tempfile.NamedTemporaryFile(delete=False, suffix=".db")
         temp_db.close()
         cfg = AppConfig(
             database_file=temp_db.name,
-            reverse_proxy_xff_count=xff_count,
+            trusted_proxy_ips=trusted_proxy_ips,
         )
         app = create_app(cfg)
         return app, temp_db.name
 
     def test_no_proxy_fix_when_not_configured(self):
-        app, db_path = self._make_app(xff_count=None)
+        app, db_path = self._make_app(trusted_proxy_ips=None)
         try:
             assert not isinstance(app.wsgi_app, ProxyFix)
         finally:
@@ -53,7 +52,7 @@ class TestProxyFixMiddleware:
             os.unlink(db_path)
 
     def test_proxy_fix_applied_when_configured(self):
-        app, db_path = self._make_app(xff_count=1)
+        app, db_path = self._make_app(trusted_proxy_ips="10.89.0.90")
         try:
             assert isinstance(app.wsgi_app, ProxyFix)
         finally:
@@ -61,19 +60,19 @@ class TestProxyFixMiddleware:
 
             os.unlink(db_path)
 
-    def test_proxy_fix_uses_configured_count(self):
-        app, db_path = self._make_app(xff_count=3)
+    def test_proxy_fix_uses_single_hop(self):
+        app, db_path = self._make_app(trusted_proxy_ips="10.89.0.90")
         try:
             assert isinstance(app.wsgi_app, ProxyFix)
-            assert app.wsgi_app.x_for == 3
-            assert app.wsgi_app.x_proto == 3
+            assert app.wsgi_app.x_for == 1
+            assert app.wsgi_app.x_proto == 1
         finally:
             import os
 
             os.unlink(db_path)
 
     def test_proxy_fix_respects_x_forwarded_for(self):
-        app, db_path = self._make_app(xff_count=1)
+        app, db_path = self._make_app(trusted_proxy_ips="10.89.0.90")
         try:
 
             @app.route("/__test_ip")
@@ -96,32 +95,8 @@ class TestProxyFixMiddleware:
 
             os.unlink(db_path)
 
-    def test_proxy_fix_chains_multiple_proxies(self):
-        app, db_path = self._make_app(xff_count=2)
-        try:
-
-            @app.route("/__test_multi")
-            def test_multi():
-                from flask import request
-
-                return {"remote_addr": request.remote_addr}
-
-            with app.test_client() as client:
-                response = client.get(
-                    "/__test_multi",
-                    headers={
-                        "X-Forwarded-For": "1.2.3.4, 10.0.0.1",
-                    },
-                )
-                data = response.get_json()
-                assert data["remote_addr"] == "1.2.3.4"
-        finally:
-            import os
-
-            os.unlink(db_path)
-
     def test_proxy_fix_respects_x_forwarded_proto(self):
-        app, db_path = self._make_app(xff_count=1)
+        app, db_path = self._make_app(trusted_proxy_ips="10.89.0.90")
         try:
 
             @app.route("/__test_scheme")
@@ -144,26 +119,16 @@ class TestProxyFixMiddleware:
 
             os.unlink(db_path)
 
-    def test_proxy_fix_without_headers_keeps_defaults(self):
-        app, db_path = self._make_app(xff_count=None)
-        try:
 
-            @app.route("/__test_ip_default")
-            def test_ip_default():
-                from flask import request
+def test_gunicorn_uses_trusted_proxy_ips():
+    cfg = AppConfig(trusted_proxy_ips="10.89.0.90,10.89.0.91")
+    gunicorn_config = _build_gunicorn_config(cfg)
 
-                return {"remote_addr": request.remote_addr}
+    assert gunicorn_config["forwarded_allow_ips"] == "10.89.0.90,10.89.0.91"
 
-            with app.test_client() as client:
-                response = client.get(
-                    "/__test_ip_default",
-                    headers={
-                        "X-Forwarded-For": "9.9.9.9",
-                    },
-                )
-                data = response.get_json()
-                assert data["remote_addr"] == "127.0.0.1"
-        finally:
-            import os
 
-            os.unlink(db_path)
+def test_gunicorn_leaves_forwarded_allow_ips_unset_when_not_configured():
+    cfg = AppConfig(trusted_proxy_ips=None)
+    gunicorn_config = _build_gunicorn_config(cfg)
+
+    assert "forwarded_allow_ips" not in gunicorn_config


### PR DESCRIPTION
## Summary
- replace `reverse_proxy_xff_count` with `trusted_proxy_ips`, a comma-separated list of exact trusted reverse proxy IPs
- enable `ProxyFix` with a single trusted forwarded hop whenever `trusted_proxy_ips` is set, while passing the same IP list to Gunicorn `forwarded_allow_ips` only when running via `malla-web-gunicorn`
- update reverse proxy tests and docs to reflect the new security model and deployment guidance

## Why
Gunicorn was dropping `X-Forwarded-*` headers from containerized reverse proxies unless the immediate peer IP was trusted, which meant `ProxyFix`, access logs, and OpenTelemetry still saw the proxy IP instead of the client IP. This change makes the trust boundary explicit and keeps the extra Gunicorn trust scoped to Gunicorn deployments only.