### PR TITLE
Add telemetry history charts to the node detail page

### DIFF
--- a/src/malla/database/repositories.py
+++ b/src/malla/database/repositories.py
@@ -8,7 +8,7 @@ import json
 import logging
 import time
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal
 
 from meshtastic import mesh_pb2, telemetry_pb2
 from meshtastic.protobuf import mqtt_pb2
@@ -27,7 +27,9 @@ logger = logging.getLogger(__name__)
 # with a unit and a coarse ``group`` so related metrics can be plotted together.
 # Only fields the node actually reports are returned. Values are read as-is,
 # matching the packet-detail view (no scaling).
-_TELEMETRY_METRICS: tuple[tuple[str, str, str, str], ...] = (
+_TELEMETRY_METRICS: tuple[
+    tuple[Literal["environment_metrics", "device_metrics"], str, str, str], ...
+] = (
     # (sub_message, field, unit, group)
     ("environment_metrics", "temperature", "°C", "environment"),
     ("environment_metrics", "relative_humidity", "%", "environment"),

--- a/src/malla/database/repositories.py
+++ b/src/malla/database/repositories.py
@@ -10,16 +10,154 @@ import time
 from datetime import UTC, datetime
 from typing import Any
 
-from meshtastic import mesh_pb2
+from meshtastic import mesh_pb2, telemetry_pb2
 from meshtastic.protobuf import mqtt_pb2
 
 from ..config import get_config
 from ..utils.decryption import try_decrypt_mesh_packet
 from ..utils.formatting import format_time_ago
-from ..utils.node_utils import get_bulk_node_short_names
+from ..utils.node_utils import convert_node_id, get_bulk_node_short_names
 from .connection import get_db_connection
 
 logger = logging.getLogger(__name__)
+
+# Telemetry metrics charted on the node detail page. Each entry maps a
+# TELEMETRY_APP protobuf sub-message + field to display metadata. Chart grouping
+# and axis assignment are a frontend concern; here each metric is just tagged
+# with a unit and a coarse ``group`` so related metrics can be plotted together.
+# Only fields the node actually reports are returned. Values are read as-is,
+# matching the packet-detail view (no scaling).
+_TELEMETRY_METRICS: tuple[tuple[str, str, str, str], ...] = (
+    # (sub_message, field, unit, group)
+    ("environment_metrics", "temperature", "°C", "environment"),
+    ("environment_metrics", "relative_humidity", "%", "environment"),
+    ("environment_metrics", "barometric_pressure", "hPa", "pressure"),
+    ("environment_metrics", "gas_resistance", "MΩ", "air_quality"),
+    ("environment_metrics", "iaq", "", "air_quality"),
+    ("environment_metrics", "lux", "lx", "light"),
+    ("device_metrics", "battery_level", "%", "power"),
+    ("device_metrics", "voltage", "V", "power"),
+    ("device_metrics", "channel_utilization", "%", "channel"),
+    ("device_metrics", "air_util_tx", "%", "channel"),
+)
+
+# Gaps longer than this (seconds) break the line and the smoothing window, so a
+# node that was offline for a while does not get a trend drawn across the void.
+# Matches GAP_LIMIT in node_telemetry.js.
+_AGGREGATE_GAP = 86400
+
+# Half-width of the faded band, in standard deviations around the mean. ~1.5σ
+# covers the bulk of the spread without the band ballooning out to rare extremes.
+_BAND_SIGMA = 1.5
+
+
+def _aggregate_run(
+    points: list[list[Any]], n_buckets: int
+) -> tuple[list[list[Any]], list[list[Any]]]:
+    """Aggregate one *continuous* run (no gap > ``_AGGREGATE_GAP``) into
+    ``n_buckets`` buckets: a smoothed mean line plus a ``mean ± k·σ`` band.
+
+    The line is the windowed mean and the band is that same window's mean plus
+    or minus ``_BAND_SIGMA`` standard deviations, so the line sits exactly in the
+    centre of the band and the band shows the *typical* spread — it is not blown
+    out by the occasional extreme the way a raw min/max envelope is.
+    """
+    n = len(points)
+    n_buckets = max(1, min(n_buckets, n))
+    step = n / n_buckets
+    ts_list: list[float] = []
+    counts: list[int] = []
+    sums: list[float] = []
+    sumsqs: list[float] = []
+    bucket_min: list[float] = []
+    bucket_max: list[float] = []
+    for i in range(n_buckets):
+        lo = int(i * step)
+        hi = int((i + 1) * step) if i < n_buckets - 1 else n
+        if hi <= lo:
+            continue
+        segment = points[lo:hi]
+        values = [p[1] for p in segment]
+        ts_list.append(segment[len(segment) // 2][0])
+        counts.append(len(values))
+        sums.append(sum(values))
+        sumsqs.append(sum(v * v for v in values))
+        bucket_min.append(min(values))
+        bucket_max.append(max(values))
+
+    # Mean and standard deviation over a small centred window of buckets (the run
+    # is continuous, so the window never spans a real gap). Pooling the raw sums
+    # captures both within- and between-bucket variation, so cyclic swings widen
+    # the band while one-off spikes barely move it. The band is clamped to the
+    # window's real min/max so it never claims a value that was never observed.
+    m = len(ts_list)
+    half = 2
+    avg_line: list[list[Any]] = []
+    band: list[list[Any]] = []
+    for i in range(m):
+        lo2 = max(0, i - half)
+        hi2 = min(m, i + half + 1)
+        total_n = sum(counts[lo2:hi2])
+        total_s = sum(sums[lo2:hi2])
+        total_q = sum(sumsqs[lo2:hi2])
+        mean = total_s / total_n
+        var = total_q / total_n - mean * mean
+        std = var**0.5 if var > 0 else 0.0
+        lower = max(mean - _BAND_SIGMA * std, min(bucket_min[lo2:hi2]))
+        upper = min(mean + _BAND_SIGMA * std, max(bucket_max[lo2:hi2]))
+        avg_line.append([ts_list[i], round(mean, 3)])
+        band.append([ts_list[i], round(lower, 3), round(upper, 3)])
+    return avg_line, band
+
+
+def _aggregate(
+    points: list[list[Any]], max_points: int
+) -> tuple[list[list[Any]], list[list[Any]]]:
+    """Aggregate ``[ts, value]`` points into ~``max_points`` time buckets.
+
+    Returns ``(avg_line, band)`` where ``avg_line`` is ``[ts, average]`` per
+    bucket and ``band`` is ``[ts, lower, upper]`` (mean ± ``_BAND_SIGMA`` σ) per
+    bucket. Charts draw the average as a smooth line centred in the faded band,
+    so wide-range views show the typical spread without turning the line into
+    noise.
+
+    Real gaps in the raw data (no readings for longer than ``_AGGREGATE_GAP``)
+    split the points into continuous runs; each run is aggregated on its own so a
+    bucket never straddles an outage, and the runs are joined by ``[ts, None]`` /
+    ``[ts, None, None]`` break entries that tell the chart to lift the pen. This
+    is done from the raw timestamps, not the spacing between bucket centres —
+    over a long span every bucket is naturally many hours wide, and that width
+    must not be mistaken for a gap.
+    """
+    n = len(points)
+    # Far fewer buckets than the raw cap so each bucket averages many points:
+    # the average line stays smooth (noise averages out) while the band keeps the
+    # typical spread.
+    n_buckets = max(1, min(max_points, 150))
+
+    # Split into continuous runs wherever the raw data was interrupted.
+    runs: list[tuple[int, int]] = []
+    start = 0
+    for i in range(1, n):
+        if points[i][0] - points[i - 1][0] > _AGGREGATE_GAP:
+            runs.append((start, i))
+            start = i
+    runs.append((start, n))
+
+    avg_line: list[list[Any]] = []
+    band: list[list[Any]] = []
+    for idx, (rs, re) in enumerate(runs):
+        run = points[rs:re]
+        # Buckets per run in proportion to its share of the points.
+        run_buckets = max(1, round(n_buckets * len(run) / n))
+        run_avg, run_band = _aggregate_run(run, run_buckets)
+        if idx > 0:
+            gap_mid = (points[rs - 1][0] + points[rs][0]) / 2
+            avg_line.append([gap_mid, None])
+            band.append([gap_mid, None, None])
+        avg_line.extend(run_avg)
+        band.extend(run_band)
+    return avg_line, band
 
 RELAY_CANDIDATE_CACHE_TTL_SECONDS = 1800
 RELAY_CANDIDATE_CACHE_MAX_ENTRIES = 4096
@@ -72,6 +210,14 @@ def _store_relay_candidates(
     )
 
 
+# Dashboard stats are recomputed from an all-time COUNT(*) plus 24h aggregates
+# over packet_history. The landing page ("/") and /api/stats hit this on every
+# view, so a short TTL cache keeps the common case O(1) while the numbers stay
+# fresh to within a few seconds. Keyed by gateway_id (None => site-wide).
+DASHBOARD_STATS_CACHE_TTL_SECONDS = 30
+_dashboard_stats_cache: dict[str | None, tuple[float, dict[str, Any]]] = {}
+
+
 class DashboardRepository:
     """Repository for dashboard statistics."""
 
@@ -79,6 +225,13 @@ class DashboardRepository:
     def get_stats(gateway_id: str | None = None) -> dict[str, Any]:
         """Get overview statistics for the dashboard using optimized single query."""
         logger.info(f"Getting dashboard stats with gateway_id={gateway_id}")
+
+        now = time.time()
+        cached = _dashboard_stats_cache.get(gateway_id)
+        if cached is not None:
+            cached_at, cached_stats = cached
+            if now - cached_at <= DASHBOARD_STATS_CACHE_TTL_SECONDS:
+                return dict(cached_stats)
 
         try:
             conn = get_db_connection()
@@ -122,11 +275,18 @@ class DashboardRepository:
 
             stats_row = cursor.fetchone()
 
-            # Get total packet count (all time) separately
-            cursor.execute(
-                f"SELECT COUNT(*) as total FROM packet_history WHERE 1=1{gateway_filter}",
-                gateway_params,
-            )
+            # Get total packet count (all time) separately. Avoid a vestigial
+            # "WHERE 1=1" when there is no gateway filter: with a bare COUNT(*)
+            # and no WHERE clause SQLite uses its OP_Count optimization (walk the
+            # smallest index's page counts) instead of visiting every row, which
+            # is several times faster on a large packet_history.
+            if gateway_filter:
+                cursor.execute(
+                    f"SELECT COUNT(*) as total FROM packet_history WHERE 1=1{gateway_filter}",
+                    gateway_params,
+                )
+            else:
+                cursor.execute("SELECT COUNT(*) as total FROM packet_history")
             total_packets_all_time = cursor.fetchone()["total"]
 
             # Get packet types separately (more efficient than JSON aggregation in SQLite)
@@ -145,7 +305,7 @@ class DashboardRepository:
 
             conn.close()
 
-            return {
+            stats = {
                 "total_nodes": total_nodes,
                 "active_nodes_24h": stats_row["active_nodes_24h"] or 0,
                 "total_packets": total_packets_all_time or 0,
@@ -155,6 +315,9 @@ class DashboardRepository:
                 "packet_types": packet_types,
                 "success_rate": stats_row["success_rate"] or 0,
             }
+
+            _dashboard_stats_cache[gateway_id] = (now, dict(stats))
+            return stats
 
         except Exception as e:
             logger.error(f"Error getting dashboard stats: {e}")
@@ -3016,6 +3179,101 @@ class NodeRepository:
         except Exception as e:
             logger.error(f"Error getting unique packet channels: {e}")
             return []
+
+    @staticmethod
+    def get_node_telemetry_history(
+        node_id: int | str,
+        start_time: float | None = None,
+        end_time: float | None = None,
+        max_points: int = 1500,
+    ) -> dict[str, Any]:
+        """Return per-metric telemetry time series for a node.
+
+        Reads this node's ``TELEMETRY_APP`` packets in the ``[start_time,
+        end_time]`` window (open-ended when either is ``None``/``0``), decodes
+        each protobuf, and returns one point series per metric the node actually
+        reports. The query is bounded to the node and time window by the
+        ``(from_node_id, timestamp)`` index, so cost scales with the node's
+        telemetry in-window, not the whole table. Series longer than
+        ``max_points`` are decimated to keep the payload and chart render light;
+        the returned ``decimated`` flag lets the client re-request a narrower
+        window at full resolution (zoom-to-detail).
+        """
+        node_id_int = convert_node_id(node_id)
+
+        conn = get_db_connection()
+        try:
+            cursor = conn.cursor()
+            params: list[Any] = [node_id_int]
+            time_clause = ""
+            if start_time:
+                time_clause += " AND timestamp >= ?"
+                params.append(start_time)
+            if end_time:
+                time_clause += " AND timestamp <= ?"
+                params.append(end_time)
+
+            cursor.execute(
+                f"""
+                SELECT timestamp, raw_payload
+                FROM packet_history
+                WHERE from_node_id = ?
+                AND portnum = 67  -- TELEMETRY_APP
+                AND raw_payload IS NOT NULL
+                {time_clause}
+                ORDER BY timestamp ASC
+                """,
+                params,
+            )
+            rows = cursor.fetchall()
+        finally:
+            conn.close()
+
+        series: dict[str, dict[str, Any]] = {}
+        for row in rows:
+            raw = row["raw_payload"]
+            if not raw:
+                continue
+            try:
+                telemetry = telemetry_pb2.Telemetry()
+                telemetry.ParseFromString(raw)
+            except Exception:
+                continue
+
+            ts = row["timestamp"]
+            for sub_message, field, unit, group in _TELEMETRY_METRICS:
+                if not telemetry.HasField(sub_message):
+                    continue
+                metrics = getattr(telemetry, sub_message)
+                if not metrics.HasField(field):
+                    continue
+                entry = series.get(field)
+                if entry is None:
+                    entry = {"unit": unit, "group": group, "points": []}
+                    series[field] = entry
+                entry["points"].append([ts, round(float(getattr(metrics, field)), 3)])
+
+        # True latest telemetry time (before aggregation, whose last bucket
+        # centre lags the real last reading) — used for the offline note.
+        latest = rows[-1]["timestamp"] if rows else None
+
+        total = 0
+        was_decimated = False
+        for entry in series.values():
+            points = entry["points"]
+            total += len(points)
+            if len(points) > max_points:
+                was_decimated = True
+                avg_line, band = _aggregate(points, max_points)
+                entry["points"] = avg_line
+                entry["band"] = band
+
+        return {
+            "series": series,
+            "count": total,
+            "decimated": was_decimated,
+            "latest": latest,
+        }
 
 
 class TracerouteRepository:

--- a/src/malla/database/schema.py
+++ b/src/malla/database/schema.py
@@ -83,6 +83,15 @@ INDEX_SPECS: tuple[tuple[str, str, str], ...] = (
         "CREATE INDEX IF NOT EXISTS idx_packet_history_position_lookup_time ON packet_history(portnum, timestamp DESC, from_node_id) WHERE portnum = 3 AND raw_payload IS NOT NULL AND from_node_id IS NOT NULL",
     ),
     (
+        # Node telemetry-history charts: fetch one node's telemetry packets in a
+        # time window. Without this, the query falls back to the (from_node_id,
+        # timestamp) index and scans ALL of the node's packets to filter out the
+        # telemetry ones — slow for nodes where telemetry is a small share.
+        "idx_packet_history_telemetry_lookup",
+        "packet_history",
+        "CREATE INDEX IF NOT EXISTS idx_packet_history_telemetry_lookup ON packet_history(from_node_id, timestamp) WHERE portnum = 67 AND raw_payload IS NOT NULL AND from_node_id IS NOT NULL",
+    ),
+    (
         "idx_packet_mesh_id",
         "packet_history",
         "CREATE INDEX IF NOT EXISTS idx_packet_mesh_id ON packet_history(mesh_packet_id)",
@@ -127,6 +136,48 @@ def _get_existing_indexes(cursor: sqlite3.Cursor) -> set[str]:
         "SELECT name FROM sqlite_master WHERE type = 'index' AND name IS NOT NULL"
     )
     return {row[0] for row in cursor.fetchall()}
+
+
+def query_planner_stats_present(cursor: sqlite3.Cursor) -> bool:
+    """Return ``True`` if SQLite query-planner statistics (sqlite_stat1) exist."""
+
+    cursor.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'sqlite_stat1'"
+    )
+    if cursor.fetchone() is None:
+        return False
+    cursor.execute("SELECT 1 FROM sqlite_stat1 LIMIT 1")
+    return cursor.fetchone() is not None
+
+
+def ensure_query_planner_stats(cursor: sqlite3.Cursor) -> bool:
+    """Seed SQLite query-planner statistics if they are missing.
+
+    Without ``sqlite_stat1`` the planner guesses index selectivity and can pick
+    a badly-scaling plan (e.g. a full scan of ``packet_history`` for a query a
+    partial index would serve in milliseconds). A one-off ``ANALYZE`` fixes this;
+    ``PRAGMA analysis_limit`` keeps it bounded so it stays fast even on a
+    multi-gigabyte database. Returns ``True`` when ANALYZE was run.
+
+    Note: even a bounded ANALYZE reads ~``analysis_limit`` sample rows per index,
+    which can be ~100 seconds of random I/O on a cold multi-gigabyte database.
+    Prefer :func:`malla.database.connection.seed_query_planner_stats_async` on
+    the startup path so this never blocks request serving or packet ingestion.
+
+    Stats are only *seeded* here (when absent). Keeping them fresh as the
+    database grows is handled separately by periodic ``PRAGMA optimize`` in the
+    capture daemon.
+    """
+
+    if query_planner_stats_present(cursor):
+        return False  # stats already present – nothing to do
+
+    # analysis_limit bounds the work per index; without it ANALYZE would scan
+    # every index in full and could take many minutes on a huge packet_history.
+    cursor.execute("PRAGMA analysis_limit=1000")
+    logger.info("Query-planner statistics missing – running bounded ANALYZE")
+    cursor.execute("ANALYZE")
+    return True
 
 
 def ensure_startup_schema(

--- a/src/malla/routes/api_routes.py
+++ b/src/malla/routes/api_routes.py
@@ -832,6 +832,31 @@ def api_node_location_history(node_id):
         return jsonify({"error": str(e)}), 500
 
 
+@api_bp.route("/node/<node_id>/telemetry")
+def api_node_telemetry(node_id):
+    """API endpoint for a node's telemetry history charts.
+
+    Query param ``range`` is one of ``1d``/``7d``/``30d``/``all`` (default 7d).
+    """
+    logger.info(f"API node telemetry endpoint accessed for node {node_id}")
+    try:
+        start = request.args.get("start", type=float)
+        end = request.args.get("end", type=float)
+        if start is not None and end is not None and end > start:
+            data = NodeService.get_node_telemetry_history(node_id, start=start, end=end)
+        else:
+            range_key = request.args.get("range", "7d")
+            if range_key not in NodeService.TELEMETRY_RANGES:
+                range_key = "7d"
+            data = NodeService.get_node_telemetry_history(node_id, range_key=range_key)
+        return safe_jsonify(data)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        logger.error(f"Error in API node telemetry: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
 @api_bp.route("/node/<node_id>/direct-receptions")
 def api_node_direct_receptions(node_id):
     """API endpoint for bidirectional direct receptions (0-hop packets)."""

--- a/src/malla/services/node_service.py
+++ b/src/malla/services/node_service.py
@@ -3,6 +3,7 @@ Node service for business logic related to node operations
 """
 
 import logging
+import time
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -88,6 +89,44 @@ class NodeService:
         history = LocationService.get_node_location_history(node_id_int, limit=limit)
 
         return {"node_id": node_id_int, "location_history": history}
+
+    # Supported telemetry chart ranges -> window length in seconds (0 = all).
+    TELEMETRY_RANGES = {"1d": 86400, "7d": 604800, "30d": 2592000, "all": 0}
+
+    @staticmethod
+    def get_node_telemetry_history(
+        node_id,
+        range_key: str = "7d",
+        start: float | None = None,
+        end: float | None = None,
+    ) -> dict[str, Any]:
+        """
+        Get telemetry (device / environment) history for a node's charts.
+
+        Args:
+            node_id: Node ID in various formats
+            range_key: One of "1d", "7d", "30d", "all" (defaults to "7d")
+            start, end: Explicit unix-second window. When both are given they
+                take precedence over ``range_key`` — used by the charts to load
+                full-resolution data for a zoomed-in time range.
+
+        Returns:
+            Dictionary with node_id, the window, per-metric series and count
+        """
+        node_id_int = convert_node_id(node_id)
+
+        if start is not None and end is not None:
+            result = NodeRepository.get_node_telemetry_history(
+                node_id_int, start_time=start, end_time=end
+            )
+            return {"node_id": node_id_int, "start": start, "end": end, **result}
+
+        seconds = NodeService.TELEMETRY_RANGES.get(range_key, 604800)
+        start_time = (time.time() - seconds) if seconds else None
+        result = NodeRepository.get_node_telemetry_history(
+            node_id_int, start_time=start_time
+        )
+        return {"node_id": node_id_int, "range": range_key, **result}
 
     @staticmethod
     def get_node_neighbors(node_id, max_distance: float = 10.0) -> dict[str, Any]:

--- a/src/malla/static/js/node_telemetry.js
+++ b/src/malla/static/js/node_telemetry.js
@@ -1,0 +1,759 @@
+/*
+ * Node telemetry history charts.
+ *
+ * Renders one full-width Chart.js line chart per metric group (Environment /
+ * Power / Radio) the node reports. Features: range buttons, drag/double-click/
+ * button zoom (1-day minimum, synced across charts), per-metric summary stats
+ * over the visible window, a synced crosshair + tooltip across all charts,
+ * legend hover to highlight a metric and reveal its axis, a zero-baseline
+ * toggle, an offline note, dark-mode-aware colours, smooth (monotone) curves,
+ * and line breaks across gaps longer than 24 hours.
+ *
+ * Resolution follows the view: a wide window is served as a smooth average line
+ * with a faded min/max band; zooming in refetches that window and, once it is
+ * small enough, shows the raw points instead.
+ */
+(function () {
+  "use strict";
+
+  const METRIC_LABELS = {
+    temperature: "Temperature",
+    relative_humidity: "Humidity",
+    barometric_pressure: "Pressure",
+    gas_resistance: "Gas Resistance",
+    iaq: "IAQ",
+    lux: "Lux",
+    battery_level: "Battery",
+    voltage: "Voltage",
+    channel_utilization: "Channel Util",
+    air_util_tx: "Air Util TX",
+  };
+
+  // One chart per group; only related metrics share a chart.
+  const CHART_GROUPS = [
+    {
+      title: "Environment",
+      metrics: ["temperature", "relative_humidity", "barometric_pressure", "gas_resistance", "iaq", "lux"],
+    },
+    { title: "Power", metrics: ["battery_level", "voltage"] },
+    { title: "Radio", metrics: ["channel_utilization", "air_util_tx"] },
+  ];
+
+  const COLORS = ["#0e7490", "#f59e0b", "#6366f1", "#16a34a", "#dc3545", "#0891b2"];
+  const MIN_WINDOW = 86400; // smallest zoom window: one day
+  const GAP_LIMIT = 86400; // break the line across gaps longer than 24h
+  const OFFLINE_AFTER = 86400; // flag "offline" only after 24h without telemetry
+
+  function fmt(ts, format) {
+    if (typeof window.formatTimestamp === "function") return window.formatTimestamp(ts, format);
+    return new Date(ts * 1000).toLocaleString();
+  }
+  function isDark() {
+    return document.documentElement.getAttribute("data-bs-theme") === "dark";
+  }
+  function themeColors() {
+    const d = isDark();
+    return {
+      tick: d ? "#adb5bd" : "#6c757d",
+      grid: d ? "rgba(255,255,255,0.09)" : "rgba(0,0,0,0.06)",
+      text: d ? "#dee2e6" : "#495057",
+      crosshair: d ? "rgba(255,255,255,0.4)" : "rgba(0,0,0,0.3)",
+    };
+  }
+  function fade(color, alpha) {
+    if (alpha == null) alpha = 0.15;
+    if (typeof color === "string" && color[0] === "#" && color.length === 7) {
+      const r = parseInt(color.slice(1, 3), 16);
+      const g = parseInt(color.slice(3, 5), 16);
+      const b = parseInt(color.slice(5, 7), 16);
+      return `rgba(${r},${g},${b},${alpha})`;
+    }
+    return color;
+  }
+
+  // --- Perceptual band opacity ---------------------------------------------
+  // A translucent band's prominence is its perceptual contrast against the
+  // surface, which varies a lot by hue at a fixed alpha (a light amber barely
+  // marks white; a dark teal barely marks a dark surface — and the two swap
+  // when the theme flips). So instead of a fixed alpha we solve, per hue and
+  // per surface, the alpha that hits a constant OKLab ΔE — every band then
+  // reads with the same weight, in light and dark.
+  const BAND_CONTRAST = 0.1; // target OKLab ΔE between band and surface
+  function hexRgb(h) {
+    return [parseInt(h.slice(1, 3), 16), parseInt(h.slice(3, 5), 16), parseInt(h.slice(5, 7), 16)];
+  }
+  function srgbToLinear(c) {
+    c /= 255;
+    return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  }
+  function oklab(rgb) {
+    const r = srgbToLinear(rgb[0]), g = srgbToLinear(rgb[1]), b = srgbToLinear(rgb[2]);
+    const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
+    const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
+    const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
+    return [
+      0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
+      1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s,
+      0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s,
+    ];
+  }
+  // First opaque background walking up from the chart container = the surface
+  // the bands actually sit on (falls back to the theme's canonical surface).
+  function surfaceRgb() {
+    let el = document.getElementById("telemetry-charts");
+    while (el) {
+      const m = getComputedStyle(el).backgroundColor.match(
+        /rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/
+      );
+      if (m && (m[4] === undefined || parseFloat(m[4]) > 0.99)) return [+m[1], +m[2], +m[3]];
+      el = el.parentElement;
+    }
+    return isDark() ? [33, 37, 41] : [255, 255, 255];
+  }
+  function bandAlpha(hexColor) {
+    const c = hexRgb(hexColor);
+    const bg = surfaceRgb();
+    const labBg = oklab(bg);
+    const dE = (a) => {
+      const bl = [bg[0] + (c[0] - bg[0]) * a, bg[1] + (c[1] - bg[1]) * a, bg[2] + (c[2] - bg[2]) * a];
+      const l = oklab(bl);
+      return Math.hypot(l[0] - labBg[0], l[1] - labBg[1], l[2] - labBg[2]);
+    };
+    let lo = 0, hi = 1;
+    for (let i = 0; i < 24; i++) {
+      const mid = (lo + hi) / 2;
+      if (dE(mid) < BAND_CONTRAST) lo = mid;
+      else hi = mid;
+    }
+    // Clamp so a band never vanishes nor turns opaque enough to hide others.
+    return Math.max(0.1, Math.min(0.45, (lo + hi) / 2));
+  }
+  function round(v) {
+    if (!isFinite(v)) return "–";
+    const a = Math.abs(v);
+    return a >= 100 ? v.toFixed(0) : a >= 1 ? v.toFixed(1) : v.toFixed(2);
+  }
+
+  // Vertical crosshair drawn at chart._crosshairX (a timestamp) on every chart.
+  const crosshairPlugin = {
+    id: "telemetryCrosshair",
+    afterDatasetsDraw(chart) {
+      const x = chart._crosshairX;
+      if (x == null) return;
+      const xs = chart.scales.x;
+      if (!xs || x < xs.min || x > xs.max) return;
+      const px = xs.getPixelForValue(x);
+      const area = chart.chartArea;
+      const ctx = chart.ctx;
+      ctx.save();
+      ctx.beginPath();
+      ctx.moveTo(px, area.top);
+      ctx.lineTo(px, area.bottom);
+      ctx.lineWidth = 1;
+      ctx.setLineDash([4, 3]);
+      ctx.strokeStyle = themeColors().crosshair;
+      ctx.stroke();
+      ctx.restore();
+    },
+  };
+
+  class NodeTelemetryChart {
+    constructor(nodeId) {
+      this.nodeId = nodeId;
+      this.range = "7d";
+      this.charts = [];
+      this.syncing = false;
+      this.zeroBase = false;
+      // Zoom-out is clamped to the range extent (stable); the loaded window is
+      // what is currently fetched. When they diverge we refetch at the right
+      // resolution — raw when zoomed in, aggregated when zoomed out.
+      this.rangeMin = null;
+      this.rangeMax = null;
+      this.loadedMin = null;
+      this.loadedMax = null;
+      this.latestTs = -Infinity;
+      this._detailTimer = null;
+      this.card = document.getElementById("telemetry-card");
+      this.chartsEl = document.getElementById("telemetry-charts");
+      this.loadingEl = document.getElementById("telemetry-loading");
+      this.emptyEl = document.getElementById("telemetry-empty");
+      this.hintEl = document.getElementById("telemetry-hint");
+      this.offlineEl = document.getElementById("telemetry-offline");
+      this.rangeEl = document.getElementById("telemetry-range");
+      this.zoomEl = document.getElementById("telemetry-zoom");
+    }
+
+    initialize() {
+      if (!this.card) return;
+      if (this.rangeEl) {
+        this.rangeEl.addEventListener("click", (e) => {
+          const btn = e.target.closest("button[data-range]");
+          if (!btn) return;
+          this.range = btn.dataset.range;
+          this.rangeEl.querySelectorAll("button").forEach((b) => b.classList.toggle("active", b === btn));
+          this.load();
+        });
+      }
+      if (this.zoomEl) {
+        this.zoomEl.addEventListener("click", (e) => {
+          const btn = e.target.closest("button[data-zoom], button[data-zero]");
+          if (!btn) return;
+          if (btn.dataset.zero != null) {
+            this.toggleZero(btn);
+            return;
+          }
+          const a = btn.dataset.zoom;
+          if (a === "in") this.zoomBy(1.6);
+          else if (a === "out") this.zoomBy(1 / 1.6);
+          else this.resetZoom();
+        });
+      }
+      // Re-render with new colours if the light/dark theme changes.
+      new MutationObserver(() => this.load()).observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["data-bs-theme"],
+      });
+      this.load();
+    }
+
+    async load() {
+      this.destroyCharts();
+      this.showEmpty(false);
+      if (this.loadingEl) this.loadingEl.style.display = "flex";
+      // Recompute the range extent from this range's data.
+      this.rangeMin = null;
+      this.rangeMax = null;
+      try {
+        const res = await fetch(`/api/node/${this.nodeId}/telemetry?range=${this.range}`);
+        const data = await res.json();
+        if (this.loadingEl) this.loadingEl.style.display = "none";
+        this.render((data && data.series) || {});
+        this.rangeMin = this.fullMin;
+        this.rangeMax = this.fullMax;
+        this.loadedMin = this.fullMin;
+        this.loadedMax = this.fullMax;
+        // Prefer the true latest reading; on aggregated views the last plotted
+        // point is a bucket centre that lags the real last reading.
+        this.latestTs = data && data.latest != null ? data.latest : this.fullMax;
+        this.updateOffline(this.latestTs);
+      } catch (err) {
+        console.error("Failed to load telemetry", err);
+        if (this.loadingEl) this.loadingEl.style.display = "none";
+        this.showEmpty(true, "Failed to load telemetry.");
+      }
+    }
+
+    // Refetch just the visible window so the backend serves it at native
+    // resolution: raw points when the window is small, an aggregated average +
+    // min/max band when it is wide. Keeps the range extent (zoom bounds) intact.
+    async loadWindow(min, max) {
+      min = Math.floor(min);
+      max = Math.ceil(max);
+      try {
+        const res = await fetch(`/api/node/${this.nodeId}/telemetry?start=${min}&end=${max}`);
+        const data = await res.json();
+        const series = (data && data.series) || {};
+        if (!Object.keys(series).length) return; // keep the current view
+        this.destroyCharts();
+        this.render(series);
+        this.loadedMin = this.fullMin;
+        this.loadedMax = this.fullMax;
+      } catch (err) {
+        console.error("Failed to load telemetry window", err);
+      }
+    }
+
+    showEmpty(show, text) {
+      if (!this.emptyEl) return;
+      if (text) this.emptyEl.textContent = text;
+      this.emptyEl.style.display = show ? "flex" : "none";
+    }
+
+    render(series) {
+      this.fullMin = Infinity;
+      this.fullMax = -Infinity;
+      for (const group of CHART_GROUPS) {
+        const metrics = group.metrics.filter((m) => series[m] && series[m].points && series[m].points.length);
+        if (!metrics.length) continue;
+        metrics.forEach((m) => {
+          const pts = series[m].points;
+          this.fullMin = Math.min(this.fullMin, pts[0][0]);
+          this.fullMax = Math.max(this.fullMax, pts[pts.length - 1][0]);
+        });
+        this.charts.push(this.buildChart(group, metrics, series));
+      }
+      if (this.hintEl) this.hintEl.style.display = this.charts.length ? "" : "none";
+      if (!this.charts.length) this.showEmpty(true, "No telemetry reported by this node.");
+      this.updateStats();
+    }
+
+    updateOffline(latest) {
+      if (!this.offlineEl) return;
+      if (!isFinite(latest) || Date.now() / 1000 - latest <= OFFLINE_AFTER) {
+        this.offlineEl.style.display = "none";
+        return;
+      }
+      this.offlineEl.innerHTML =
+        '<i class="bi bi-exclamation-triangle"></i> No telemetry since ' + fmt(latest, "datetime");
+      this.offlineEl.style.display = "";
+    }
+
+    buildChart(group, metrics, series) {
+      const col = document.createElement("div");
+      col.className = "col-12";
+      const heading = document.createElement("h6");
+      heading.className = "text-muted mb-1";
+      heading.textContent = group.title;
+      const wrap = document.createElement("div");
+      wrap.style.height = "320px";
+      const canvas = document.createElement("canvas");
+      wrap.appendChild(canvas);
+      const statsEl = document.createElement("div");
+      statsEl.className = "tele-stats small mt-1 mb-2";
+      col.appendChild(heading);
+      col.appendChild(wrap);
+      col.appendChild(statsEl);
+      this.chartsEl.appendChild(col);
+
+      const tc = themeColors();
+      let minX = Infinity;
+      let maxX = -Infinity;
+      metrics.forEach((m) => {
+        const pts = series[m].points;
+        if (pts.length) {
+          minX = Math.min(minX, pts[0][0]);
+          maxX = Math.max(maxX, pts[pts.length - 1][0]);
+        }
+      });
+      // Zoom-out reaches the full range extent, not just the loaded window.
+      const limitMin = this.rangeMin != null ? this.rangeMin : minX;
+      const limitMax = this.rangeMax != null ? this.rangeMax : maxX;
+
+      const datasets = [];
+      const axisOrigDisplay = {};
+      const axisUnits = {};
+      const scales = {
+        x: {
+          type: "linear",
+          min: minX,
+          max: maxX,
+          ticks: {
+            maxRotation: 0,
+            autoSkip: false,
+            color: tc.tick,
+            callback: (value, index, ticks) => {
+              const span = ticks.length > 1 ? ticks[ticks.length - 1].value - ticks[0].value : 0;
+              return fmt(value, span <= 2 * 86400 ? "time" : "date");
+            },
+          },
+          grid: { color: tc.grid },
+          afterBuildTicks: (axis) => {
+            const n = 6;
+            const lo = axis.min;
+            const hi = axis.max;
+            if (!(hi > lo)) {
+              axis.ticks = [{ value: lo }];
+              return;
+            }
+            const step = (hi - lo) / (n - 1);
+            axis.ticks = Array.from({ length: n }, (_, i) => ({ value: lo + i * step }));
+          },
+        },
+      };
+
+      metrics.forEach((metric, idx) => {
+        const s = series[metric];
+        const color = COLORS[idx % COLORS.length];
+        const axisId = "y_" + metric;
+        const hasBand = !!(s.band && s.band.length);
+        // Faded min/max envelope for aggregated (wide-range) data. Two hidden
+        // datasets — lower (min) then upper (max) filled down to it. The backend
+        // marks real data gaps with null band entries, so spanGaps:false breaks
+        // the fill there instead of drawing across an outage.
+        if (hasBand) {
+          const bandCommon = {
+            _band: true,
+            yAxisID: axisId,
+            borderColor: "transparent",
+            pointRadius: 0,
+            spanGaps: false,
+            tension: 0.4,
+            cubicInterpolationMode: "monotone",
+          };
+          datasets.push({
+            ...bandCommon,
+            data: s.band.map((b) => ({ x: b[0], y: b[1] })),
+            fill: false,
+          });
+          datasets.push({
+            ...bandCommon,
+            data: s.band.map((b) => ({ x: b[0], y: b[2] })),
+            backgroundColor: fade(color, bandAlpha(color)),
+            fill: "-1",
+          });
+        }
+        datasets.push({
+          _metric: metric,
+          _band_data: s.band || null,
+          label: (METRIC_LABELS[metric] || metric) + (s.unit ? ` (${s.unit})` : ""),
+          data: s.points.map((p) => ({ x: p[0], y: p[1] })),
+          yAxisID: axisId,
+          borderColor: color,
+          backgroundColor: color + "22",
+          borderWidth: 2,
+          pointRadius: hasBand ? 0 : 2,
+          pointHoverRadius: 5,
+          cubicInterpolationMode: "monotone",
+          tension: 0.4,
+          spanGaps: false,
+          // Aggregated data breaks at the backend's null markers; raw points
+          // (buckets naturally many hours apart) break by wall-clock distance.
+          segment: hasBand
+            ? {}
+            : {
+                borderColor: (ctx) =>
+                  ctx.p1.parsed.x - ctx.p0.parsed.x > GAP_LIMIT ? "rgba(0,0,0,0)" : undefined,
+              },
+        });
+        const visible = idx < 2;
+        axisOrigDisplay[axisId] = visible;
+        axisUnits[axisId] = s.unit || "";
+        scales[axisId] = {
+          position: idx === 1 ? "right" : "left",
+          display: visible,
+          title: { display: visible, text: s.unit || METRIC_LABELS[metric] || metric, color: tc.text },
+          ticks: { color: tc.tick },
+          grid: { drawOnChartArea: idx === 0, color: tc.grid },
+        };
+        this.applyZeroScale(scales[axisId], s.unit || "");
+      });
+
+      const self = this;
+      const chart = new Chart(canvas, {
+        type: "line",
+        data: { datasets },
+        plugins: [crosshairPlugin],
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          interaction: { mode: "index", intersect: false },
+          onHover: (evt) => {
+            const t = chart.scales.x.getValueForPixel(evt.x);
+            if (isFinite(t)) self.syncHover(t);
+          },
+          plugins: {
+            legend: {
+              display: true,
+              position: "bottom",
+              labels: {
+                color: tc.text,
+                filter: (item, data) => !data.datasets[item.datasetIndex]._band,
+              },
+              onHover: (e, item, legend) => self.highlightMetric(legend.chart, item.datasetIndex),
+              onLeave: (e, item, legend) => self.unhighlight(legend.chart),
+              onClick: (e, item, legend) => self.toggleLegend(legend.chart, item.datasetIndex),
+            },
+            tooltip: {
+              filter: (item) => !item.dataset._band,
+              callbacks: {
+                title: (items) => (items.length ? fmt(items[0].parsed.x, "datetime") : ""),
+                label: (item) => {
+                  const ds = item.dataset;
+                  let out = ds.label + ": " + round(item.parsed.y);
+                  if (ds._band_data && ds._band_data[item.dataIndex]) {
+                    const b = ds._band_data[item.dataIndex];
+                    out += ` (${round(b[1])}–${round(b[2])})`;
+                  }
+                  return out;
+                },
+              },
+            },
+            zoom: {
+              limits: { x: { min: limitMin, max: limitMax, minRange: MIN_WINDOW } },
+              pan: { enabled: false },
+              zoom: {
+                mode: "x",
+                drag: {
+                  enabled: true,
+                  threshold: 10,
+                  backgroundColor: "rgba(14, 116, 144, 0.15)",
+                  borderColor: "rgba(14, 116, 144, 0.6)",
+                  borderWidth: 1,
+                },
+                onZoomComplete: ({ chart }) => {
+                  if (self.syncing) return;
+                  self.applyWindow(chart.scales.x.min, chart.scales.x.max);
+                },
+              },
+            },
+          },
+          scales,
+        },
+      });
+      chart.$statsEl = statsEl;
+      chart.$axisOrigDisplay = axisOrigDisplay;
+      chart.$axisUnits = axisUnits;
+      chart.$origMin = minX;
+      chart.$origMax = maxX;
+
+      canvas.addEventListener("dblclick", (e) => {
+        const rect = canvas.getBoundingClientRect();
+        const focus = chart.scales.x.getValueForPixel(e.clientX - rect.left);
+        this.zoomAround(focus, 0.5);
+      });
+      canvas.addEventListener("mouseleave", () => this.clearHover());
+      return chart;
+    }
+
+    applyWindow(min, max) {
+      if (max - min < MIN_WINDOW) {
+        const center = (min + max) / 2;
+        min = center - MIN_WINDOW / 2;
+        max = center + MIN_WINDOW / 2;
+      }
+      const lo = this.rangeMin != null ? this.rangeMin : this.fullMin;
+      const hi = this.rangeMax != null ? this.rangeMax : this.fullMax;
+      if (isFinite(lo)) min = Math.max(min, lo);
+      if (isFinite(hi)) max = Math.min(max, hi);
+      this.syncing = true;
+      this.charts.forEach((c) => c.zoomScale("x", { min, max }, "none"));
+      this.syncing = false;
+      this.updateStats();
+      this.scheduleDetail();
+    }
+
+    // After the view settles, refetch the visible window if it no longer matches
+    // the resolution we have loaded (debounced so rapid zoom steps fetch once).
+    scheduleDetail() {
+      if (this._detailTimer) clearTimeout(this._detailTimer);
+      this._detailTimer = setTimeout(() => {
+        this._detailTimer = null;
+        this.maybeFetchWindow();
+      }, 350);
+    }
+
+    maybeFetchWindow() {
+      if (!this.charts.length) return;
+      const xs = this.charts[0].scales.x;
+      const min = xs.min;
+      const max = xs.max;
+      const tol = (max - min) * 0.05;
+      if (
+        this.loadedMin != null &&
+        this.loadedMax != null &&
+        Math.abs(min - this.loadedMin) <= tol &&
+        Math.abs(max - this.loadedMax) <= tol
+      ) {
+        return; // already showing this window at native resolution
+      }
+      this.loadWindow(min, max);
+    }
+
+    zoomBy(factor) {
+      if (!this.charts.length) return;
+      const x = this.charts[0].scales.x;
+      const center = (x.min + x.max) / 2;
+      const half = (x.max - x.min) / 2 / factor;
+      this.applyWindow(center - half, center + half);
+    }
+
+    zoomAround(focus, factor) {
+      if (!this.charts.length || !isFinite(focus)) return;
+      const x = this.charts[0].scales.x;
+      const half = ((x.max - x.min) / 2) * factor;
+      this.applyWindow(focus - half, focus + half);
+    }
+
+    resetZoom() {
+      // Back to the full range at its native (aggregated) resolution.
+      this.load();
+    }
+
+    // Per-metric current value plus min / max / average over the visible window.
+    updateStats() {
+      this.charts.forEach((chart) => {
+        const el = chart.$statsEl;
+        if (!el) return;
+        const xs = chart.scales.x;
+        const parts = [];
+        chart.data.datasets.forEach((ds) => {
+          if (ds._band) return;
+          let mn = Infinity;
+          let mx = -Infinity;
+          let sum = 0;
+          let count = 0;
+          ds.data.forEach((p, i) => {
+            if (p.y == null || p.x < xs.min || p.x > xs.max) return;
+            sum += p.y;
+            count++;
+            // Use the true min/max envelope when the data is aggregated.
+            const b = ds._band_data && ds._band_data[i];
+            if (b && b[1] != null) {
+              if (b[1] < mn) mn = b[1];
+              if (b[2] > mx) mx = b[2];
+            } else {
+              if (p.y < mn) mn = p.y;
+              if (p.y > mx) mx = p.y;
+            }
+          });
+          if (!count) return;
+          let cur = null;
+          for (let i = ds.data.length - 1; i >= 0; i--) {
+            if (ds.data[i].y != null) {
+              cur = ds.data[i].y;
+              break;
+            }
+          }
+          const label = ds.label.replace(/\s*\([^)]*\)$/, "");
+          const unitMatch = ds.label.match(/\(([^)]*)\)$/);
+          const unit = unitMatch ? unitMatch[1] : "";
+          parts.push(
+            '<span class="tele-stat me-3"><span class="tele-dot" style="background:' +
+              ds.borderColor +
+              '"></span>' +
+              label +
+              " <b>" +
+              round(cur) +
+              (unit ? " " + unit : "") +
+              '</b> <span class="text-muted">' +
+              round(mn) +
+              "–" +
+              round(mx) +
+              " · μ" +
+              round(sum / count) +
+              "</span></span>"
+          );
+        });
+        el.innerHTML = parts.join("");
+      });
+    }
+
+    // Synced crosshair + tooltip across all charts at time t (throttled to rAF).
+    syncHover(t) {
+      this._pendingHover = t;
+      if (this._hoverRAF) return;
+      this._hoverRAF = requestAnimationFrame(() => {
+        this._hoverRAF = null;
+        this._applyHover(this._pendingHover);
+      });
+    }
+
+    _applyHover(t) {
+      this.charts.forEach((chart) => {
+        chart._crosshairX = t;
+        const line = chart.data.datasets.find((d) => !d._band);
+        if (!line || !line.data.length) {
+          chart.draw();
+          return;
+        }
+        let idx = 0;
+        let best = Infinity;
+        for (let i = 0; i < line.data.length; i++) {
+          const d = Math.abs(line.data[i].x - t);
+          if (d < best) {
+            best = d;
+            idx = i;
+          }
+        }
+        const active = [];
+        chart.data.datasets.forEach((ds, di) => {
+          if (!ds._band) active.push({ datasetIndex: di, index: idx });
+        });
+        chart.setActiveElements(active);
+        if (chart.tooltip) {
+          const px = chart.scales.x.getPixelForValue(t);
+          chart.tooltip.setActiveElements(active, { x: px, y: chart.chartArea.top });
+        }
+        chart.update("none");
+      });
+    }
+
+    clearHover() {
+      this.charts.forEach((chart) => {
+        chart._crosshairX = null;
+        chart.setActiveElements([]);
+        if (chart.tooltip) chart.tooltip.setActiveElements([], { x: 0, y: 0 });
+        chart.update("none");
+      });
+    }
+
+    // Legend hover: emphasise one metric (dim the rest) and reveal its axis.
+    highlightMetric(chart, datasetIndex) {
+      chart.data.datasets.forEach((ds, i) => {
+        if (ds._fullColor == null) ds._fullColor = ds.borderColor;
+        ds.borderColor = i === datasetIndex ? ds._fullColor : fade(ds._fullColor);
+      });
+      const axisId = chart.data.datasets[datasetIndex].yAxisID;
+      if (chart.options.scales[axisId]) chart.options.scales[axisId].display = true;
+      chart.update("none");
+    }
+
+    unhighlight(chart) {
+      chart.data.datasets.forEach((ds) => {
+        if (ds._fullColor != null) ds.borderColor = ds._fullColor;
+      });
+      const orig = chart.$axisOrigDisplay || {};
+      Object.keys(orig).forEach((axisId) => {
+        if (chart.options.scales[axisId]) chart.options.scales[axisId].display = orig[axisId];
+      });
+      chart.update("none");
+    }
+
+    // Legend click: hide/show the metric line together with its faded band
+    // (the band datasets are hidden from the legend but share the line's axis).
+    toggleLegend(chart, datasetIndex) {
+      const line = chart.data.datasets[datasetIndex];
+      if (!line) return;
+      const axisId = line.yAxisID;
+      const show = !chart.isDatasetVisible(datasetIndex);
+      chart.setDatasetVisibility(datasetIndex, show);
+      chart.data.datasets.forEach((ds, i) => {
+        if (ds._band && ds.yAxisID === axisId) chart.setDatasetVisibility(i, show);
+      });
+      chart.update();
+    }
+
+    // When the zero-baseline toggle is on, pin each axis to its natural full
+    // scale: percentages 0–100, cell voltage 0–4.6 V, anything else 0–auto.
+    // When off, clear the fixed bounds so the axis auto-fits the data again.
+    applyZeroScale(scale, unit) {
+      if (!this.zeroBase) {
+        scale.min = undefined;
+        scale.max = undefined;
+        scale.beginAtZero = false;
+        return;
+      }
+      scale.beginAtZero = true;
+      if (unit === "%") {
+        scale.min = 0;
+        scale.max = 100;
+      } else if (unit === "V") {
+        scale.min = 0;
+        scale.max = 4.6;
+      } else {
+        scale.min = 0;
+        scale.max = undefined;
+      }
+    }
+
+    toggleZero(btn) {
+      this.zeroBase = !this.zeroBase;
+      if (btn) btn.classList.toggle("active", this.zeroBase);
+      this.charts.forEach((chart) => {
+        const units = chart.$axisUnits || {};
+        Object.keys(chart.options.scales).forEach((id) => {
+          if (id !== "x") this.applyZeroScale(chart.options.scales[id], units[id]);
+        });
+        chart.update("none");
+      });
+    }
+
+    destroyCharts() {
+      this.charts.forEach((c) => c.destroy());
+      this.charts = [];
+      if (this.chartsEl) this.chartsEl.innerHTML = "";
+    }
+  }
+
+  window.NodeTelemetryChart = NodeTelemetryChart;
+})();

--- a/src/malla/templates/node_detail.html
+++ b/src/malla/templates/node_detail.html
@@ -228,6 +228,45 @@
                 </div>
             </div>
 
+            <!-- Telemetry History -->
+            <div class="card mb-4" id="telemetry-card" data-node-id="{{ node.node_id }}">
+                <div class="card-header d-flex justify-content-between align-items-center flex-wrap gap-2">
+                    <h5 class="mb-0"><i class="bi bi-thermometer-half"></i> Telemetry History</h5>
+                    <div class="d-flex flex-wrap gap-2">
+                        <div class="btn-group btn-group-sm" role="group" id="telemetry-range" aria-label="Telemetry time range">
+                            <button type="button" class="btn btn-outline-primary" data-range="1d">1D</button>
+                            <button type="button" class="btn btn-outline-primary active" data-range="7d">7D</button>
+                            <button type="button" class="btn btn-outline-primary" data-range="30d">30D</button>
+                            <button type="button" class="btn btn-outline-primary" data-range="all">All</button>
+                        </div>
+                        <div class="btn-group btn-group-sm" role="group" id="telemetry-zoom" aria-label="Telemetry zoom">
+                            <button type="button" class="btn btn-outline-secondary" data-zoom="in" title="Zoom in"><i class="bi bi-zoom-in"></i></button>
+                            <button type="button" class="btn btn-outline-secondary" data-zoom="out" title="Zoom out"><i class="bi bi-zoom-out"></i></button>
+                            <button type="button" class="btn btn-outline-secondary" data-zoom="reset" title="Reset zoom"><i class="bi bi-arrow-counterclockwise"></i></button>
+                            <button type="button" class="btn btn-outline-secondary" data-zero title="Start axes at zero"><b>0</b></button>
+                        </div>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <div id="telemetry-loading" class="text-center text-muted" style="display: none; min-height: 240px; align-items: center; justify-content: center; gap: .5rem;">
+                        <div class="spinner-border spinner-border-sm" role="status"></div> Loading telemetry…
+                    </div>
+                    <div id="telemetry-empty" class="text-center text-muted" style="display: none; min-height: 240px; align-items: center; justify-content: center;">
+                        No telemetry reported by this node.
+                    </div>
+                    <div id="telemetry-offline" class="alert alert-warning py-1 px-2 small mb-2" style="display: none;"></div>
+                    <div id="telemetry-hint" class="text-muted small mb-2" style="display: none;">
+                        <i class="bi bi-search"></i> Drag to select a time range, double-click to zoom in, or use the buttons. Hover a legend item to focus a metric.
+                    </div>
+                    <div id="telemetry-charts" class="row g-4"></div>
+                </div>
+            </div>
+            <style>
+                .tele-stats { line-height: 1.9; }
+                .tele-stat { white-space: nowrap; }
+                .tele-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 4px; vertical-align: middle; }
+            </style>
+
             <!-- Location Information -->
             {% if location %}
             <div class="card mb-4">
@@ -727,6 +766,12 @@
 <!-- Relay Node Analysis Component -->
 <script src="{{ url_for('static', filename='js/relay_node_analysis.js') }}"></script>
 
+<!-- Chart.js zoom plugin (drag / double-click / button zoom on telemetry charts) -->
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.2.0/dist/chartjs-plugin-zoom.min.js"></script>
+
+<!-- Telemetry History Charts -->
+<script src="{{ url_for('static', filename='js/node_telemetry.js') }}?v={{ ASSET_VERSION }}"></script>
+
 <!-- Location data for JavaScript -->
 {% if location %}
 <script id="location-data" type="application/json">
@@ -1009,6 +1054,10 @@ document.addEventListener('DOMContentLoaded', function() {
     if (nodeId && window.DirectReceptionsChart) {
         directReceptionsChart = new DirectReceptionsChart(nodeId);
         directReceptionsChart.initialize();
+    }
+
+    if (nodeId && window.NodeTelemetryChart) {
+        new NodeTelemetryChart(nodeId).initialize();
     }
 
     // Format all timestamps based on current timezone preference

--- a/src/malla/web_ui.py
+++ b/src/malla/web_ui.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import sys
+import time
 from pathlib import Path
 
 from flask import Flask
@@ -38,6 +39,9 @@ logging.basicConfig(
 )
 
 logger = logging.getLogger(__name__)
+
+# Static-asset cache-busting token; changes each process start (i.e. each deploy).
+_ASSET_VERSION = str(int(time.time()))
 
 
 class TrustedProxyClientIPMiddleware:
@@ -256,6 +260,10 @@ def create_app(cfg: AppConfig | None = None):  # noqa: D401
             "APP_NAME": cfg.name,
             "APP_CONFIG": cfg,
             "DATABASE_FILE": cfg.database_file,
+            # Cache-busting token for static assets: changes each time the app
+            # starts (i.e. on every deploy/restart), so browsers reliably pick
+            # up updated JS/CSS instead of serving a stale cached copy.
+            "ASSET_VERSION": _ASSET_VERSION,
         }
 
     # Initialize database

--- a/tests/integration/test_node_telemetry.py
+++ b/tests/integration/test_node_telemetry.py
@@ -1,0 +1,177 @@
+"""Tests for the node telemetry history feature (repository, service, API)."""
+
+import os
+import sqlite3
+import tempfile
+import time
+
+import pytest
+from meshtastic import telemetry_pb2
+
+from malla.config import AppConfig, _clear_config_cache
+from malla.database.repositories import NodeRepository
+from malla.services.node_service import NodeService
+from malla.web_ui import create_app
+from tests.fixtures.database_fixtures import DatabaseFixtures
+
+NODE_ID = 0x11223344
+
+
+def _env_payload(temperature=None, humidity=None, pressure=None):
+    t = telemetry_pb2.Telemetry()
+    if temperature is not None:
+        t.environment_metrics.temperature = temperature
+    if humidity is not None:
+        t.environment_metrics.relative_humidity = humidity
+    if pressure is not None:
+        t.environment_metrics.barometric_pressure = pressure
+    return t.SerializeToString()
+
+
+def _device_payload(battery=None, voltage=None):
+    t = telemetry_pb2.Telemetry()
+    if battery is not None:
+        t.device_metrics.battery_level = battery
+    if voltage is not None:
+        t.device_metrics.voltage = voltage
+    return t.SerializeToString()
+
+
+def _insert_telemetry(db_path, node_id, offset_seconds, raw):
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        INSERT INTO packet_history
+            (timestamp, topic, from_node_id, portnum, portnum_name,
+             payload_length, raw_payload, processed_successfully)
+        VALUES (?, ?, ?, 67, 'TELEMETRY_APP', ?, ?, 1)
+        """,
+        (time.time() - offset_seconds, "msh/test", node_id, len(raw), raw),
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture()
+def telemetry_client():
+    """Flask test client backed by a fixture DB seeded with telemetry packets."""
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".db")
+    tmp.close()
+    DatabaseFixtures().create_test_database(tmp.name)
+
+    # Recent environment + device telemetry (within 1 day)
+    for i in range(4):
+        _insert_telemetry(tmp.name, NODE_ID, i * 3600, _env_payload(20 + i, 55 + i))
+        _insert_telemetry(tmp.name, NODE_ID, i * 3600, _device_payload(90 - i, 4.1))
+    # An old environment sample (~10 days ago) — excluded by 1d/7d ranges
+    _insert_telemetry(tmp.name, NODE_ID, 10 * 86400, _env_payload(temperature=5))
+
+    _clear_config_cache()
+    app = create_app(AppConfig(database_file=tmp.name))
+    app.config["TESTING"] = True
+    try:
+        yield app.test_client()
+    finally:
+        _clear_config_cache()
+        try:
+            os.unlink(tmp.name)
+        except FileNotFoundError:
+            pass
+
+
+def test_repository_extracts_metrics(telemetry_client):
+    db = os.environ["MALLA_DATABASE_FILE"]
+    result = NodeRepository.get_node_telemetry_history(NODE_ID)
+    series = result["series"]
+
+    assert set(series) >= {"temperature", "relative_humidity", "battery_level", "voltage"}
+    assert series["temperature"]["unit"] == "°C"
+    assert series["temperature"]["group"] == "environment"
+    assert series["voltage"]["unit"] == "V"
+    assert series["voltage"]["group"] == "power"
+    # points are [timestamp, value] and ascending in time
+    pts = series["temperature"]["points"]
+    assert all(len(p) == 2 for p in pts)
+    assert pts == sorted(pts, key=lambda p: p[0])
+    assert db  # sanity: env override wired by create_app
+
+
+def test_service_range_filters_old_samples(telemetry_client):
+    # The -5°C sample is ~10 days old: present in "all"/30d, absent from 1d/7d.
+    all_temps = NodeService.get_node_telemetry_history(NODE_ID, "all")["series"][
+        "temperature"
+    ]["points"]
+    week_temps = NodeService.get_node_telemetry_history(NODE_ID, "7d")["series"][
+        "temperature"
+    ]["points"]
+
+    assert any(p[1] == 5.0 for p in all_temps)
+    assert not any(p[1] == 5.0 for p in week_temps)
+    assert len(week_temps) < len(all_temps)
+
+
+def test_repository_aggregates_with_band(telemetry_client):
+    full = NodeRepository.get_node_telemetry_history(NODE_ID)["series"]["temperature"][
+        "points"
+    ]
+    temp = NodeRepository.get_node_telemetry_history(NODE_ID, max_points=3)["series"][
+        "temperature"
+    ]
+    pts = temp["points"]
+    band = temp["band"]
+    assert "band" in temp and len(band) == len(pts)
+    # Aggregated into an averaged line of ~max_points real buckets (break markers
+    # excluded), each with a mean ± σ band entry.
+    real = [p for p in pts if p[1] is not None]
+    assert 0 < len(real) <= 3
+    # The ~10-day-old sample is isolated by a gap, so the series is split into two
+    # runs joined by a break marker (a None entry) — no line drawn across the gap.
+    assert any(p[1] is None for p in pts)
+    # The band is mean ± k·σ (clamped to observed values), so the line always
+    # stays inside it and never claims a value outside the raw data's range.
+    raw_lo = min(p[1] for p in full)
+    raw_hi = max(p[1] for p in full)
+    for p, b in zip(pts, band):
+        if p[1] is not None:
+            assert b[1] <= p[1] <= b[2]
+            assert raw_lo <= b[1] and b[2] <= raw_hi
+
+
+def test_api_endpoint_returns_series(telemetry_client):
+    resp = telemetry_client.get(f"/api/node/{NODE_ID}/telemetry?range=7d")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["range"] == "7d"
+    assert data["count"] > 0
+    assert "temperature" in data["series"]
+    assert data["series"]["battery_level"]["group"] == "power"
+
+
+def test_api_defaults_and_validates_range(telemetry_client):
+    # Unknown range falls back to the 7d default rather than erroring.
+    resp = telemetry_client.get(f"/api/node/{NODE_ID}/telemetry?range=bogus")
+    assert resp.status_code == 200
+    assert resp.get_json()["range"] == "7d"
+
+
+def test_api_start_end_window(telemetry_client):
+    # An explicit start/end window (last day) overrides range and excludes the
+    # ~10-day-old sample — this backs the charts' zoom-to-detail refetch.
+    now = time.time()
+    resp = telemetry_client.get(
+        f"/api/node/{NODE_ID}/telemetry?start={now - 86400}&end={now}"
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["start"] and data["end"]
+    assert "decimated" in data
+    temps = data["series"].get("temperature", {}).get("points", [])
+    assert temps and not any(p[1] == 5.0 for p in temps)
+
+
+def test_api_empty_for_node_without_telemetry(telemetry_client):
+    resp = telemetry_client.get("/api/node/0x99999999/telemetry?range=all")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["series"] == {}
+    assert data["count"] == 0

--- a/tests/integration/test_node_telemetry.py
+++ b/tests/integration/test_node_telemetry.py
@@ -131,7 +131,7 @@ def test_repository_aggregates_with_band(telemetry_client):
     # stays inside it and never claims a value outside the raw data's range.
     raw_lo = min(p[1] for p in full)
     raw_hi = max(p[1] for p in full)
-    for p, b in zip(pts, band):
+    for p, b in zip(pts, band, strict=True):
         if p[1] is not None:
             assert b[1] <= p[1] <= b[2]
             assert raw_lo <= b[1] and b[2] <= raw_hi


### PR DESCRIPTION
## Summary

Adds an interactive **Telemetry History** card to `/node/<id>` that plots the
device- and environment-metrics a node reports — temperature, humidity,
pressure, battery, voltage, channel/air utilisation, and so on — over time. It
reads the telemetry packets already stored in `packet_history`, so there is no
new capture path and no schema change.

## What it adds

- **Grouped charts** — one full-width chart per metric family (Environment /
  Power / Radio); only the groups a node actually reports are shown.
- **Ranges & zoom** — 1D / 7D / 30D / All buttons, plus drag-select,
  double-click, and zoom in/out/reset, synced across every chart. The minimum
  zoom window is one day.
- **Resolution follows the view** — a wide window is served as a smoothed
  average line with a faded spread band; zoom in and the visible window is
  refetched, dropping to the raw points once it is small enough.
- **Gap-aware** — a real outage (no readings for more than 24 h) splits the
  series into runs, so the line and band break there instead of being drawn
  across the void.
- **Read at a glance** — per-metric current value with min / max / average over
  the visible window, a synced crosshair + tooltip across all charts,
  legend-hover to focus a single metric, an optional full-scale baseline
  (0–100 % / 0–4.6 V), and an offline note after 24 h of silence.
- Dark-mode aware, smoothed (monotone) curves.

## How it works

- **Backend** (`repositories.py`) — `get_node_telemetry_history()` decodes the
  telemetry protobufs for a node within a time window (bounded by the
  `(from_node_id, timestamp)` index, so cost scales with the node's telemetry
  in-window, not the whole table) and returns one point series per metric.
  Series above a cap are aggregated into ~150 buckets: a moving-average trend
  line plus a `mean ± 1.5σ` band clamped to the observed values, so the line
  sits centred in its band and wide views stay light and readable.
- **API** (`api_routes.py`) — `GET /api/node/<id>/telemetry?range=…`, or
  `?start=…&end=…` for the zoom-to-detail refetch.
- **Service** (`node_service.py`) — maps a range key to a window.
- **Frontend** (`node_telemetry.js` + `node_detail.html`) — Chart.js line
  charts with `chartjs-plugin-zoom`, rendered entirely client-side. Static
  assets are cache-busted with an `ASSET_VERSION` token so browsers pick up
  updated JS/CSS after a deploy.

## Screenshots

Both captured from the live deployment — https://meshmap.pro/node/2012698032

**All — smoothed average with a faded ± σ spread band, breaks across data gaps,
and a synced crosshair/tooltip across both charts:**

<img width="1546" height="1669" alt="ALL" src="https://github.com/user-attachments/assets/43cbaf63-21f3-471f-9a21-af3ce41b3f87" />

**7 days — full resolution: the raw points, showing the daily
charge/discharge cycle:**

<img width="1551" height="1684" alt="7D" src="https://github.com/user-attachments/assets/e6a9b6f3-bfe9-4cd6-8d68-86d99c8e7cb3" />

## Testing

`tests/integration/test_node_telemetry.py` — 7 tests covering metric
extraction, range filtering, aggregation + band containment, the start/end
window (zoom-to-detail), and the API contract.
