### PR TITLE
Fix: dashboard charts showed misleading data. real 7d+ trends, rolling coverage, real hop distribution.

### DIFF
--- a/src/malla/database/repositories.py
+++ b/src/malla/database/repositories.py
@@ -242,6 +242,7 @@ class DashboardRepository:
             # Calculate time thresholds
             twenty_four_hours_ago = time.time() - (24 * 3600)
             one_hour_ago = time.time() - 3600
+            seven_days_ago = time.time() - (7 * 24 * 3600)
 
             # Build WHERE clause for gateway filtering
             gateway_filter = ""
@@ -277,6 +278,22 @@ class DashboardRepository:
 
             stats_row = cursor.fetchone()
 
+            # Nodes heard from at least once in the trailing 7 days. This is the
+            # denominator for the "network coverage" ratio shown on the dashboard:
+            # node_info only ever grows (it remembers every node ever seen), so
+            # active/total would decay toward zero as the roster ages. Sourcing
+            # both sides of the ratio from packet_history keeps them consistent;
+            # the (timestamp, from_node_id) covering index makes this cheap.
+            cursor.execute(
+                f"""
+                SELECT COUNT(DISTINCT from_node_id) as nodes_seen_7d
+                FROM packet_history
+                WHERE timestamp > ? AND from_node_id IS NOT NULL{gateway_filter}
+            """,
+                [seven_days_ago] + gateway_params,
+            )
+            nodes_seen_7d = cursor.fetchone()["nodes_seen_7d"] or 0
+
             # Get total packet count (all time) separately. Avoid a vestigial
             # "WHERE 1=1" when there is no gateway filter: with a bare COUNT(*)
             # and no WHERE clause SQLite uses its OP_Count optimization (walk the
@@ -310,6 +327,7 @@ class DashboardRepository:
             stats = {
                 "total_nodes": total_nodes,
                 "active_nodes_24h": stats_row["active_nodes_24h"] or 0,
+                "nodes_seen_7d": nodes_seen_7d,
                 "total_packets": total_packets_all_time or 0,
                 "recent_packets": stats_row["recent_packets"] or 0,
                 "avg_rssi": round(stats_row["avg_rssi"] or 0, 1),

--- a/src/malla/database/schema.py
+++ b/src/malla/database/schema.py
@@ -123,6 +123,24 @@ LEGACY_INDEX_NAMES: tuple[str, ...] = (
     "idx_packet_from_node",
 )
 
+# Per-local-day activity aggregates for the dashboard timeline. Completed days
+# never change (packet_history is append-only and rows are stamped with insert
+# time), so each (tz_offset, day) is computed once and reused forever; only the
+# current day is recomputed live. Without this, the "All" range re-aggregates
+# the entire multi-million-row packet_history on every view.
+ACTIVITY_ROLLUP_TABLE_SQL = """
+    CREATE TABLE IF NOT EXISTS activity_daily_rollup (
+        tz_offset_minutes INTEGER NOT NULL,
+        day TEXT NOT NULL,
+        total_packets INTEGER NOT NULL DEFAULT 0,
+        active_nodes INTEGER NOT NULL DEFAULT 0,
+        gateway_count INTEGER NOT NULL DEFAULT 0,
+        new_nodes INTEGER NOT NULL DEFAULT 0,
+        computed_at REAL NOT NULL,
+        PRIMARY KEY (tz_offset_minutes, day)
+    )
+"""
+
 
 def _get_existing_tables(cursor: sqlite3.Cursor) -> set[str]:
     cursor.execute(
@@ -187,6 +205,8 @@ def ensure_startup_schema(
 
     existing_tables = _get_existing_tables(cursor)
     existing_indexes = _get_existing_indexes(cursor)
+
+    cursor.execute(ACTIVITY_ROLLUP_TABLE_SQL)
 
     if "node_info" in existing_tables:
         cursor.execute("PRAGMA table_info(node_info)")

--- a/src/malla/routes/api_routes.py
+++ b/src/malla/routes/api_routes.py
@@ -165,6 +165,26 @@ def api_analytics():
         return jsonify({"error": str(e)}), 500
 
 
+@api_bp.route("/activity-timeline")
+def api_activity_timeline():
+    """API endpoint for the dashboard activity timeline (24h / 7d / 30d / all)."""
+    try:
+        range_key = request.args.get("range", "7d")
+        # Viewer's UTC offset in minutes (east positive), used to align buckets
+        # with local calendar days/hours. Clamped to the real-world UTC-12..
+        # UTC+14 range so it can't explode the rollup table or cache.
+        tz_offset = request.args.get("tz_offset", default=0, type=int)
+        tz_offset = max(-720, min(840, tz_offset))
+
+        timeline = AnalyticsService.get_activity_timeline(
+            range_key=range_key, tz_offset_minutes=tz_offset
+        )
+        return safe_jsonify(timeline)
+    except Exception as e:
+        logger.error(f"Error in API activity timeline: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
 @api_bp.route("/packets")
 def api_packets():
     """API endpoint for packet data."""

--- a/src/malla/services/analytics_service.py
+++ b/src/malla/services/analytics_service.py
@@ -5,6 +5,7 @@ Analytics service for Meshtastic Mesh Health Web UI
 import logging
 import time
 from collections import defaultdict
+from datetime import UTC, datetime
 from typing import Any
 
 from ..database.repositories import NodeRepository
@@ -66,7 +67,7 @@ class AnalyticsService:
                 filters, twenty_four_hours_ago
             )
             node_stats = AnalyticsService._get_node_activity_statistics(
-                filters, twenty_four_hours_ago
+                filters, twenty_four_hours_ago, seven_days_ago
             )
             signal_stats = AnalyticsService._get_signal_quality_statistics(
                 filters, twenty_four_hours_ago
@@ -81,6 +82,9 @@ class AnalyticsService:
             gateway_stats = AnalyticsService._get_gateway_distribution(
                 filters, twenty_four_hours_ago
             )
+            hop_distribution = AnalyticsService._get_hop_distribution(
+                filters, twenty_four_hours_ago
+            )
 
             result = {
                 "packet_statistics": packet_stats,
@@ -90,6 +94,7 @@ class AnalyticsService:
                 "top_nodes": top_nodes,
                 "packet_types": packet_types,
                 "gateway_distribution": gateway_stats,
+                "hop_distribution": hop_distribution,
             }
 
             # Save to cache
@@ -156,7 +161,7 @@ class AnalyticsService:
 
     @staticmethod
     def _get_node_activity_statistics(
-        filters: dict, since_timestamp: float
+        filters: dict, since_timestamp: float, seven_days_ago: float
     ) -> dict[str, Any]:
         """Get node activity statistics using optimized SQL query."""
         from ..database.connection import get_db_connection
@@ -200,10 +205,30 @@ class AnalyticsService:
         )
 
         activity_row = cursor.fetchone()
+
+        # Nodes heard from in the trailing 7 days — the reference roster for
+        # activity ratios. node_info only ever grows (every node ever seen),
+        # so ratios against it decay toward zero as the roster ages; a rolling
+        # window measures against nodes that are actually still around.
+        seen_params: list[Any] = [seven_days_ago]
+        seen_filter = ""
+        if filters.get("gateway_id"):
+            seen_filter = " AND gateway_id = ?"
+            seen_params.append(filters["gateway_id"])
+        cursor.execute(
+            f"""
+            SELECT COUNT(DISTINCT from_node_id) as nodes_seen_7d
+            FROM packet_history
+            WHERE timestamp >= ? AND from_node_id IS NOT NULL{seen_filter}
+        """,
+            seen_params,
+        )
+        nodes_seen_7d = cursor.fetchone()["nodes_seen_7d"] or 0
         conn.close()
 
         active_nodes = activity_row["active_nodes"] or 0
-        inactive_nodes = total_nodes - active_nodes
+        # "Inactive" = seen this week but silent in the current window.
+        inactive_nodes = max(nodes_seen_7d - active_nodes, 0)
 
         activity_ranges = {
             "very_active": activity_row["very_active"] or 0,
@@ -214,10 +239,11 @@ class AnalyticsService:
 
         return {
             "total_nodes": total_nodes,
+            "nodes_seen_7d": nodes_seen_7d,
             "active_nodes": active_nodes,
             "inactive_nodes": inactive_nodes,
-            "activity_rate": round((active_nodes / total_nodes * 100), 2)
-            if total_nodes > 0
+            "activity_rate": round((active_nodes / nodes_seen_7d * 100), 2)
+            if nodes_seen_7d > 0
             else 0,
             "activity_distribution": activity_ranges,
         }
@@ -384,6 +410,381 @@ class AnalyticsService:
             "peak_hour": peak_hour,
             "quiet_hour": quiet_hour,
         }
+
+    # ------------------------------------------------------------------
+    # Activity timeline (dashboard trends panels with a range selector)
+    # ------------------------------------------------------------------
+
+    TIMELINE_RANGES: frozenset[str] = frozenset({"24h", "7d", "30d", "all"})
+
+    # (range_key, tz_offset_minutes) → (timestamp, data)
+    _TIMELINE_CACHE: dict[tuple[str, int], tuple[float, dict[str, Any]]] = {}
+
+    @staticmethod
+    def get_activity_timeline(
+        range_key: str = "7d", tz_offset_minutes: int = 0
+    ) -> dict[str, Any]:
+        """Get the activity timeline for one of the ranges 24h / 7d / 30d / all.
+
+        Buckets are hourly for 24h and per local calendar day otherwise
+        (tz_offset_minutes = viewer's minutes east of UTC). Each bucket carries
+        packet volume, distinct sending nodes, distinct reporting gateways and
+        newly discovered nodes. Completed days are served from the
+        activity_daily_rollup table (append-only history makes them immutable),
+        so even the "all" range stays fast; only the current day/hour window is
+        aggregated live.
+        """
+        if range_key not in AnalyticsService.TIMELINE_RANGES:
+            range_key = "7d"
+
+        cache_key = (range_key, tz_offset_minutes)
+        now_ts = time.time()
+        cached = AnalyticsService._TIMELINE_CACHE.get(cache_key)
+        if cached and (now_ts - cached[0] < AnalyticsService._CACHE_TTL_SEC):
+            return cached[1]
+
+        if range_key == "24h":
+            buckets = AnalyticsService._get_hourly_buckets(tz_offset_minutes)
+            granularity = "hour"
+        else:
+            buckets = AnalyticsService._get_daily_buckets(range_key, tz_offset_minutes)
+            granularity = "day"
+
+        result = {"range": range_key, "granularity": granularity, "buckets": buckets}
+        AnalyticsService._TIMELINE_CACHE[cache_key] = (now_ts, result)
+        return result
+
+    @staticmethod
+    def _get_hourly_buckets(tz_offset_minutes: int) -> list[dict[str, Any]]:
+        """Aggregate the trailing 24 local-clock hours (last bucket = this hour so far)."""
+        from ..database.connection import get_db_connection
+
+        offset_sec = tz_offset_minutes * 60
+        current_hour_local = (int(time.time() + offset_sec) // 3600) * 3600
+        start_local = current_hour_local - 23 * 3600
+        start_utc = start_local - offset_sec
+
+        buckets: dict[str, dict[str, Any]] = {}
+        for i in range(24):
+            key = datetime.fromtimestamp(start_local + i * 3600, tz=UTC).strftime(
+                "%Y-%m-%d %H:00"
+            )
+            buckets[key] = {
+                "bucket": key,
+                "total_packets": 0,
+                "active_nodes": 0,
+                "gateway_count": 0,
+                "new_nodes": 0,
+            }
+
+        conn = get_db_connection()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT
+                    strftime('%Y-%m-%d %H:00', timestamp + ?, 'unixepoch') AS bucket,
+                    COUNT(*) AS total_packets,
+                    COUNT(DISTINCT from_node_id) AS active_nodes
+                FROM packet_history
+                WHERE timestamp >= ?
+                GROUP BY bucket
+            """,
+                (offset_sec, start_utc),
+            )
+            for row in cursor.fetchall():
+                entry = buckets.get(row["bucket"])
+                if entry:
+                    entry["total_packets"] = row["total_packets"]
+                    entry["active_nodes"] = row["active_nodes"]
+
+            cursor.execute(
+                """
+                SELECT
+                    strftime('%Y-%m-%d %H:00', timestamp + ?, 'unixepoch') AS bucket,
+                    COUNT(DISTINCT gateway_id) AS gateway_count
+                FROM packet_history
+                WHERE gateway_id IS NOT NULL AND timestamp >= ?
+                GROUP BY bucket
+            """,
+                (offset_sec, start_utc),
+            )
+            for row in cursor.fetchall():
+                entry = buckets.get(row["bucket"])
+                if entry:
+                    entry["gateway_count"] = row["gateway_count"]
+
+            cursor.execute(
+                """
+                SELECT
+                    strftime('%Y-%m-%d %H:00', first_seen + ?, 'unixepoch') AS bucket,
+                    COUNT(*) AS new_nodes
+                FROM node_info
+                WHERE first_seen >= ?
+                GROUP BY bucket
+            """,
+                (offset_sec, start_utc),
+            )
+            for row in cursor.fetchall():
+                entry = buckets.get(row["bucket"])
+                if entry:
+                    entry["new_nodes"] = row["new_nodes"]
+        finally:
+            conn.close()
+
+        return list(buckets.values())
+
+    @staticmethod
+    def _get_daily_buckets(
+        range_key: str, tz_offset_minutes: int
+    ) -> list[dict[str, Any]]:
+        """Aggregate per local calendar day for 7d / 30d / all.
+
+        Completed days come from (and are persisted to) activity_daily_rollup;
+        only today is computed live from packet_history.
+        """
+        from ..database.connection import get_db_connection
+        from ..database.schema import ACTIVITY_ROLLUP_TABLE_SQL
+
+        offset_sec = tz_offset_minutes * 60
+        today_local = (int(time.time() + offset_sec) // 86400) * 86400
+
+        conn = get_db_connection()
+        try:
+            cursor = conn.cursor()
+            # Defensive create: the web app normally creates this at startup,
+            # but the service must also work against bare test databases.
+            cursor.execute(ACTIVITY_ROLLUP_TABLE_SQL)
+
+            if range_key == "7d":
+                start_local = today_local - 7 * 86400
+            elif range_key == "30d":
+                start_local = today_local - 30 * 86400
+            else:  # all: from the local day of the first recorded packet
+                cursor.execute("SELECT MIN(timestamp) AS mn FROM packet_history")
+                row = cursor.fetchone()
+                mn = row["mn"] if row else None
+                start_local = (
+                    (int(mn + offset_sec) // 86400) * 86400
+                    if mn is not None
+                    else today_local
+                )
+                start_local = min(start_local, today_local)
+
+            day_epochs = list(range(start_local, today_local + 86400, 86400))
+            completed_epochs = [d for d in day_epochs if d < today_local]
+
+            rollup_rows = AnalyticsService._ensure_daily_rollup(
+                cursor, tz_offset_minutes, offset_sec, completed_epochs
+            )
+            conn.commit()
+
+            today_stats = AnalyticsService._compute_daily_span(
+                cursor, offset_sec, today_local, today_local + 86400
+            )
+        finally:
+            conn.close()
+
+        buckets: list[dict[str, Any]] = []
+        for day_epoch in day_epochs:
+            key = AnalyticsService._local_day_key(day_epoch)
+            source = today_stats if day_epoch >= today_local else rollup_rows
+            stats = source.get(key, {})
+            buckets.append(
+                {
+                    "bucket": key,
+                    "total_packets": stats.get("total_packets", 0),
+                    "active_nodes": stats.get("active_nodes", 0),
+                    "gateway_count": stats.get("gateway_count", 0),
+                    "new_nodes": stats.get("new_nodes", 0),
+                }
+            )
+        return buckets
+
+    @staticmethod
+    def _local_day_key(local_day_epoch: int) -> str:
+        """ISO date string for a local-midnight epoch (local time == shifted UTC)."""
+        return datetime.fromtimestamp(local_day_epoch, tz=UTC).date().isoformat()
+
+    @staticmethod
+    def _ensure_daily_rollup(
+        cursor: Any,
+        tz_offset_minutes: int,
+        offset_sec: int,
+        completed_epochs: list[int],
+    ) -> dict[str, dict[str, Any]]:
+        """Return rollup stats for the given completed local days, computing any
+        missing ones from packet_history and persisting them.
+
+        Rows are safe to persist forever: packet_history is append-only with
+        insert-time timestamps and node_info.first_seen is assigned once, so a
+        finished local day can never change retroactively.
+        """
+        if not completed_epochs:
+            return {}
+
+        wanted = {AnalyticsService._local_day_key(d): d for d in completed_epochs}
+        placeholders = ",".join("?" * len(wanted))
+        cursor.execute(
+            f"""
+            SELECT day, total_packets, active_nodes, gateway_count, new_nodes
+            FROM activity_daily_rollup
+            WHERE tz_offset_minutes = ? AND day IN ({placeholders})
+        """,
+            [tz_offset_minutes, *wanted.keys()],
+        )
+        cached: dict[str, dict[str, Any]] = {
+            row["day"]: dict(row) for row in cursor.fetchall()
+        }
+
+        missing = [epoch for key, epoch in wanted.items() if key not in cached]
+        if not missing:
+            return cached
+
+        # One aggregation pass over the contiguous span covering all missing
+        # days (holes are rare; recomputing a cached day inside the span is
+        # harmless — only missing days are written back).
+        computed = AnalyticsService._compute_daily_span(
+            cursor, offset_sec, min(missing), max(missing) + 86400
+        )
+        now_ts = time.time()
+        for epoch in missing:
+            key = AnalyticsService._local_day_key(epoch)
+            stats = computed.get(key, {})
+            row = {
+                "total_packets": stats.get("total_packets", 0),
+                "active_nodes": stats.get("active_nodes", 0),
+                "gateway_count": stats.get("gateway_count", 0),
+                "new_nodes": stats.get("new_nodes", 0),
+            }
+            cursor.execute(
+                """
+                INSERT OR REPLACE INTO activity_daily_rollup
+                (tz_offset_minutes, day, total_packets, active_nodes,
+                 gateway_count, new_nodes, computed_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+                (
+                    tz_offset_minutes,
+                    key,
+                    row["total_packets"],
+                    row["active_nodes"],
+                    row["gateway_count"],
+                    row["new_nodes"],
+                    now_ts,
+                ),
+            )
+            cached[key] = {"day": key, **row}
+        return cached
+
+    @staticmethod
+    def _compute_daily_span(
+        cursor: Any, offset_sec: int, span_start_local: int, span_end_local: int
+    ) -> dict[str, dict[str, Any]]:
+        """Aggregate packet/node/gateway metrics per local day over one span.
+
+        The packet queries are answered entirely from the (timestamp,
+        from_node_id) and (timestamp, gateway_id) covering indexes.
+        """
+        start_utc = span_start_local - offset_sec
+        end_utc = span_end_local - offset_sec
+
+        stats: dict[str, dict[str, Any]] = {}
+
+        def entry(day: str) -> dict[str, Any]:
+            return stats.setdefault(day, {})
+
+        cursor.execute(
+            """
+            SELECT
+                date(timestamp + ?, 'unixepoch') AS day,
+                COUNT(*) AS total_packets,
+                COUNT(DISTINCT from_node_id) AS active_nodes
+            FROM packet_history
+            WHERE timestamp >= ? AND timestamp < ?
+            GROUP BY day
+        """,
+            (offset_sec, start_utc, end_utc),
+        )
+        for row in cursor.fetchall():
+            entry(row["day"]).update(
+                total_packets=row["total_packets"], active_nodes=row["active_nodes"]
+            )
+
+        cursor.execute(
+            """
+            SELECT
+                date(timestamp + ?, 'unixepoch') AS day,
+                COUNT(DISTINCT gateway_id) AS gateway_count
+            FROM packet_history
+            WHERE gateway_id IS NOT NULL AND timestamp >= ? AND timestamp < ?
+            GROUP BY day
+        """,
+            (offset_sec, start_utc, end_utc),
+        )
+        for row in cursor.fetchall():
+            entry(row["day"]).update(gateway_count=row["gateway_count"])
+
+        cursor.execute(
+            """
+            SELECT
+                date(first_seen + ?, 'unixepoch') AS day,
+                COUNT(*) AS new_nodes
+            FROM node_info
+            WHERE first_seen >= ? AND first_seen < ?
+            GROUP BY day
+        """,
+            (offset_sec, start_utc, end_utc),
+        )
+        for row in cursor.fetchall():
+            entry(row["day"]).update(new_nodes=row["new_nodes"])
+
+        return stats
+
+    @staticmethod
+    def _get_hop_distribution(
+        filters: dict, since_timestamp: float
+    ) -> list[dict[str, Any]]:
+        """Get the real hop-count distribution (hop_start - hop_limit) for the window."""
+        from ..database.connection import get_db_connection
+
+        where_conditions: list[str] = [
+            "timestamp >= ?",
+            "hop_start IS NOT NULL",
+            "hop_limit IS NOT NULL",
+            # Guard against malformed packets reporting negative hop counts.
+            "hop_start >= hop_limit",
+        ]
+        params: list[Any] = [since_timestamp]
+
+        if filters.get("gateway_id"):
+            where_conditions.append("gateway_id = ?")
+            params.append(filters["gateway_id"])
+
+        if filters.get("from_node"):
+            where_conditions.append("from_node_id = ?")
+            params.append(filters["from_node"])
+
+        where_clause = " AND ".join(where_conditions)
+
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            f"""
+            SELECT
+                (hop_start - hop_limit) AS hops,
+                COUNT(*) AS count
+            FROM packet_history
+            WHERE {where_clause}
+            GROUP BY hops
+            ORDER BY hops
+        """,
+            params,
+        )
+        distribution = [dict(row) for row in cursor.fetchall()]
+        conn.close()
+
+        return distribution
 
     @staticmethod
     def _get_top_active_nodes(

--- a/src/malla/templates/dashboard.html
+++ b/src/malla/templates/dashboard.html
@@ -2,6 +2,17 @@
 
 {% block title %}Mesh Network Dashboard - {{ APP_NAME }}{% endblock %}
 
+{% block extra_css %}
+<style>
+/* Activity-timeline panels: fixed chart height, tightened on phones so the
+   2x2 grid stays a compact at-a-glance block instead of a long stack. */
+.timeline-panel { height: 130px; position: relative; }
+@media (max-width: 575.98px) {
+    .timeline-panel { height: 110px; }
+}
+</style>
+{% endblock %}
+
 {% block content %}
 <div class="container-fluid">
     {# Optional Markdown content defined in config.yaml #}
@@ -39,9 +50,9 @@
                 <div class="card-body card-metric">
                     <div class="metric-value text-success">{{ stats.active_nodes_24h }}</div>
                     <div class="metric-label">Active Nodes (24h)</div>
-                    {% set total_nodes_safe = stats.total_nodes if stats.total_nodes > 0 else 1 %}
-                    {% set coverage_pct = (stats.active_nodes_24h / total_nodes_safe * 100)|int %}
-                    <small class="text-muted">{{ coverage_pct }}% network coverage</small>
+                    {% set nodes_seen_7d_safe = stats.nodes_seen_7d if stats.nodes_seen_7d and stats.nodes_seen_7d > 0 else 1 %}
+                    {% set coverage_pct = (stats.active_nodes_24h / nodes_seen_7d_safe * 100)|int %}
+                    <small class="text-muted">{{ coverage_pct }}% network coverage (of {{ stats.nodes_seen_7d }} seen in 7d)</small>
                 </div>
             </div>
         </div>
@@ -86,20 +97,55 @@
 
     <!-- Network Health and Activity Row -->
     <div class="row mb-4">
-        <!-- Network Activity Chart -->
+        <!-- Network Activity Timeline -->
         <div class="col-md-8 mb-4">
             <div class="card h-100">
-                <div class="card-header">
-                    <h5 class="card-title mb-0"><i class="bi bi-graph-up-arrow"></i> Network Activity Trends (7 Days)</h5>
+                <div class="card-header d-flex justify-content-between align-items-center flex-wrap gap-2">
+                    <h5 class="card-title mb-0"><i class="bi bi-graph-up-arrow"></i> Network Activity Trends</h5>
+                    <div class="btn-group btn-group-sm" role="group" aria-label="Time range" id="timelineRangeButtons">
+                        <button type="button" class="btn btn-outline-secondary" data-range="24h">24h</button>
+                        <button type="button" class="btn btn-outline-secondary" data-range="7d">7d</button>
+                        <button type="button" class="btn btn-outline-secondary" data-range="30d">30d</button>
+                        <button type="button" class="btn btn-outline-secondary" data-range="all">All</button>
+                    </div>
                 </div>
                 <div class="card-body">
-                    <div id="timeSeriesChartLoading" class="text-center py-4">
+                    <div id="activityTimelinePanelsLoading" class="text-center py-4">
                         <div class="spinner-border text-primary" role="status">
                             <span class="visually-hidden">Loading...</span>
                         </div>
                         <p class="mt-2 text-muted">Loading chart data...</p>
                     </div>
-                    <canvas id="timeSeriesChart" style="height: 300px; display: none;"></canvas>
+                    <div id="activityTimelinePanels" class="row g-3" style="display: none;">
+                        <div class="col-6">
+                            <div class="d-flex justify-content-between align-items-baseline flex-wrap mb-1">
+                                <small class="text-muted">Messages</small>
+                                <small class="fw-semibold" id="tlMessagesVal"></small>
+                            </div>
+                            <div class="timeline-panel"><canvas id="tlMessages"></canvas></div>
+                        </div>
+                        <div class="col-6">
+                            <div class="d-flex justify-content-between align-items-baseline flex-wrap mb-1">
+                                <small class="text-muted">Active Nodes</small>
+                                <small class="fw-semibold" id="tlActiveNodesVal"></small>
+                            </div>
+                            <div class="timeline-panel"><canvas id="tlActiveNodes"></canvas></div>
+                        </div>
+                        <div class="col-6">
+                            <div class="d-flex justify-content-between align-items-baseline flex-wrap mb-1">
+                                <small class="text-muted">Gateways</small>
+                                <small class="fw-semibold" id="tlGatewaysVal"></small>
+                            </div>
+                            <div class="timeline-panel"><canvas id="tlGateways"></canvas></div>
+                        </div>
+                        <div class="col-6">
+                            <div class="d-flex justify-content-between align-items-baseline flex-wrap mb-1">
+                                <small class="text-muted">New Nodes</small>
+                                <small class="fw-semibold" id="tlNewNodesVal"></small>
+                            </div>
+                            <div class="timeline-panel"><canvas id="tlNewNodes"></canvas></div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -114,14 +160,14 @@
                     <div class="mb-3">
                         <h6>Network Coverage</h6>
                         <div class="progress mb-2">
-                            {% set total_nodes_safe = stats.total_nodes if stats.total_nodes > 0 else 1 %}
-                            {% set activity_percentage = (stats.active_nodes_24h / total_nodes_safe * 100)|int %}
+                            {% set nodes_seen_7d_safe = stats.nodes_seen_7d if stats.nodes_seen_7d and stats.nodes_seen_7d > 0 else 1 %}
+                            {% set activity_percentage = (stats.active_nodes_24h / nodes_seen_7d_safe * 100)|int %}
                             {% set coverage_class = 'bg-success' if activity_percentage >= 70 else 'bg-warning' if activity_percentage >= 40 else 'bg-danger' %}
                             <div class="progress-bar {{ coverage_class }}" style="width: {{ activity_percentage }}%;">
                                 {{ activity_percentage }}%
                             </div>
                         </div>
-                        <small class="text-muted">{{ stats.active_nodes_24h }} of {{ stats.total_nodes }} nodes active</small>
+                        <small class="text-muted">{{ stats.active_nodes_24h }} of {{ stats.nodes_seen_7d }} nodes seen this week active in 24h</small>
                     </div>
 
                     <div class="mb-3">
@@ -376,8 +422,8 @@
                     <div class="row">
                         <div class="col-12">
                             <strong>Network Health:</strong><br>
-                            {% set total_nodes_safe = stats.total_nodes if stats.total_nodes > 0 else 1 %}
-                            {% set activity_percentage = (stats.active_nodes_24h / total_nodes_safe * 100)|int %}
+                            {% set nodes_seen_7d_safe = stats.nodes_seen_7d if stats.nodes_seen_7d and stats.nodes_seen_7d > 0 else 1 %}
+                            {% set activity_percentage = (stats.active_nodes_24h / nodes_seen_7d_safe * 100)|int %}
                             {% if activity_percentage >= 70 %}
                                 <span class="text-success">Excellent</span>
                             {% elif activity_percentage >= 40 %}
@@ -477,12 +523,14 @@ function updateChartsForTheme() {
         chartInstances = {};
 
         // Recreate charts with new theme
-        createTimeSeriesChart(analyticsData.temporal_patterns);
         createNodeActivityChart(analyticsData.node_statistics);
         createGatewayActivityChart(analyticsData.gateway_distribution);
         createSignalDistributionChart(analyticsData.signal_quality);
-        createHopDistributionChart(analyticsData.temporal_patterns);
+        createHopDistributionChart(analyticsData.hop_distribution);
         createPacketTypesChart(analyticsData.packet_types);
+    }
+    if (timelineData) {
+        renderTimelinePanels();
     }
 }
 
@@ -491,10 +539,32 @@ document.addEventListener('DOMContentLoaded', function () {
     // Load analytics data asynchronously
     loadAnalyticsData();
 
+    // Activity timeline: restore the last-used range and wire the selector
+    loadActivityTimeline(timelineRange);
+    const rangeButtons = document.getElementById('timelineRangeButtons');
+    if (rangeButtons) {
+        rangeButtons.addEventListener('click', function (event) {
+            const button = event.target.closest('button[data-range]');
+            if (button && button.dataset.range !== timelineRange) {
+                loadActivityTimeline(button.dataset.range);
+            }
+        });
+    }
+
     // Listen for theme changes and update charts
     window.addEventListener('themeChanged', function(event) {
         updateChartsForTheme();
     });
+
+    // Re-render the timeline when crossing the phone breakpoint so tick
+    // density matches the new panel width (Chart.js only rescales, it does
+    // not re-read our narrow-mode options).
+    const narrowQuery = window.matchMedia('(max-width: 575.98px)');
+    if (typeof narrowQuery.addEventListener === 'function') {
+        narrowQuery.addEventListener('change', function () {
+            if (timelineData) renderTimelinePanels();
+        });
+    }
 });
 
 async function loadAnalyticsData() {
@@ -506,11 +576,10 @@ async function loadAnalyticsData() {
         analyticsData = await response.json();
 
         // Render all charts and tables with loaded data
-        createTimeSeriesChart(analyticsData.temporal_patterns);
         createNodeActivityChart(analyticsData.node_statistics);
         createGatewayActivityChart(analyticsData.gateway_distribution);
         createSignalDistributionChart(analyticsData.signal_quality);
-        createHopDistributionChart(analyticsData.temporal_patterns);
+        createHopDistributionChart(analyticsData.hop_distribution);
         createPacketTypesChart(analyticsData.packet_types);
         populateTopNodesTable(analyticsData.top_nodes);
 
@@ -539,58 +608,192 @@ function showErrorMessage(message) {
     console.error(message);
 }
 
-function createTimeSeriesChart(temporalData) {
-    if (!temporalData || !temporalData.hourly_breakdown) return;
+// ---------------------------------------------------------------------------
+// Activity timeline: four single-metric panels sharing one time axis, with a
+// 24h / 7d / 30d / All range selector. One metric per panel (no dual axes) so
+// each scale reads directly.
+// ---------------------------------------------------------------------------
+let timelineData = null;
+let timelineRange = localStorage.getItem('mallaTimelineRange') || '7d';
 
-    hideLoadingSpinner('timeSeriesChart');
-    const ctx = document.getElementById('timeSeriesChart');
-    if (!ctx) return;
+// kind: bars for per-bucket flows, lines for levels; agg drives the header stat.
+const TIMELINE_PANELS = [
+    { key: 'total_packets', canvas: 'tlMessages',    valueEl: 'tlMessagesVal',    color: 'info',      kind: 'bar',  agg: 'sum'  },
+    { key: 'active_nodes',  canvas: 'tlActiveNodes', valueEl: 'tlActiveNodesVal', color: 'success',   kind: 'line', agg: 'last' },
+    { key: 'gateway_count', canvas: 'tlGateways',    valueEl: 'tlGatewaysVal',    color: 'primary',   kind: 'line', agg: 'last' },
+    { key: 'new_nodes',     canvas: 'tlNewNodes',    valueEl: 'tlNewNodesVal',    color: 'warning',   kind: 'bar',  agg: 'sum'  },
+];
 
-    // Determine timezone offset for display.
-    // getTimezoneOffset() returns minutes *behind* UTC (positive = west), so negate
-    // to get the number of minutes to add to UTC to reach local time.
-    const tzPref = (typeof getTimezonePreference === 'function') ? getTimezonePreference() : 'local';
-    const tzOffsetMinutes = (tzPref === 'utc') ? 0 : -new Date().getTimezoneOffset();
+function hexToRgba(hex, alpha) {
+    let h = (hex || '').trim().replace('#', '');
+    if (h.length === 3) h = h.split('').map(c => c + c).join('');
+    if (h.length !== 6) return `rgba(128, 128, 128, ${alpha})`;
+    const n = parseInt(h, 16);
+    return `rgba(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255}, ${alpha})`;
+}
 
-    // The API returns data bucketed by UTC hour (0-23).  Rotate into local time by
-    // computing, for each local hour L, which UTC hour contributed its data.
-    // For half-hour / quarter-hour timezones we round to the nearest whole hour –
-    // this is the same approximation a UTC-only chart already makes per bucket.
-    const tzOffsetHours = Math.round(tzOffsetMinutes / 60);
+function formatCompact(value) {
+    return Math.abs(value) >= 1000
+        ? new Intl.NumberFormat('en', { notation: 'compact', maximumFractionDigits: 1 }).format(value)
+        : String(value);
+}
 
-    // Build a UTC-indexed lookup: utcCounts[utcHour] = total_packets
-    const utcCounts = new Array(24).fill(0);
-    temporalData.hourly_breakdown.forEach(item => {
-        utcCounts[item.hour] = item.total_packets;
+// Bucket labels arrive as "YYYY-MM-DD" (days) or "YYYY-MM-DD HH:00" (hours);
+// ticks show a short form, tooltips keep the full label. Narrow panels get an
+// even shorter year-month ("25-12") so dense ticks can't collide.
+function shortBucketLabel(label, granularity, dense, narrow) {
+    if (granularity === 'hour') return label.slice(11);
+    if (!dense) return label.slice(5);
+    return narrow ? label.slice(2, 7) : label.slice(0, 7);
+}
+
+async function loadActivityTimeline(range) {
+    timelineRange = range;
+    try { localStorage.setItem('mallaTimelineRange', range); } catch (e) { /* private mode */ }
+
+    const buttons = document.querySelectorAll('#timelineRangeButtons button[data-range]');
+    buttons.forEach(b => {
+        const active = b.dataset.range === range;
+        b.classList.toggle('active', active);
+        b.setAttribute('aria-pressed', active);
     });
 
-    // Build chart arrays ordered by local hour (0 → 23)
-    const labels = [];
-    const data = [];
-    for (let localHour = 0; localHour < 24; localHour++) {
-        // The +24 before the outer % 24 ensures the result is non-negative in
-        // JavaScript, where (negative % positive) can return a negative number.
-        const utcHour = ((localHour - tzOffsetHours) % 24 + 24) % 24;
-        labels.push(`${localHour}:00`);
-        data.push(utcCounts[utcHour]);
+    const panels = document.getElementById('activityTimelinePanels');
+    if (panels) panels.style.opacity = '0.5';
+
+    try {
+        const tzPref = (typeof getTimezonePreference === 'function') ? getTimezonePreference() : 'local';
+        const tzOffset = (tzPref === 'utc') ? 0 : -new Date().getTimezoneOffset();
+        const response = await fetch(`/api/activity-timeline?range=${encodeURIComponent(range)}&tz_offset=${tzOffset}`);
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        timelineData = await response.json();
+        renderTimelinePanels();
+    } catch (error) {
+        console.error('Error loading activity timeline:', error);
+        hideLoadingSpinner('activityTimelinePanels');
+    } finally {
+        if (panels) panels.style.opacity = '';
     }
+}
 
+function renderTimelinePanels() {
+    if (!timelineData || !timelineData.buckets) return;
+
+    // Not hideLoadingSpinner(): that forces display:block, which would break
+    // the Bootstrap .row flex layout of the panel grid.
+    const loading = document.getElementById('activityTimelinePanelsLoading');
+    if (loading) loading.style.display = 'none';
+    const panelsEl = document.getElementById('activityTimelinePanels');
+    if (panelsEl) panelsEl.style.display = '';
+
+    const buckets = timelineData.buckets;
+    const granularity = timelineData.granularity;
+    const dense = buckets.length > 60;  // "All": bars degrade into slivers, use lines
+    const labels = buckets.map(b => b.bucket);
     const colors = getChartColors();
-    const options = getDefaultChartOptions();
+    const latestLabel = granularity === 'hour' ? 'now' : 'today';
+    // Phones show the same 2x2 grid at ~half the panel width: fewer, smaller
+    // ticks so axis labels don't collide.
+    const narrow = window.matchMedia('(max-width: 575.98px)').matches;
+    const tickFont = narrow ? { size: 10 } : undefined;
 
-    chartInstances.timeSeriesChart = new Chart(ctx, {
-        type: 'line',
-        data: {
-            labels: labels,
-            datasets: [{
-                label: 'Messages per Hour',
-                data: data,
-                borderColor: colors.info,
-                backgroundColor: colors.infoBg,
-                tension: 0.1
-            }]
-        },
-        options: options
+    TIMELINE_PANELS.forEach(panel => {
+        const ctx = document.getElementById(panel.canvas);
+        if (!ctx) return;
+
+        const chartKey = 'timeline_' + panel.key;
+        if (chartInstances[chartKey]) {
+            chartInstances[chartKey].destroy();
+        }
+
+        const series = buckets.map(b => b[panel.key] || 0);
+        const hex = colors[panel.color];
+
+        const valueEl = document.getElementById(panel.valueEl);
+        if (valueEl) {
+            // Headers must stay one line so the grid rows align: on phones,
+            // compact big sums (13.8M) and drop the today/now suffix.
+            if (panel.agg === 'sum') {
+                const total = series.reduce((a, v) => a + v, 0);
+                valueEl.textContent = narrow ? formatCompact(total) : total.toLocaleString();
+                valueEl.title = total.toLocaleString();
+            } else {
+                const latest = (series[series.length - 1] || 0).toLocaleString();
+                valueEl.textContent = narrow ? latest : `${latest} ${latestLabel}`;
+                valueEl.title = `${latest} ${latestLabel}`;
+            }
+        }
+
+        const type = (dense && panel.kind === 'bar') ? 'line' : panel.kind;
+        const dataset = type === 'bar'
+            ? {
+                data: series,
+                backgroundColor: hexToRgba(hex, 0.65),
+                hoverBackgroundColor: hexToRgba(hex, 0.85),
+                borderColor: hex,
+                borderWidth: 1,
+                borderRadius: 3,
+                borderSkipped: 'start',
+                maxBarThickness: 26,
+                categoryPercentage: 0.72,
+                barPercentage: 1
+            }
+            : {
+                data: series,
+                borderColor: hex,
+                backgroundColor: hexToRgba(hex, 0.12),
+                borderWidth: 2,
+                fill: true,
+                tension: 0.3,
+                pointRadius: 0,
+                pointHoverRadius: 4,
+                pointHitRadius: 10
+            };
+
+        chartInstances[chartKey] = new Chart(ctx, {
+            type: type,
+            data: { labels: labels, datasets: [dataset] },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                interaction: { mode: 'index', intersect: false },
+                plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                        callbacks: {
+                            label: c => c.parsed.y.toLocaleString()
+                        }
+                    }
+                },
+                scales: {
+                    x: {
+                        grid: { display: false },
+                        ticks: {
+                            color: colors.mutedTextColor,
+                            maxTicksLimit: narrow ? 3 : 5,
+                            maxRotation: 0,
+                            autoSkip: true,
+                            font: tickFont,
+                            callback: function (value) {
+                                return shortBucketLabel(this.getLabelForValue(value), granularity, dense, narrow);
+                            }
+                        }
+                    },
+                    y: {
+                        beginAtZero: true,
+                        grid: { color: colors.gridColor },
+                        ticks: {
+                            color: colors.mutedTextColor,
+                            maxTicksLimit: narrow ? 3 : 4,
+                            font: tickFont,
+                            callback: value => formatCompact(value)
+                        }
+                    }
+                }
+            }
+        });
     });
 }
 
@@ -607,7 +810,7 @@ function createNodeActivityChart(nodeData) {
     chartInstances.nodeActivityChart = new Chart(ctx, {
         type: 'doughnut',
         data: {
-            labels: ['Very Active (>100)', 'Moderately Active (10-100)', 'Lightly Active (1-10)', 'Inactive'],
+            labels: ['Very Active (>100)', 'Moderately Active (10-100)', 'Lightly Active (1-10)', 'Quiet (seen in 7d)'],
             datasets: [{
                 data: [
                     activityDist.very_active || 0,
@@ -699,23 +902,28 @@ function createSignalDistributionChart(signalData) {
     });
 }
 
-function createHopDistributionChart(temporalData) {
-    // Create a simple hop distribution chart based on available data
+function createHopDistributionChart(hopDistribution) {
     hideLoadingSpinner('hopDistributionChart');
     const ctx = document.getElementById('hopDistributionChart');
     if (!ctx) return;
+    if (!hopDistribution || hopDistribution.length === 0) return;
 
     const colors = getChartColors();
 
-    // For now, create a chart showing message routing efficiency
-    // This could be enhanced with actual hop count data from the API
+    // Real hop counts (hop_start - hop_limit) over the last 24h, bucketed
+    // into direct / 1 / 2 / 3+ hops.
+    const totals = [0, 0, 0, 0];
+    hopDistribution.forEach(d => {
+        totals[Math.min(d.hops, 3)] += d.count;
+    });
+
     chartInstances.hopDistributionChart = new Chart(ctx, {
         type: 'doughnut',
         data: {
-            labels: ['Direct Messages', 'Routed Messages', 'Multi-hop Messages'],
+            labels: ['Direct (0 hops)', '1 hop', '2 hops', '3+ hops'],
             datasets: [{
-                data: [60, 30, 10], // Placeholder data - could be enhanced with real hop analysis
-                backgroundColor: [colors.success, colors.warning, colors.danger]
+                data: totals,
+                backgroundColor: [colors.success, colors.info, colors.warning, colors.danger]
             }]
         },
         options: {

--- a/tests/unit/test_network_coverage_stats.py
+++ b/tests/unit/test_network_coverage_stats.py
@@ -1,0 +1,277 @@
+"""Tests for the 7-day rolling network-coverage denominator and daily activity.
+
+node_info only ever grows (it remembers every node ever seen), so the old
+coverage ratio active_nodes_24h / total_nodes decayed toward zero as the
+roster aged. These tests pin the replacement: both sides of the ratio come
+from packet_history, with a trailing-7-day roster as the denominator, plus
+the per-local-day activity buckets that feed the dashboard trends chart.
+"""
+
+import sqlite3
+import time
+
+import malla.database.repositories as repositories
+from malla.database.repositories import DashboardRepository
+from malla.services.analytics_service import AnalyticsService
+
+HOUR = 3600
+DAY = 86400
+
+
+def _reset_data(db_path: str, packets, nodes):
+    """Replace fixture data with a controlled set of packets and nodes."""
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute("DELETE FROM packet_history")
+    cursor.execute("DELETE FROM node_info")
+    cursor.executemany(
+        """INSERT INTO packet_history
+           (timestamp, topic, from_node_id, gateway_id, hop_start, hop_limit,
+            processed_successfully)
+           VALUES (?, 'test', ?, ?, ?, ?, 1)""",
+        packets,
+    )
+    cursor.executemany(
+        "INSERT INTO node_info (node_id, first_seen, last_updated) VALUES (?, ?, ?)",
+        nodes,
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_nodes_seen_7d_rolling_window(temp_database, monkeypatch):
+    """Coverage denominator counts distinct senders in 7d, not the all-time roster."""
+    monkeypatch.setenv("MALLA_DATABASE_FILE", temp_database)
+    repositories._dashboard_stats_cache.clear()
+
+    now = time.time()
+    _reset_data(
+        temp_database,
+        packets=[
+            (now - HOUR, 1, "!gw1", 3, 3),  # node 1: active in 24h and 7d
+            (now - 3 * DAY, 2, "!gw1", 3, 3),  # node 2: in 7d only
+            (now - 10 * DAY, 3, "!gw1", 3, 3),  # node 3: outside the window
+        ],
+        nodes=[
+            (1, now - 10 * DAY, now),
+            (2, now - 10 * DAY, now),
+            (3, now - 10 * DAY, now),
+        ],
+    )
+
+    stats = DashboardRepository.get_stats()
+
+    assert stats["total_nodes"] == 3
+    assert stats["active_nodes_24h"] == 1
+    assert stats["nodes_seen_7d"] == 2
+
+
+def test_node_activity_statistics_use_7d_roster(temp_database, monkeypatch):
+    """Analytics activity rate and 'inactive' compare 24h activity to the 7d roster."""
+    monkeypatch.setenv("MALLA_DATABASE_FILE", temp_database)
+
+    now = time.time()
+    _reset_data(
+        temp_database,
+        packets=[
+            (now - HOUR, 1, "!gw1", 3, 3),
+            (now - 3 * DAY, 2, "!gw1", 3, 3),
+            (now - 10 * DAY, 3, "!gw1", 3, 3),
+        ],
+        nodes=[
+            (1, now - 10 * DAY, now),
+            (2, now - 10 * DAY, now),
+            (3, now - 10 * DAY, now),
+        ],
+    )
+
+    stats = AnalyticsService._get_node_activity_statistics(
+        {}, now - 24 * HOUR, now - 7 * DAY
+    )
+
+    assert stats["active_nodes"] == 1
+    assert stats["nodes_seen_7d"] == 2
+    assert stats["inactive_nodes"] == 1
+    assert stats["activity_rate"] == 50.0
+    assert stats["activity_distribution"]["inactive"] == 1
+    # The all-time roster is still reported for reference.
+    assert stats["total_nodes"] == 3
+
+
+def test_timeline_7d_buckets_align_to_local_days(temp_database, monkeypatch):
+    """Packets either side of a local midnight land in different buckets."""
+    monkeypatch.setenv("MALLA_DATABASE_FILE", temp_database)
+    AnalyticsService._TIMELINE_CACHE.clear()
+
+    tz_offset_minutes = 480  # UTC+8
+    offset_sec = tz_offset_minutes * 60
+    now = time.time()
+    local_today_start = (int(now + offset_sec) // DAY) * DAY
+    ts_today = local_today_start - offset_sec + 1800  # 00:30 local today
+    ts_yesterday = local_today_start - offset_sec - 1800  # 23:30 local yesterday
+
+    _reset_data(
+        temp_database,
+        packets=[
+            (ts_today, 1, "!gw1", 3, 3),
+            (ts_yesterday, 2, "!gw2", 3, 3),
+            (ts_yesterday - 60, 2, "!gw2", 3, 3),
+        ],
+        nodes=[(1, ts_today, now), (2, ts_yesterday, now)],
+    )
+
+    timeline = AnalyticsService.get_activity_timeline("7d", tz_offset_minutes)
+    days = timeline["buckets"]
+
+    assert timeline["granularity"] == "day"
+    assert len(days) == 8  # 7 complete local days + today so far
+    assert days == sorted(days, key=lambda d: d["bucket"])
+
+    today, yesterday = days[-1], days[-2]
+    assert today["total_packets"] == 1
+    assert today["active_nodes"] == 1
+    assert today["gateway_count"] == 1
+    assert today["new_nodes"] == 1
+    assert yesterday["total_packets"] == 2
+    assert yesterday["active_nodes"] == 1
+    assert yesterday["gateway_count"] == 1
+    assert yesterday["new_nodes"] == 1
+    assert all(d["total_packets"] == 0 and d["active_nodes"] == 0 for d in days[:-2])
+
+
+def test_timeline_completed_days_served_from_rollup(temp_database, monkeypatch):
+    """Completed days are persisted to activity_daily_rollup and reused as-is."""
+    monkeypatch.setenv("MALLA_DATABASE_FILE", temp_database)
+    AnalyticsService._TIMELINE_CACHE.clear()
+
+    tz_offset_minutes = 0
+    now = time.time()
+    local_today_start = (int(now) // DAY) * DAY
+    ts_yesterday = local_today_start - 12 * HOUR
+
+    _reset_data(
+        temp_database,
+        packets=[
+            (ts_yesterday, 1, "!gw1", 3, 3),
+            (ts_yesterday + 60, 2, "!gw1", 3, 3),
+            (now, 3, "!gw1", 3, 3),
+        ],
+        nodes=[(1, ts_yesterday, now)],
+    )
+
+    first = AnalyticsService.get_activity_timeline("7d", tz_offset_minutes)
+    assert first["buckets"][-2]["total_packets"] == 2
+
+    # The completed day is now persisted.
+    conn = sqlite3.connect(temp_database)
+    rollup_days = {
+        row[0]
+        for row in conn.execute(
+            "SELECT day FROM activity_daily_rollup WHERE tz_offset_minutes = 0"
+        )
+    }
+    conn.close()
+    assert first["buckets"][-2]["bucket"] in rollup_days
+    assert first["buckets"][-1]["bucket"] not in rollup_days  # today never cached
+
+    # A packet backdated into a completed day must NOT change the rollup value
+    # (append-only history can't grow the past; this pins that we serve the
+    # cached aggregate instead of rescanning), while today stays live.
+    conn = sqlite3.connect(temp_database)
+    conn.execute(
+        "INSERT INTO packet_history (timestamp, topic, from_node_id, gateway_id, "
+        "hop_start, hop_limit, processed_successfully) VALUES (?, 'test', 9, '!gw9', 3, 3, 1)",
+        (ts_yesterday + 120,),
+    )
+    conn.execute(
+        "INSERT INTO packet_history (timestamp, topic, from_node_id, gateway_id, "
+        "hop_start, hop_limit, processed_successfully) VALUES (?, 'test', 4, '!gw1', 3, 3, 1)",
+        (now,),
+    )
+    conn.commit()
+    conn.close()
+
+    AnalyticsService._TIMELINE_CACHE.clear()
+    second = AnalyticsService.get_activity_timeline("7d", tz_offset_minutes)
+    assert second["buckets"][-2]["total_packets"] == 2  # unchanged, from rollup
+    assert second["buckets"][-1]["total_packets"] == 2  # today recomputed live
+
+
+def test_timeline_24h_hourly_buckets(temp_database, monkeypatch):
+    """The 24h range returns 24 hourly buckets ending at the current hour."""
+    monkeypatch.setenv("MALLA_DATABASE_FILE", temp_database)
+    AnalyticsService._TIMELINE_CACHE.clear()
+
+    now = time.time()
+    _reset_data(
+        temp_database,
+        packets=[
+            (now - 60, 1, "!gw1", 3, 3),  # current hour
+            (now - 5 * HOUR, 2, "!gw1", 3, 3),
+            (now - 5 * HOUR + 30, 2, "!gw1", 3, 3),
+            (now - 30 * HOUR, 3, "!gw1", 3, 3),  # outside the window
+        ],
+        nodes=[(1, now - 60, now)],
+    )
+
+    timeline = AnalyticsService.get_activity_timeline("24h", 0)
+    buckets = timeline["buckets"]
+
+    assert timeline["granularity"] == "hour"
+    assert len(buckets) == 24
+    assert buckets[-1]["total_packets"] == 1
+    five_hours_ago = buckets[-6]
+    assert five_hours_ago["total_packets"] == 2
+    assert five_hours_ago["active_nodes"] == 1
+    assert sum(b["total_packets"] for b in buckets) == 3
+
+
+def test_timeline_all_starts_at_first_packet(temp_database, monkeypatch):
+    """The all range spans from the first packet's local day through today."""
+    monkeypatch.setenv("MALLA_DATABASE_FILE", temp_database)
+    AnalyticsService._TIMELINE_CACHE.clear()
+
+    now = time.time()
+    _reset_data(
+        temp_database,
+        packets=[
+            (now - 3 * DAY, 1, "!gw1", 3, 3),
+            (now, 2, "!gw1", 3, 3),
+        ],
+        nodes=[(1, now - 3 * DAY, now)],
+    )
+
+    timeline = AnalyticsService.get_activity_timeline("all", 0)
+    buckets = timeline["buckets"]
+
+    # 3 days ago .. today inclusive = 4 or 5 buckets depending on where "now"
+    # sits inside the day; the first bucket must hold the oldest packet.
+    assert 4 <= len(buckets) <= 5
+    assert buckets[0]["total_packets"] == 1
+    assert buckets[-1]["total_packets"] == 1
+    assert sum(b["total_packets"] for b in buckets) == 2
+
+
+def test_hop_distribution_counts_real_hops(temp_database, monkeypatch):
+    """Hop distribution reflects hop_start - hop_limit, excluding malformed rows."""
+    monkeypatch.setenv("MALLA_DATABASE_FILE", temp_database)
+
+    now = time.time()
+    _reset_data(
+        temp_database,
+        packets=[
+            (now - HOUR, 1, "!gw1", 3, 3),  # 0 hops
+            (now - HOUR, 1, "!gw1", 3, 3),  # 0 hops
+            (now - HOUR, 2, "!gw1", 3, 2),  # 1 hop
+            (now - HOUR, 3, "!gw1", 5, 2),  # 3 hops
+            (now - HOUR, 4, "!gw1", 2, 3),  # malformed (negative), excluded
+            (now - HOUR, 5, "!gw1", None, None),  # unknown hops, excluded
+            (now - 2 * DAY, 6, "!gw1", 3, 3),  # outside 24h window
+        ],
+        nodes=[(1, now - DAY, now)],
+    )
+
+    distribution = AnalyticsService._get_hop_distribution({}, now - 24 * HOUR)
+    counts = {row["hops"]: row["count"] for row in distribution}
+
+    assert counts == {0: 2, 1: 1, 3: 1}


### PR DESCRIPTION
Three dashboard elements showed misleading data:

  1. **"Network Activity Trends (7 Days)" actually plotted the last 24 hours**, bucketed by hour of day — the title and the
  data disagreed.
  2. **"Network coverage" divided 24h-active nodes by the all-time `node_info` roster**, which only ever grows, so the ratio
  mathematically decays toward zero regardless of mesh health. On our 7-month-old deployment it read 12% while ~60% of the
  roster hadn't been heard from in 90+ days.
  3. **"Message Routing Patterns" rendered hard-coded placeholder data** (`[60, 30, 10]`).

  ## Changes

  - The trends card is now a real timeline with a **24h / 7d / 30d / All** range selector (default 7d, remembered in
  localStorage), rendered as **four single-metric panels** sharing one time axis — Messages, Active Nodes, Gateways, New Nodes
  — instead of mixing ~50k-scale and ~700-scale series on dual y-axes. Buckets align to the viewer's local calendar via a
  clamped `tz_offset` param. Panels stay a compact 2×2 grid on phones.
  - New `/api/activity-timeline` endpoint. Completed local days are persisted to a new `activity_daily_rollup` table —
  append-only history with insert-time stamps means a finished day never changes, so each `(tz_offset, day)` is aggregated
  once and reused forever; only the current day/hour is computed live. Measured on an 8.5GB production DB: 24h ≈ 0.06s live,
  7d/30d/All ≈ 0.13s with warm rollup.
  - **Coverage = distinct senders in 24h ÷ distinct senders in 7 days**, both from `packet_history` (consistent sources;
  `node_info.last_updated` only bumps on NODEINFO packets so it undercounts). Reads 67% instead of 12% on the same deployment.
  Same 7-day roster for the analytics `activity_rate` and the node-activity doughnut's "Inactive" slice.
  - The routing doughnut now shows the **real hop-count distribution** (`hop_start - hop_limit`, malformed negatives excluded)
  for the last 24h.

  All aggregation is answered from the existing covering indexes (`(timestamp, from_node_id)` / `(timestamp, gateway_id)`)
  behind the existing short in-process caches.

<img width="1718" height="910" alt="1" src="https://github.com/user-attachments/assets/493a3e05-2057-4904-9abe-1c96651658b5" />
<img width="1716" height="902" alt="2" src="https://github.com/user-attachments/assets/8fff2347-003d-4c83-9a59-8378f8473ec1" />


  ## Verification

  - New unit tests: rolling coverage window, 7d-roster stats, local-midnight bucket alignment (UTC+8), rollup immutability for
  completed days, 24h hourly buckets, All-range span, hop counting.
  - Full suite: 395 passed. `ruff` + `basedpyright` clean.
  - Running in production for a day: verified live at 375px–1280px in light and dark themes.