### PR TITLE
perf: keep the web UI fast as packet_history grows

### DIFF
--- a/src/malla/database/connection.py
+++ b/src/malla/database/connection.py
@@ -5,13 +5,136 @@ Database connection management for Meshtastic Mesh Health Web UI.
 import logging
 import os
 import sqlite3
+import threading
 
 # Prefer configuration loader over environment variables
 from malla.config import get_config
 
-from .schema import ensure_startup_schema
+from .schema import (
+    ensure_query_planner_stats,
+    ensure_startup_schema,
+    query_planner_stats_present,
+)
 
 logger = logging.getLogger(__name__)
+
+# A larger page cache keeps query latency flat as the database grows into the
+# multi-gigabyte range. ``cache_size`` is negative so SQLite interprets it as
+# KiB (here 64 MiB) instead of a page count. ``analysis_limit`` bounds ANALYZE /
+# ``PRAGMA optimize`` so refreshing planner statistics stays cheap even on a
+# huge ``packet_history``.
+#
+# NOTE: mmap (PRAGMA mmap_size) is deliberately NOT used. With the capture
+# daemon writing continuously, memory-mapped readers can observe an incoherent
+# view during WAL checkpoints and report "database disk image is malformed",
+# so it is left at SQLite's default (off).
+_CACHE_SIZE_KIB = 65536  # 64 MiB page cache (negative value => KiB, not pages)
+_ANALYSIS_LIMIT = 1000  # cap ANALYZE work per index (see PRAGMA analysis_limit)
+
+
+def _apply_connection_pragmas(cursor: sqlite3.Cursor) -> None:
+    """Apply the shared SQLite tuning pragmas to *cursor*'s connection."""
+
+    # Enable WAL mode for better concurrent read/write performance
+    cursor.execute("PRAGMA journal_mode=WAL")
+
+    # Set synchronous to NORMAL for better performance while maintaining safety
+    cursor.execute("PRAGMA synchronous=NORMAL")
+
+    # Set busy timeout to handle concurrent access
+    cursor.execute("PRAGMA busy_timeout=30000")  # 30 seconds
+
+    # Enable foreign key constraints
+    cursor.execute("PRAGMA foreign_keys=ON")
+
+    # Optimize for read performance on a large, long-lived database
+    cursor.execute(f"PRAGMA cache_size=-{_CACHE_SIZE_KIB}")  # 64 MiB (negative => KiB)
+    cursor.execute("PRAGMA temp_store=MEMORY")
+
+    # Keep any ANALYZE / PRAGMA optimize triggered on this connection bounded.
+    cursor.execute(f"PRAGMA analysis_limit={_ANALYSIS_LIMIT}")
+
+
+def _resolve_db_path() -> str:
+    """Resolve the SQLite database path from env override, config, then default."""
+
+    return (
+        os.getenv("MALLA_DATABASE_FILE")
+        or get_config().database_file
+        or "meshtastic_history.db"
+    )
+
+
+# Guards against spawning more than one concurrent background ANALYZE seeder
+# per process. Tracks the live thread (not a latching flag) so a later startup
+# call can retry if a previous seed thread died, and so tests stay isolated.
+_stats_seed_lock = threading.Lock()
+_stats_seed_thread: threading.Thread | None = None
+
+
+def seed_query_planner_stats_async(db_path: str | None = None) -> bool:
+    """Seed SQLite planner statistics in a background thread if they are missing.
+
+    A bounded ANALYZE still reads ~1000 sample rows per index, which can take
+    ~100 seconds of random I/O on a cold multi-gigabyte database. Running it
+    synchronously at startup would block web request serving or packet
+    ingestion for that whole time, so we do it off-thread instead. When stats
+    are already present (the common case after the first run) this is a single
+    fast SELECT and no thread is started.
+
+    Returns ``True`` if a seeding thread was started.
+    """
+
+    global _stats_seed_thread
+
+    path = db_path or _resolve_db_path()
+
+    # Fast pre-check on the calling thread: usually stats already exist and we
+    # return immediately without touching threads.
+    try:
+        conn = sqlite3.connect(path, timeout=30.0)
+        try:
+            if query_planner_stats_present(conn.cursor()):
+                return False
+        finally:
+            conn.close()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Could not check query-planner statistics: %s", exc)
+        return False
+
+    with _stats_seed_lock:
+        if _stats_seed_thread is not None and _stats_seed_thread.is_alive():
+            return False
+
+    def _worker() -> None:
+        import time
+
+        try:
+            conn = sqlite3.connect(path, timeout=60.0)
+            try:
+                _apply_connection_pragmas(conn.cursor())
+                started = time.time()
+                if ensure_query_planner_stats(conn.cursor()):
+                    conn.commit()
+                    logger.info(
+                        "Seeded query-planner statistics in %.1fs",
+                        time.time() - started,
+                    )
+            finally:
+                conn.close()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Background ANALYZE seeding failed: %s", exc)
+
+    thread = threading.Thread(
+        target=_worker, name="malla-analyze-seed", daemon=True
+    )
+    with _stats_seed_lock:
+        # Re-check under the lock in case a concurrent caller started one.
+        if _stats_seed_thread is not None and _stats_seed_thread.is_alive():
+            return False
+        _stats_seed_thread = thread
+        thread.start()
+    return True
 
 
 def get_db_connection() -> sqlite3.Connection:
@@ -21,16 +144,7 @@ def get_db_connection() -> sqlite3.Connection:
     Returns:
         sqlite3.Connection: Database connection with row factory set and WAL mode enabled
     """
-    # Resolve DB path:
-    # 1. Explicit override via `MALLA_DATABASE_FILE` env-var (handy for scripts)
-    # 2. Value from YAML configuration
-    # 3. Fallback to hard-coded default
-
-    db_path: str = (
-        os.getenv("MALLA_DATABASE_FILE")
-        or get_config().database_file
-        or "meshtastic_history.db"
-    )
+    db_path = _resolve_db_path()
 
     try:
         conn = sqlite3.connect(
@@ -38,24 +152,8 @@ def get_db_connection() -> sqlite3.Connection:
         )  # 30 second timeout for busy database
         conn.row_factory = sqlite3.Row  # Enable column access by name
 
-        # Configure SQLite for better concurrency
-        cursor = conn.cursor()
-
-        # Enable WAL mode for better concurrent read/write performance
-        cursor.execute("PRAGMA journal_mode=WAL")
-
-        # Set synchronous to NORMAL for better performance while maintaining safety
-        cursor.execute("PRAGMA synchronous=NORMAL")
-
-        # Set busy timeout to handle concurrent access
-        cursor.execute("PRAGMA busy_timeout=30000")  # 30 seconds
-
-        # Enable foreign key constraints
-        cursor.execute("PRAGMA foreign_keys=ON")
-
-        # Optimize for read performance
-        cursor.execute("PRAGMA cache_size=10000")  # 10MB cache
-        cursor.execute("PRAGMA temp_store=MEMORY")
+        # Configure SQLite for better concurrency and large-database performance
+        _apply_connection_pragmas(conn.cursor())
 
         return conn
     except Exception as e:
@@ -68,16 +166,7 @@ def init_database() -> None:
     Initialize the database connection and verify it's accessible.
     This function is called during application startup.
     """
-    # Resolve DB path:
-    # 1. Explicit override via `MALLA_DATABASE_FILE` env-var (handy for scripts)
-    # 2. Value from YAML configuration
-    # 3. Fallback to hard-coded default
-
-    db_path: str = (
-        os.getenv("MALLA_DATABASE_FILE")
-        or get_config().database_file
-        or "meshtastic_history.db"
-    )
+    db_path = _resolve_db_path()
 
     logger.info(f"Initializing database connection to: {db_path}")
 
@@ -97,6 +186,12 @@ def init_database() -> None:
         journal_mode = cursor.fetchone()[0]
 
         conn.close()
+
+        # Seed query-planner statistics on first run so the planner picks
+        # index-based plans instead of full scans on a large packet_history.
+        # Runs in a background thread so a cold ANALYZE (~100s on a multi-GB DB)
+        # never blocks request serving.
+        seed_query_planner_stats_async(db_path)
 
         logger.info(
             f"Database connection successful - found {table_count} tables, journal_mode: {journal_mode}"

--- a/src/malla/database/repositories.py
+++ b/src/malla/database/repositories.py
@@ -72,6 +72,14 @@ def _store_relay_candidates(
     )
 
 
+# Dashboard stats are recomputed from an all-time COUNT(*) plus 24h aggregates
+# over packet_history. The landing page ("/") and /api/stats hit this on every
+# view, so a short TTL cache keeps the common case O(1) while the numbers stay
+# fresh to within a few seconds. Keyed by gateway_id (None => site-wide).
+DASHBOARD_STATS_CACHE_TTL_SECONDS = 30
+_dashboard_stats_cache: dict[str | None, tuple[float, dict[str, Any]]] = {}
+
+
 class DashboardRepository:
     """Repository for dashboard statistics."""
 
@@ -79,6 +87,13 @@ class DashboardRepository:
     def get_stats(gateway_id: str | None = None) -> dict[str, Any]:
         """Get overview statistics for the dashboard using optimized single query."""
         logger.info(f"Getting dashboard stats with gateway_id={gateway_id}")
+
+        now = time.time()
+        cached = _dashboard_stats_cache.get(gateway_id)
+        if cached is not None:
+            cached_at, cached_stats = cached
+            if now - cached_at <= DASHBOARD_STATS_CACHE_TTL_SECONDS:
+                return dict(cached_stats)
 
         try:
             conn = get_db_connection()
@@ -122,11 +137,18 @@ class DashboardRepository:
 
             stats_row = cursor.fetchone()
 
-            # Get total packet count (all time) separately
-            cursor.execute(
-                f"SELECT COUNT(*) as total FROM packet_history WHERE 1=1{gateway_filter}",
-                gateway_params,
-            )
+            # Get total packet count (all time) separately. Avoid a vestigial
+            # "WHERE 1=1" when there is no gateway filter: with a bare COUNT(*)
+            # and no WHERE clause SQLite uses its OP_Count optimization (walk the
+            # smallest index's page counts) instead of visiting every row, which
+            # is several times faster on a large packet_history.
+            if gateway_filter:
+                cursor.execute(
+                    f"SELECT COUNT(*) as total FROM packet_history WHERE 1=1{gateway_filter}",
+                    gateway_params,
+                )
+            else:
+                cursor.execute("SELECT COUNT(*) as total FROM packet_history")
             total_packets_all_time = cursor.fetchone()["total"]
 
             # Get packet types separately (more efficient than JSON aggregation in SQLite)
@@ -145,7 +167,7 @@ class DashboardRepository:
 
             conn.close()
 
-            return {
+            stats = {
                 "total_nodes": total_nodes,
                 "active_nodes_24h": stats_row["active_nodes_24h"] or 0,
                 "total_packets": total_packets_all_time or 0,
@@ -155,6 +177,9 @@ class DashboardRepository:
                 "packet_types": packet_types,
                 "success_rate": stats_row["success_rate"] or 0,
             }
+
+            _dashboard_stats_cache[gateway_id] = (now, dict(stats))
+            return stats
 
         except Exception as e:
             logger.error(f"Error getting dashboard stats: {e}")

--- a/src/malla/database/schema.py
+++ b/src/malla/database/schema.py
@@ -129,6 +129,48 @@ def _get_existing_indexes(cursor: sqlite3.Cursor) -> set[str]:
     return {row[0] for row in cursor.fetchall()}
 
 
+def query_planner_stats_present(cursor: sqlite3.Cursor) -> bool:
+    """Return ``True`` if SQLite query-planner statistics (sqlite_stat1) exist."""
+
+    cursor.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'sqlite_stat1'"
+    )
+    if cursor.fetchone() is None:
+        return False
+    cursor.execute("SELECT 1 FROM sqlite_stat1 LIMIT 1")
+    return cursor.fetchone() is not None
+
+
+def ensure_query_planner_stats(cursor: sqlite3.Cursor) -> bool:
+    """Seed SQLite query-planner statistics if they are missing.
+
+    Without ``sqlite_stat1`` the planner guesses index selectivity and can pick
+    a badly-scaling plan (e.g. a full scan of ``packet_history`` for a query a
+    partial index would serve in milliseconds). A one-off ``ANALYZE`` fixes this;
+    ``PRAGMA analysis_limit`` keeps it bounded so it stays fast even on a
+    multi-gigabyte database. Returns ``True`` when ANALYZE was run.
+
+    Note: even a bounded ANALYZE reads ~``analysis_limit`` sample rows per index,
+    which can be ~100 seconds of random I/O on a cold multi-gigabyte database.
+    Prefer :func:`malla.database.connection.seed_query_planner_stats_async` on
+    the startup path so this never blocks request serving or packet ingestion.
+
+    Stats are only *seeded* here (when absent). Keeping them fresh as the
+    database grows is handled separately by periodic ``PRAGMA optimize`` in the
+    capture daemon.
+    """
+
+    if query_planner_stats_present(cursor):
+        return False  # stats already present – nothing to do
+
+    # analysis_limit bounds the work per index; without it ANALYZE would scan
+    # every index in full and could take many minutes on a huge packet_history.
+    cursor.execute("PRAGMA analysis_limit=1000")
+    logger.info("Query-planner statistics missing – running bounded ANALYZE")
+    cursor.execute("ANALYZE")
+    return True
+
+
 def ensure_startup_schema(
     cursor: sqlite3.Cursor, *, drop_legacy_indexes: bool = False
 ) -> None:

--- a/src/malla/mqtt_capture.py
+++ b/src/malla/mqtt_capture.py
@@ -56,6 +56,7 @@ from paho.mqtt.enums import CallbackAPIVersion
 # ---------------------------------------------------------------------------
 from malla.config import get_config  # Import here to avoid circular import issues
 
+from .database.connection import seed_query_planner_stats_async
 from .database.schema import ensure_startup_schema
 
 # Load the singleton configuration once at module import time.  This ensures the
@@ -282,13 +283,18 @@ def init_database() -> None:
     conn.row_factory = sqlite3.Row
     cursor = conn.cursor()
 
-    # Configure SQLite for better concurrency
+    # Configure SQLite for better concurrency and large-database performance.
+    # cache_size is negative so SQLite reads it as KiB (64 MiB) rather than a
+    # page count. mmap is intentionally left off: with continuous writes,
+    # memory-mapped readers can report "database disk image is malformed"
+    # during WAL checkpoints.
     cursor.execute("PRAGMA journal_mode=WAL")
     cursor.execute("PRAGMA synchronous=NORMAL")
     cursor.execute("PRAGMA busy_timeout=30000")
     cursor.execute("PRAGMA foreign_keys=ON")
-    cursor.execute("PRAGMA cache_size=10000")
+    cursor.execute("PRAGMA cache_size=-65536")  # 64 MiB (negative => KiB)
     cursor.execute("PRAGMA temp_store=MEMORY")
+    cursor.execute("PRAGMA analysis_limit=1000")  # bound ANALYZE / optimize work
 
     # Table for packet history
     cursor.execute("""
@@ -409,6 +415,13 @@ def init_database() -> None:
 
     conn.commit()
     conn.close()
+
+    # Seed query-planner statistics on first run so the planner picks
+    # index-based plans instead of full scans on a large packet_history. Runs in
+    # a background thread so a cold ANALYZE (~100s on a multi-GB DB) does not
+    # delay packet ingestion or hold the write lock.
+    seed_query_planner_stats_async(DATABASE_FILE)
+
     logging.info(
         "Database initialized: %s (%.3fs)",
         DATABASE_FILE,
@@ -950,9 +963,17 @@ def get_node_statistics() -> dict[str, Any]:
         )
         active_nodes_24h = cursor.fetchone()[0]
 
-        # Total packets received
-        cursor.execute("SELECT COUNT(*) FROM packet_history")
-        total_packets = cursor.fetchone()[0]
+        # Total packets received. Use the AUTOINCREMENT high-water mark from
+        # sqlite_sequence (O(1)) instead of COUNT(*) over the whole table, which
+        # would scan all of packet_history while holding db_lock every minute and
+        # stall packet ingestion as history grows. This is an upper bound; if row
+        # deletion (data retention) is ever enabled it slightly overcounts, which
+        # is acceptable for a log line.
+        cursor.execute(
+            "SELECT seq FROM sqlite_sequence WHERE name = 'packet_history'"
+        )
+        seq_row = cursor.fetchone()
+        total_packets = seq_row[0] if seq_row else 0
 
         conn.close()
 
@@ -1441,12 +1462,34 @@ def main() -> None:
 
     try:
         # Keep the main thread alive
+        optimize_interval = 3600  # refresh query-planner stats hourly
+        last_optimize = time.time()
         while True:
             time.sleep(60)  # Print stats every minute
             stats = get_node_statistics()
             logging.info(
                 f"Stats: {stats['total_nodes']} nodes, {stats['total_packets']} packets, {stats['active_nodes_24h']} active (24h)"
             )
+
+            # Periodically refresh query-planner statistics so the planner keeps
+            # choosing index-based plans as packet_history grows. PRAGMA optimize
+            # is bounded by the analysis_limit set on the connection and only
+            # re-analyzes indexes that changed enough to matter, so it usually
+            # does little. It runs on its own connection WITHOUT db_lock so its
+            # sampling never stalls packet ingestion; WAL plus busy_timeout make
+            # its brief final stats write safe alongside concurrent inserts.
+            now = time.time()
+            if now - last_optimize >= optimize_interval:
+                try:
+                    opt_conn = sqlite3.connect(DATABASE_FILE, timeout=60.0)
+                    opt_conn.execute("PRAGMA busy_timeout=30000")
+                    opt_conn.execute("PRAGMA analysis_limit=1000")
+                    opt_conn.execute("PRAGMA optimize")
+                    opt_conn.close()
+                    logging.debug("Ran PRAGMA optimize to refresh planner stats")
+                except Exception as exc:  # noqa: BLE001
+                    logging.warning("PRAGMA optimize failed: %s", exc)
+                last_optimize = now
     except KeyboardInterrupt:
         logging.info("Script interrupted by user. Shutting down...")
     finally:

--- a/tests/unit/test_dashboard_stats_cache.py
+++ b/tests/unit/test_dashboard_stats_cache.py
@@ -1,0 +1,75 @@
+"""Tests for the dashboard statistics TTL cache.
+
+DashboardRepository.get_stats runs an all-time COUNT(*) plus 24h aggregates over
+packet_history on the most-visited page ("/") and /api/stats. A short TTL cache
+keeps repeated views O(1); these tests pin that behaviour.
+"""
+
+import malla.database.repositories as repositories
+from malla.database.repositories import DashboardRepository
+
+
+def test_get_stats_cached_within_ttl(temp_database, monkeypatch):
+    """A second call within the TTL reuses the cache and skips the DB."""
+
+    monkeypatch.setenv("MALLA_DATABASE_FILE", temp_database)
+    repositories._dashboard_stats_cache.clear()
+
+    calls = {"n": 0}
+    real_get_conn = repositories.get_db_connection
+
+    def counting_get_conn():
+        calls["n"] += 1
+        return real_get_conn()
+
+    monkeypatch.setattr(repositories, "get_db_connection", counting_get_conn)
+
+    first = DashboardRepository.get_stats()
+    second = DashboardRepository.get_stats()
+
+    assert first == second
+    assert "total_packets" in first
+    # Only the first call touches the database; the second is served from cache.
+    assert calls["n"] == 1
+
+
+def test_get_stats_recomputes_after_ttl_expiry(temp_database, monkeypatch):
+    """Once the cache entry ages past the TTL the stats are recomputed."""
+
+    monkeypatch.setenv("MALLA_DATABASE_FILE", temp_database)
+    repositories._dashboard_stats_cache.clear()
+
+    calls = {"n": 0}
+    real_get_conn = repositories.get_db_connection
+
+    def counting_get_conn():
+        calls["n"] += 1
+        return real_get_conn()
+
+    monkeypatch.setattr(repositories, "get_db_connection", counting_get_conn)
+
+    DashboardRepository.get_stats()
+    assert calls["n"] == 1
+
+    # Age the cached entry beyond the TTL by rewriting its timestamp.
+    cached_at, cached_stats = repositories._dashboard_stats_cache[None]
+    repositories._dashboard_stats_cache[None] = (
+        cached_at - repositories.DASHBOARD_STATS_CACHE_TTL_SECONDS - 1,
+        cached_stats,
+    )
+
+    DashboardRepository.get_stats()
+    assert calls["n"] == 2
+
+
+def test_get_stats_cache_keyed_by_gateway(temp_database, monkeypatch):
+    """Different gateway filters are cached independently."""
+
+    monkeypatch.setenv("MALLA_DATABASE_FILE", temp_database)
+    repositories._dashboard_stats_cache.clear()
+
+    DashboardRepository.get_stats()
+    DashboardRepository.get_stats(gateway_id="!deadbeef")
+
+    assert None in repositories._dashboard_stats_cache
+    assert "!deadbeef" in repositories._dashboard_stats_cache

--- a/tests/unit/test_query_planner_stats.py
+++ b/tests/unit/test_query_planner_stats.py
@@ -1,0 +1,125 @@
+"""Tests for SQLite query-planner statistics seeding.
+
+Without ``sqlite_stat1`` the planner can pick full-scan plans that degrade as
+``packet_history`` grows. These tests cover the helpers that seed those stats
+on first run (synchronously and via the non-blocking background thread).
+"""
+
+import sqlite3
+import time
+
+from malla.database.connection import seed_query_planner_stats_async
+from malla.database.schema import (
+    ensure_query_planner_stats,
+    ensure_startup_schema,
+    query_planner_stats_present,
+)
+
+
+def _make_populated_db(path: str) -> None:
+    """Create a small packet_history/node_info DB with startup indexes."""
+
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE packet_history (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp REAL NOT NULL,
+            topic TEXT NOT NULL,
+            from_node_id INTEGER,
+            to_node_id INTEGER,
+            portnum INTEGER,
+            portnum_name TEXT,
+            gateway_id TEXT,
+            channel_id TEXT,
+            mesh_packet_id INTEGER,
+            rssi INTEGER,
+            snr REAL,
+            hop_limit INTEGER,
+            hop_start INTEGER,
+            payload_length INTEGER,
+            raw_payload BLOB,
+            processed_successfully BOOLEAN DEFAULT TRUE,
+            relay_node INTEGER
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE node_info (
+            node_id INTEGER PRIMARY KEY,
+            hex_id TEXT,
+            long_name TEXT,
+            short_name TEXT,
+            hw_model TEXT,
+            role TEXT,
+            first_seen REAL NOT NULL,
+            last_updated REAL NOT NULL
+        )
+        """
+    )
+    for i in range(200):
+        cur.execute(
+            "INSERT INTO packet_history (timestamp, topic, from_node_id, portnum_name) "
+            "VALUES (?, ?, ?, ?)",
+            (1000.0 + i, "msh/x", i % 20, "TEXT_MESSAGE_APP"),
+        )
+    ensure_startup_schema(cur)
+    conn.commit()
+    conn.close()
+
+
+def test_stats_absent_then_seeded(tmp_path):
+    """ensure_query_planner_stats creates sqlite_stat1 the first time only."""
+
+    db = str(tmp_path / "stats.db")
+    _make_populated_db(db)
+
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+
+    assert query_planner_stats_present(cur) is False
+
+    ran = ensure_query_planner_stats(cur)
+    conn.commit()
+    assert ran is True
+    assert query_planner_stats_present(cur) is True
+
+    # Second call is a no-op because stats already exist.
+    assert ensure_query_planner_stats(cur) is False
+    conn.close()
+
+
+def test_async_seeder_populates_stats(tmp_path):
+    """The background seeder eventually creates planner statistics."""
+
+    db = str(tmp_path / "async.db")
+    _make_populated_db(db)
+
+    started = seed_query_planner_stats_async(db)
+    assert started is True
+
+    # Wait for the daemon thread to finish (small DB => milliseconds).
+    deadline = time.time() + 10
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    while time.time() < deadline and not query_planner_stats_present(cur):
+        time.sleep(0.05)
+
+    assert query_planner_stats_present(cur) is True
+    conn.close()
+
+
+def test_async_seeder_noop_when_stats_present(tmp_path):
+    """When stats already exist the seeder returns False and starts no thread."""
+
+    db = str(tmp_path / "present.db")
+    _make_populated_db(db)
+
+    conn = sqlite3.connect(db)
+    ensure_query_planner_stats(conn.cursor())
+    conn.commit()
+    conn.close()
+
+    assert seed_query_planner_stats_async(db) is False


### PR DESCRIPTION
As the SQLite capture grows to millions of rows, page loads slow down due to unbounded per-request work and a query planner running without statistics. All changes preserve full history (no retention/deletion).

- Seed query-planner statistics (ANALYZE) on first startup so the planner stops choosing full scans. It runs in a background thread because a cold bounded ANALYZE is ~100s of random I/O on a multi-GB DB and must not block serving or ingestion; once seeded it persists. The capture daemon refreshes stats hourly via PRAGMA optimize.
- Tune SQLite for a large, long-lived database: 64 MiB page cache (the old cache_size=10000 was pages, ~40 MiB) and analysis_limit to bound ANALYZE/optimize. (mmap is intentionally left off: with the capture daemon writing continuously, memory-mapped readers can report "database disk image is malformed" during WAL checkpoints.)
- Cache dashboard stats for 30s and drop a vestigial "WHERE 1=1" that defeated SQLite's COUNT(*) optimization; the landing page and /api/stats ran an all-time COUNT on every view.
- Replace the capture daemon's per-minute COUNT(*) over packet_history (run while holding the write lock) with the O(1) sqlite_sequence value.