### PR TITLE
Add configurable custom CSS and <head> HTML

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -6,6 +6,21 @@
 # Display name shown in the navigation bar and browser title
 name: "Malla"
 
+# Operator page customization (optional).
+# custom_css is injected as an inline <style> at the end of every page's <head>,
+# so it overrides the built-in theme. The theme is driven by Bootstrap CSS
+# variables, so overriding --bs-primary recolors the whole site (incl. navbar).
+# Env var: MALLA_CUSTOM_CSS
+# custom_css: |
+#   :root { --bs-primary: #14532d; --bs-primary-rgb: 20, 83, 45; }
+#   .navbar { background-color: #14532d !important; }
+#
+# custom_html_head is raw HTML injected into <head> (favicon, meta tags,
+# <link>, <script>, ...). Scripts should wait for the DOM (defer / DOMContentLoaded).
+# Env var: MALLA_CUSTOM_HTML_HEAD
+# custom_html_head: |
+#   <link rel="icon" href="https://example.com/favicon.ico">
+
 # Markdown content rendered on the dashboard homepage
 home_markdown: |
   # Welcome to Malla

--- a/env.example
+++ b/env.example
@@ -26,6 +26,12 @@ MALLA_NAME=Malla
 # Markdown content rendered on the dashboard homepage
 # MALLA_HOME_MARKDOWN=
 
+# Inline CSS injected into every page's <head> to restyle the UI without
+# editing templates. Overriding Bootstrap CSS variables recolors the whole site.
+# MALLA_CUSTOM_CSS=:root{--bs-primary:#14532d;--bs-primary-rgb:20,83,45}
+# Raw HTML injected into <head> (favicon, meta, <link>, <script>).
+# MALLA_CUSTOM_HTML_HEAD=<link rel="icon" href="/static/favicon.ico">
+
 # Flask secret key (change this for production!)
 MALLA_SECRET_KEY=your-secret-key-here
 

--- a/src/malla/config.py
+++ b/src/malla/config.py
@@ -24,6 +24,16 @@ class AppConfig:
     name: str = "Malla"
     home_markdown: str = ""
 
+    # Operator page customization (trusted deployment config, not user input).
+    # custom_css is inlined in a <style> at the end of every page's <head>;
+    # custom_html_head is raw HTML injected right after it (favicon, meta,
+    # <link>, <script>, ...). Both let operators restyle or extend the UI
+    # without editing templates or rebuilding the image. Because the theme is
+    # driven by Bootstrap CSS variables, overriding e.g. --bs-primary in
+    # custom_css recolors the whole site (buttons, links, navbar, ...).
+    custom_css: str = ""
+    custom_html_head: str = ""
+
     # Flask/server settings
     secret_key: str = "dev-secret-key-change-in-production"
     database_file: str = "meshtastic_history.db"

--- a/src/malla/templates/base.html
+++ b/src/malla/templates/base.html
@@ -62,6 +62,10 @@
     </style>
 
     {% block extra_css %}{% endblock %}
+
+    {# Operator customization, injected last so it overrides the theme and per-page CSS #}
+    {% if APP_CONFIG and APP_CONFIG.custom_css %}<style>{{ APP_CONFIG.custom_css | safe }}</style>{% endif %}
+    {% if APP_CONFIG and APP_CONFIG.custom_html_head %}{{ APP_CONFIG.custom_html_head | safe }}{% endif %}
 </head>
 <body>
     <!-- Navigation -->

--- a/tests/unit/test_custom_css.py
+++ b/tests/unit/test_custom_css.py
@@ -1,0 +1,101 @@
+"""Tests for operator page customization (custom_css / custom_html_head)."""
+
+import os
+import tempfile
+
+from malla.config import AppConfig, _clear_config_cache, load_config
+from malla.web_ui import create_app
+from tests.fixtures.database_fixtures import DatabaseFixtures
+
+
+def test_customization_defaults(monkeypatch):
+    """Both customization fields default to empty (no behaviour change)."""
+
+    _clear_config_cache()
+    monkeypatch.delenv("MALLA_CUSTOM_CSS", raising=False)
+    monkeypatch.delenv("MALLA_CUSTOM_HTML_HEAD", raising=False)
+
+    cfg = load_config(config_path=None)
+
+    assert cfg.custom_css == ""
+    assert cfg.custom_html_head == ""
+
+
+def test_customization_from_yaml(tmp_path, monkeypatch):
+    """custom_css / custom_html_head can be set via the YAML config file."""
+
+    _clear_config_cache()
+    monkeypatch.delenv("MALLA_CUSTOM_CSS", raising=False)
+    monkeypatch.delenv("MALLA_CUSTOM_HTML_HEAD", raising=False)
+
+    yaml_file = tmp_path / "config.yaml"
+    yaml_file.write_text(
+        'custom_css: ".navbar { background: #123456; }"\n'
+        "custom_html_head: '<meta name=\"x\" content=\"y\">'\n"
+    )
+
+    cfg = load_config(config_path=yaml_file)
+
+    assert cfg.custom_css == ".navbar { background: #123456; }"
+    assert cfg.custom_html_head == '<meta name="x" content="y">'
+
+
+def test_customization_env_override(monkeypatch):
+    """MALLA_CUSTOM_CSS / MALLA_CUSTOM_HTML_HEAD override YAML/defaults."""
+
+    _clear_config_cache()
+    monkeypatch.setenv("MALLA_CUSTOM_CSS", ":root{--bs-primary:#14532d}")
+    monkeypatch.setenv("MALLA_CUSTOM_HTML_HEAD", "<link rel='icon' href='/f.ico'>")
+
+    cfg = load_config(config_path=None)
+
+    assert cfg.custom_css == ":root{--bs-primary:#14532d}"
+    assert cfg.custom_html_head == "<link rel='icon' href='/f.ico'>"
+
+
+def _client_for(cfg: AppConfig):
+    """Build a Flask test client backed by a temporary fixture database."""
+
+    temp_db = tempfile.NamedTemporaryFile(delete=False, suffix=".db")
+    temp_db.close()
+    cfg.database_file = temp_db.name
+    DatabaseFixtures().create_test_database(temp_db.name)
+    app = create_app(cfg)
+    app.config["TESTING"] = True
+    return app.test_client(), temp_db.name
+
+
+def test_customization_rendered_into_head():
+    """When set, both fields appear in the rendered <head> of a page."""
+
+    marker_css = ".navbar{background:#abcdef}"
+    marker_head = '<meta name="malla-test" content="custom-head">'
+    client, db_path = _client_for(
+        AppConfig(custom_css=marker_css, custom_html_head=marker_head)
+    )
+    try:
+        html = client.get("/nodes").get_data(as_text=True)
+        assert f"<style>{marker_css}</style>" in html
+        assert marker_head in html
+    finally:
+        _clear_config_cache()
+        try:
+            os.unlink(db_path)
+        except FileNotFoundError:
+            pass
+
+
+def test_no_customization_markup_when_unset():
+    """With the defaults, no empty <style> tag or injection is emitted."""
+
+    client, db_path = _client_for(AppConfig())
+    try:
+        html = client.get("/nodes").get_data(as_text=True)
+        assert "<style></style>" not in html
+        assert 'name="malla-test"' not in html
+    finally:
+        _clear_config_cache()
+        try:
+            os.unlink(db_path)
+        except FileNotFoundError:
+            pass


### PR DESCRIPTION
## Summary
- add two `AppConfig` fields — `custom_css` and `custom_html_head` — also settable via `MALLA_CUSTOM_CSS` / `MALLA_CUSTOM_HTML_HEAD`
- inject both into `<head>` from `base.html`, after the theme stylesheet and per-page CSS so operator styles take precedence site-wide (all page templates extend `base.html`)
- document both in `config.sample.yaml` and `env.example`

Operators often want to brand or restyle their instance — accent colour, favicon, an announcement banner — without forking templates or rebuilding the image. Because the theme is driven by Bootstrap CSS variables, overriding `--bs-primary` in `custom_css` recolours the whole site (buttons, links, table headers, navbar). Both fields default to empty, so existing deployments are unchanged; they are trusted deployment-level settings (injected with `| safe`, the same trust model as the existing `home_markdown` option).

### Example
```yaml
# config.yaml — recolour the navbar
custom_css: |
  .navbar.bg-primary { background-color: #0e4b57 !important; }
```

## Testing
- uv run pytest -n0 tests/unit/test_custom_css.py -q