### PR TITLE
Real signal histograms and ordered hop columns on the dashboard

### DIFF
--- a/src/malla/database/packet_repository_optimized.py
+++ b/src/malla/database/packet_repository_optimized.py
@@ -7,6 +7,7 @@ import time
 from datetime import UTC, datetime
 from typing import Any
 
+from ..utils.signal_quality import is_plausible_rssi, is_plausible_snr
 from . import get_db_connection
 
 logger = logging.getLogger(__name__)
@@ -180,10 +181,12 @@ class PacketRepositoryOptimized:
                         {p["gateway_id"] for p in packets_in_group if p["gateway_id"]}
                     )
                     rssi_values = [
-                        p["rssi"] for p in packets_in_group if p["rssi"] is not None
+                        p["rssi"]
+                        for p in packets_in_group
+                        if is_plausible_rssi(p["rssi"])
                     ]
                     snr_values = [
-                        p["snr"] for p in packets_in_group if p["snr"] is not None
+                        p["snr"] for p in packets_in_group if is_plausible_snr(p["snr"])
                     ]
                     hop_values = [
                         p["hop_count"]

--- a/src/malla/database/repositories.py
+++ b/src/malla/database/repositories.py
@@ -17,6 +17,12 @@ from ..config import get_config
 from ..utils.decryption import try_decrypt_mesh_packet
 from ..utils.formatting import format_time_ago
 from ..utils.node_utils import convert_node_id, get_bulk_node_short_names
+from ..utils.signal_quality import (
+    is_plausible_rssi,
+    is_plausible_snr,
+    rssi_valid_sql,
+    snr_valid_sql,
+)
 from .connection import get_db_connection
 
 logger = logging.getLogger(__name__)
@@ -264,8 +270,8 @@ class DashboardRepository:
                     COUNT(*) as total_packets,
                     COUNT(DISTINCT CASE WHEN from_node_id IS NOT NULL THEN from_node_id END) as active_nodes_24h,
                     COUNT(CASE WHEN timestamp > ? THEN 1 END) as recent_packets,
-                    AVG(CASE WHEN rssi IS NOT NULL AND rssi != 0 THEN rssi END) as avg_rssi,
-                    AVG(CASE WHEN snr IS NOT NULL THEN snr END) as avg_snr,
+                    AVG(CASE WHEN {rssi_valid_sql()} THEN rssi END) as avg_rssi,
+                    AVG(CASE WHEN {snr_valid_sql()} THEN snr END) as avg_snr,
                     SUM(CASE WHEN processed_successfully = 1 THEN 1 ELSE 0 END) as successful_packets,
                     CASE WHEN COUNT(*) > 0
                          THEN ROUND(SUM(CASE WHEN processed_successfully = 1 THEN 1 ELSE 0 END) * 100.0 / COUNT(*), 1)
@@ -625,10 +631,12 @@ class PacketRepository:
                         {p["gateway_id"] for p in packets_in_group if p["gateway_id"]}
                     )
                     rssi_values = [
-                        p["rssi"] for p in packets_in_group if p["rssi"] is not None
+                        p["rssi"]
+                        for p in packets_in_group
+                        if is_plausible_rssi(p["rssi"])
                     ]
                     snr_values = [
-                        p["snr"] for p in packets_in_group if p["snr"] is not None
+                        p["snr"] for p in packets_in_group if is_plausible_snr(p["snr"])
                     ]
                     hop_values = [
                         p["hop_count"]
@@ -907,8 +915,10 @@ class PacketRepository:
             conn = get_db_connection()
             cursor = conn.cursor()
 
-            # Build WHERE clause
-            where_conditions = ["rssi IS NOT NULL", "snr IS NOT NULL"]
+            # Build WHERE clause. This feeds the signal-quality scatter chart:
+            # restrict to plausible values so one garbage row (or the rssi=0
+            # "not provided" sentinel) cannot destroy the chart axes.
+            where_conditions = [rssi_valid_sql(), snr_valid_sql()]
             params = []
 
             if filters.get("gateway_id"):
@@ -1064,10 +1074,10 @@ class PacketRepository:
                 WHERE p1.gateway_id = ?
                     AND p2.gateway_id = ?
                     AND p1.mesh_packet_id IS NOT NULL
-                    AND p1.rssi IS NOT NULL
-                    AND p1.snr IS NOT NULL
-                    AND p2.rssi IS NOT NULL
-                    AND p2.snr IS NOT NULL
+                    AND {rssi_valid_sql("p1.rssi")}
+                    AND {snr_valid_sql("p1.snr")}
+                    AND {rssi_valid_sql("p2.rssi")}
+                    AND {snr_valid_sql("p2.snr")}
                     AND p1.hop_limit IS NOT NULL
                     AND p2.hop_limit IS NOT NULL
                     {where_clause}
@@ -1421,17 +1431,17 @@ class NodeRepository:
 
             # Aggregate only packet_history here so SQLite can use the sender-focused index.
             cursor.execute(
-                """
+                f"""
                 SELECT
                     COUNT(*) as total_packets,
                     MAX(timestamp) as last_seen,
                     MIN(timestamp) as first_seen,
                     COUNT(DISTINCT to_node_id) as unique_destinations,
                     COUNT(DISTINCT gateway_id) as unique_gateways,
-                    AVG(CASE WHEN hop_start IS NULL OR hop_limit IS NULL OR hop_start = hop_limit
-                         THEN CAST(rssi AS FLOAT) END) as avg_rssi,
-                    AVG(CASE WHEN hop_start IS NULL OR hop_limit IS NULL OR hop_start = hop_limit
-                         THEN CAST(snr AS FLOAT) END) as avg_snr,
+                    AVG(CASE WHEN (hop_start IS NULL OR hop_limit IS NULL OR hop_start = hop_limit)
+                         AND {rssi_valid_sql()} THEN CAST(rssi AS FLOAT) END) as avg_rssi,
+                    AVG(CASE WHEN (hop_start IS NULL OR hop_limit IS NULL OR hop_start = hop_limit)
+                         AND {snr_valid_sql()} THEN CAST(snr AS FLOAT) END) as avg_snr,
                     AVG(CASE WHEN hop_start IS NOT NULL AND hop_limit IS NOT NULL
                         THEN (hop_start - hop_limit) ELSE NULL END) as avg_hops
                 FROM packet_history
@@ -1585,7 +1595,7 @@ class NodeRepository:
                     grouped_packets[mesh_id]["gateway_count"] += 1
 
                     # Update min/max values
-                    if row["rssi"] is not None:
+                    if is_plausible_rssi(row["rssi"]):
                         if (
                             grouped_packets[mesh_id]["min_rssi"] is None
                             or row["rssi"] < grouped_packets[mesh_id]["min_rssi"]
@@ -1597,7 +1607,7 @@ class NodeRepository:
                         ):
                             grouped_packets[mesh_id]["max_rssi"] = row["rssi"]
 
-                    if row["snr"] is not None:
+                    if is_plausible_snr(row["snr"]):
                         if (
                             grouped_packets[mesh_id]["min_snr"] is None
                             or row["snr"] < grouped_packets[mesh_id]["min_snr"]
@@ -1884,12 +1894,12 @@ class NodeRepository:
             )
 
             # Get protocol breakdown
-            protocol_query = """
+            protocol_query = f"""
             SELECT
                 portnum_name,
                 COUNT(*) as count,
-                AVG(CAST(rssi AS FLOAT)) as avg_rssi,
-                AVG(CAST(snr AS FLOAT)) as avg_snr
+                AVG(CASE WHEN {rssi_valid_sql()} THEN CAST(rssi AS FLOAT) END) as avg_rssi,
+                AVG(CASE WHEN {snr_valid_sql()} THEN CAST(snr AS FLOAT) END) as avg_snr
             FROM packet_history
             WHERE from_node_id = ?
             GROUP BY portnum_name
@@ -1912,7 +1922,7 @@ class NodeRepository:
                 )
 
             # Get received gateways information (gateways that have received packets from this node)
-            gateways_query = """
+            gateways_query = f"""
             WITH top_gateways AS (
                 SELECT
                     p.gateway_id,
@@ -1929,17 +1939,17 @@ class NodeRepository:
                 p.gateway_id,
                 COUNT(*) as packet_count,
                 MAX(p.timestamp) as last_received,
-                AVG(CAST(p.rssi AS FLOAT)) as avg_rssi,
-                AVG(CAST(p.snr AS FLOAT)) as avg_snr,
+                AVG(CASE WHEN {rssi_valid_sql("p.rssi")} THEN CAST(p.rssi AS FLOAT) END) as avg_rssi,
+                AVG(CASE WHEN {snr_valid_sql("p.snr")} THEN CAST(p.snr AS FLOAT) END) as avg_snr,
                 MIN(CASE WHEN p.hop_start IS NOT NULL AND p.hop_limit IS NOT NULL
                     THEN (p.hop_start - p.hop_limit) ELSE NULL END) as min_hops,
                 MAX(CASE WHEN p.hop_start IS NOT NULL AND p.hop_limit IS NOT NULL
                     THEN (p.hop_start - p.hop_limit) ELSE NULL END) as max_hops,
                 AVG(CASE WHEN p.hop_start IS NOT NULL AND p.hop_limit IS NOT NULL
                     THEN (p.hop_start - p.hop_limit) ELSE NULL END) as avg_hops,
-                AVG(CASE WHEN p.hop_start = p.hop_limit
+                AVG(CASE WHEN p.hop_start = p.hop_limit AND {rssi_valid_sql("p.rssi")}
                     THEN CAST(p.rssi AS FLOAT) ELSE NULL END) as direct_rssi,
-                AVG(CASE WHEN p.hop_start = p.hop_limit
+                AVG(CASE WHEN p.hop_start = p.hop_limit AND {snr_valid_sql("p.snr")}
                     THEN CAST(p.snr AS FLOAT) ELSE NULL END) as direct_snr,
                 MAX(tg.direct_packet_count) as direct_packet_count
             FROM top_gateways tg
@@ -2095,7 +2105,7 @@ class NodeRepository:
                         stats["hop_samples"] += 1
 
                     # Only consider RSSI for direct (0-hop) receptions
-                    if hop_val == 0 and gw.get("rssi") is not None:
+                    if hop_val == 0 and is_plausible_rssi(gw.get("rssi")):
                         stats["rssi_samples"].append(gw["rssi"])
 
             # Resolve display names for gateways (may be node IDs)
@@ -2536,16 +2546,16 @@ class NodeRepository:
             cursor = conn.cursor()
 
             # Query to get relay_node values with counts and signal stats for packets reported by this gateway
-            relay_query = """
+            relay_query = f"""
             SELECT
                 relay_node,
                 COUNT(*) as count,
-                AVG(rssi) as avg_rssi,
-                AVG(snr) as avg_snr,
-                MIN(rssi) as min_rssi,
-                MAX(rssi) as max_rssi,
-                MIN(snr) as min_snr,
-                MAX(snr) as max_snr
+                AVG(CASE WHEN {rssi_valid_sql()} THEN rssi END) as avg_rssi,
+                AVG(CASE WHEN {snr_valid_sql()} THEN snr END) as avg_snr,
+                MIN(CASE WHEN {rssi_valid_sql()} THEN rssi END) as min_rssi,
+                MAX(CASE WHEN {rssi_valid_sql()} THEN rssi END) as max_rssi,
+                MIN(CASE WHEN {snr_valid_sql()} THEN snr END) as min_snr,
+                MAX(CASE WHEN {snr_valid_sql()} THEN snr END) as max_snr
             FROM packet_history
             WHERE gateway_id = ?
                 AND relay_node IS NOT NULL
@@ -2752,18 +2762,18 @@ class NodeRepository:
             gateway_hex_id = f"!{gateway_node_id:08x}"
 
             # First get aggregated statistics per node
-            stats_query = """
+            stats_query = f"""
                 SELECT
                     p.from_node_id,
                     ni.long_name,
                     ni.short_name,
                     COUNT(*) as packet_count,
-                    AVG(CAST(p.rssi AS FLOAT)) as rssi_avg,
-                    MIN(CAST(p.rssi AS FLOAT)) as rssi_min,
-                    MAX(CAST(p.rssi AS FLOAT)) as rssi_max,
-                    AVG(CAST(p.snr AS FLOAT)) as snr_avg,
-                    MIN(CAST(p.snr AS FLOAT)) as snr_min,
-                    MAX(CAST(p.snr AS FLOAT)) as snr_max,
+                    AVG(CASE WHEN {rssi_valid_sql("p.rssi")} THEN CAST(p.rssi AS FLOAT) END) as rssi_avg,
+                    MIN(CASE WHEN {rssi_valid_sql("p.rssi")} THEN CAST(p.rssi AS FLOAT) END) as rssi_min,
+                    MAX(CASE WHEN {rssi_valid_sql("p.rssi")} THEN CAST(p.rssi AS FLOAT) END) as rssi_max,
+                    AVG(CASE WHEN {snr_valid_sql("p.snr")} THEN CAST(p.snr AS FLOAT) END) as snr_avg,
+                    MIN(CASE WHEN {snr_valid_sql("p.snr")} THEN CAST(p.snr AS FLOAT) END) as snr_min,
+                    MAX(CASE WHEN {snr_valid_sql("p.snr")} THEN CAST(p.snr AS FLOAT) END) as snr_max,
                     MIN(p.timestamp) as first_seen,
                     MAX(p.timestamp) as last_seen
                 FROM packet_history p
@@ -2781,14 +2791,16 @@ class NodeRepository:
             cursor.execute(stats_query, (gateway_hex_id, gateway_node_id))
             stats_rows = cursor.fetchall()
 
-            # Then get individual packet data for chart plotting
-            packets_query = """
+            # Then get individual packet data for chart plotting; the chart
+            # autoscales its axes, so null out garbage per field (a row with a
+            # valid RSSI but missing SNR must still contribute its RSSI point).
+            packets_query = f"""
                 SELECT
                     p.id AS packet_id,
                     p.timestamp,
                     p.from_node_id,
-                    p.rssi,
-                    p.snr
+                    CASE WHEN {rssi_valid_sql("p.rssi")} THEN p.rssi END AS rssi,
+                    CASE WHEN {snr_valid_sql("p.snr")} THEN p.snr END AS snr
                 FROM packet_history p
                 WHERE p.gateway_id = ?
                   AND p.from_node_id IS NOT NULL
@@ -2890,18 +2902,18 @@ class NodeRepository:
                 gateway_hex_id = f"!{node_id:08x}"
 
                 # First get aggregated statistics per node
-                stats_query = """
+                stats_query = f"""
                     SELECT
                         p.from_node_id,
                         ni.long_name,
                         ni.short_name,
                         COUNT(*) as packet_count,
-                        AVG(CAST(p.rssi AS FLOAT)) as rssi_avg,
-                        MIN(CAST(p.rssi AS FLOAT)) as rssi_min,
-                        MAX(CAST(p.rssi AS FLOAT)) as rssi_max,
-                        AVG(CAST(p.snr AS FLOAT)) as snr_avg,
-                        MIN(CAST(p.snr AS FLOAT)) as snr_min,
-                        MAX(CAST(p.snr AS FLOAT)) as snr_max,
+                        AVG(CASE WHEN {rssi_valid_sql("p.rssi")} THEN CAST(p.rssi AS FLOAT) END) as rssi_avg,
+                        MIN(CASE WHEN {rssi_valid_sql("p.rssi")} THEN CAST(p.rssi AS FLOAT) END) as rssi_min,
+                        MAX(CASE WHEN {rssi_valid_sql("p.rssi")} THEN CAST(p.rssi AS FLOAT) END) as rssi_max,
+                        AVG(CASE WHEN {snr_valid_sql("p.snr")} THEN CAST(p.snr AS FLOAT) END) as snr_avg,
+                        MIN(CASE WHEN {snr_valid_sql("p.snr")} THEN CAST(p.snr AS FLOAT) END) as snr_min,
+                        MAX(CASE WHEN {snr_valid_sql("p.snr")} THEN CAST(p.snr AS FLOAT) END) as snr_max,
                         MIN(p.timestamp) as first_seen,
                         MAX(p.timestamp) as last_seen
                     FROM packet_history p
@@ -2917,24 +2929,6 @@ class NodeRepository:
                     LIMIT ?
                 """
 
-                # Then get individual packet data for chart plotting
-                packets_query = """
-                    SELECT
-                        p.id AS packet_id,
-                        p.timestamp,
-                        p.from_node_id,
-                        p.rssi,
-                        p.snr
-                    FROM packet_history p
-                    WHERE p.gateway_id = ?
-                      AND p.from_node_id IS NOT NULL
-                      AND p.from_node_id != ?
-                      AND p.hop_start IS NOT NULL
-                      AND p.hop_limit IS NOT NULL
-                      AND p.hop_start = p.hop_limit
-                    ORDER BY p.timestamp
-                """
-
                 cursor.execute(stats_query, (gateway_hex_id, node_id, limit))
                 stats_rows = cursor.fetchall()
 
@@ -2945,14 +2939,18 @@ class NodeRepository:
                 ]
 
                 if selected_node_ids:
+                    # Individual packet data for chart plotting; the chart
+                    # autoscales its axes, so null out garbage per field (a row
+                    # with a valid RSSI but missing SNR must still contribute
+                    # its RSSI point).
                     placeholders = ",".join(["?"] * len(selected_node_ids))
                     packets_query = f"""
                         SELECT
                             p.id AS packet_id,
                             p.timestamp,
                             p.from_node_id,
-                            p.rssi,
-                            p.snr
+                            CASE WHEN {rssi_valid_sql("p.rssi")} THEN p.rssi END AS rssi,
+                            CASE WHEN {snr_valid_sql("p.snr")} THEN p.snr END AS snr
                         FROM packet_history p
                         WHERE p.gateway_id = ?
                           AND p.from_node_id IS NOT NULL
@@ -3024,16 +3022,16 @@ class NodeRepository:
                 node_hex_id = f"!{node_id:08x}"
 
                 # First get aggregated statistics per gateway
-                stats_query = """
+                stats_query = f"""
                     SELECT
                         p.gateway_id,
                         COUNT(*) as packet_count,
-                        AVG(CAST(p.rssi AS FLOAT)) as rssi_avg,
-                        MIN(CAST(p.rssi AS FLOAT)) as rssi_min,
-                        MAX(CAST(p.rssi AS FLOAT)) as rssi_max,
-                        AVG(CAST(p.snr AS FLOAT)) as snr_avg,
-                        MIN(CAST(p.snr AS FLOAT)) as snr_min,
-                        MAX(CAST(p.snr AS FLOAT)) as snr_max,
+                        AVG(CASE WHEN {rssi_valid_sql("p.rssi")} THEN CAST(p.rssi AS FLOAT) END) as rssi_avg,
+                        MIN(CASE WHEN {rssi_valid_sql("p.rssi")} THEN CAST(p.rssi AS FLOAT) END) as rssi_min,
+                        MAX(CASE WHEN {rssi_valid_sql("p.rssi")} THEN CAST(p.rssi AS FLOAT) END) as rssi_max,
+                        AVG(CASE WHEN {snr_valid_sql("p.snr")} THEN CAST(p.snr AS FLOAT) END) as snr_avg,
+                        MIN(CASE WHEN {snr_valid_sql("p.snr")} THEN CAST(p.snr AS FLOAT) END) as snr_min,
+                        MAX(CASE WHEN {snr_valid_sql("p.snr")} THEN CAST(p.snr AS FLOAT) END) as snr_max,
                         MIN(p.timestamp) as first_seen,
                         MAX(p.timestamp) as last_seen
                     FROM packet_history p
@@ -3048,14 +3046,17 @@ class NodeRepository:
                     LIMIT ?
                 """
 
-                # Then get individual packet data for chart plotting
-                packets_query = """
+                # Then get individual packet data for chart plotting; the chart
+                # autoscales its axes, so null out garbage per field (a row with
+                # a valid RSSI but missing SNR must still contribute its RSSI
+                # point).
+                packets_query = f"""
                     SELECT
                         p.id AS packet_id,
                         p.timestamp,
                         p.gateway_id,
-                        p.rssi,
-                        p.snr
+                        CASE WHEN {rssi_valid_sql("p.rssi")} THEN p.rssi END AS rssi,
+                        CASE WHEN {snr_valid_sql("p.snr")} THEN p.snr END AS snr
                     FROM packet_history p
                     WHERE p.from_node_id = ?
                       AND p.gateway_id IS NOT NULL
@@ -3517,10 +3518,12 @@ class TracerouteRepository:
                     unique_gateways = list(set(gateway_ids))
 
                     rssi_values = [
-                        p["rssi"] for p in packets_in_group if p["rssi"] is not None
+                        p["rssi"]
+                        for p in packets_in_group
+                        if is_plausible_rssi(p["rssi"])
                     ]
                     snr_values = [
-                        p["snr"] for p in packets_in_group if p["snr"] is not None
+                        p["snr"] for p in packets_in_group if is_plausible_snr(p["snr"])
                     ]
                     hop_values = []
                     for p in packets_in_group:

--- a/src/malla/mqtt_capture.py
+++ b/src/malla/mqtt_capture.py
@@ -732,6 +732,9 @@ def log_packet_to_database(
     channel_id = (
         getattr(service_envelope, "channel_id", None) if service_envelope else None
     )
+    # Store rx_rssi/rx_snr exactly as parsed, even when a corrupt frame yields
+    # garbage (e.g. rx_rssi -1386841926): packet_history is the faithful raw
+    # record. Read-side aggregates filter with malla.utils.signal_quality.
     rssi = (
         getattr(mesh_packet, "rx_rssi", None)
         if mesh_packet and hasattr(mesh_packet, "rx_rssi")

--- a/src/malla/routes/api_routes.py
+++ b/src/malla/routes/api_routes.py
@@ -29,6 +29,7 @@ from ..utils.node_utils import (
     get_bulk_node_short_names,
 )
 from ..utils.serialization_utils import convert_bytes_to_base64, sanitize_floats
+from ..utils.signal_quality import is_plausible_traceroute_snr
 from ..utils.traceroute_utils import parse_traceroute_payload
 
 logger = logging.getLogger(__name__)
@@ -1170,7 +1171,7 @@ def api_traceroute_link(node1_id, node2_id):
 
                     direction_counts[direction] = direction_counts.get(direction, 0) + 1
 
-                    if target_hop.snr is not None:
+                    if is_plausible_traceroute_snr(target_hop.snr):
                         snr_values.append(target_hop.snr)
 
                     # Create route_hops structure for UI - include ALL RF hops (forward and return)
@@ -1185,7 +1186,11 @@ def api_traceroute_link(node1_id, node2_id):
                                 "to_node_id": hop.to_node_id,
                                 "from_node_name": hop.from_node_name,
                                 "to_node_name": hop.to_node_name,
-                                "snr": hop.snr,
+                                # Null garbage payload SNR so the per-hop rows
+                                # can't display corrupt values as real signal.
+                                "snr": hop.snr
+                                if is_plausible_traceroute_snr(hop.snr)
+                                else None,
                                 "direction": hop.direction,  # Include direction info (forward_rf, return_rf)
                                 "is_target_hop": (
                                     (
@@ -1230,7 +1235,11 @@ def api_traceroute_link(node1_id, node2_id):
                         "to_node_name": tr_packet.to_node_name,
                         "gateway_id": tr_packet.gateway_id,
                         "gateway_node_name": gateway_node_name,
-                        "hop_snr": target_hop.snr,
+                        # Null out garbage SNR so the SNR-over-time chart
+                        # (which autoscales over hop_snr) can't be flattened.
+                        "hop_snr": target_hop.snr
+                        if is_plausible_traceroute_snr(target_hop.snr)
+                        else None,
                         "route_hops": route_hops,
                         "complete_path_display": tr_packet.format_path_display(
                             "display"

--- a/src/malla/services/analytics_service.py
+++ b/src/malla/services/analytics_service.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from ..database.repositories import NodeRepository
+from ..utils.signal_quality import rssi_valid_sql, snr_valid_sql
 
 logger = logging.getLogger(__name__)
 
@@ -272,24 +273,32 @@ class AnalyticsService:
         conn = get_db_connection()
         cursor = conn.cursor()
 
-        # Get signal statistics using SQL aggregation
+        # Get signal statistics using SQL aggregation. Every branch restricts
+        # itself to plausible values: without the guard a single garbage row
+        # (rx_rssi like -1386841926 from a corrupt frame) poisons the average,
+        # and the rssi=0 "not provided" sentinel would count as "excellent".
         cursor.execute(
             f"""
             SELECT
-                AVG(CASE WHEN rssi IS NOT NULL AND rssi != 0 THEN rssi END) as avg_rssi,
-                AVG(CASE WHEN snr IS NOT NULL THEN snr END) as avg_snr,
-                COUNT(CASE WHEN rssi IS NOT NULL AND rssi != 0 THEN 1 END) as rssi_count,
-                COUNT(CASE WHEN snr IS NOT NULL THEN 1 END) as snr_count,
+                AVG(CASE WHEN {rssi_valid_sql()} THEN rssi END) as avg_rssi,
+                AVG(CASE WHEN {snr_valid_sql()} THEN snr END) as avg_snr,
+                COUNT(CASE WHEN {rssi_valid_sql()} THEN 1 END) as rssi_count,
+                COUNT(CASE WHEN {snr_valid_sql()} THEN 1 END) as snr_count,
                 -- RSSI distribution
-                SUM(CASE WHEN rssi > -70 THEN 1 ELSE 0 END) as rssi_excellent,
-                SUM(CASE WHEN rssi > -80 AND rssi <= -70 THEN 1 ELSE 0 END) as rssi_good,
-                SUM(CASE WHEN rssi > -90 AND rssi <= -80 THEN 1 ELSE 0 END) as rssi_fair,
-                SUM(CASE WHEN rssi <= -90 THEN 1 ELSE 0 END) as rssi_poor,
+                SUM(CASE WHEN {rssi_valid_sql()} AND rssi > -70 THEN 1 ELSE 0 END) as rssi_excellent,
+                SUM(CASE WHEN {rssi_valid_sql()} AND rssi > -80 AND rssi <= -70 THEN 1 ELSE 0 END) as rssi_good,
+                SUM(CASE WHEN {rssi_valid_sql()} AND rssi > -90 AND rssi <= -80 THEN 1 ELSE 0 END) as rssi_fair,
+                SUM(CASE WHEN {rssi_valid_sql()} AND rssi <= -90 THEN 1 ELSE 0 END) as rssi_poor,
                 -- SNR distribution
-                SUM(CASE WHEN snr > 10 THEN 1 ELSE 0 END) as snr_excellent,
-                SUM(CASE WHEN snr > 5 AND snr <= 10 THEN 1 ELSE 0 END) as snr_good,
-                SUM(CASE WHEN snr > 0 AND snr <= 5 THEN 1 ELSE 0 END) as snr_fair,
-                SUM(CASE WHEN snr <= 0 THEN 1 ELSE 0 END) as snr_poor
+                SUM(CASE WHEN {snr_valid_sql()} AND snr > 10 THEN 1 ELSE 0 END) as snr_excellent,
+                SUM(CASE WHEN {snr_valid_sql()} AND snr > 5 AND snr <= 10 THEN 1 ELSE 0 END) as snr_good,
+                SUM(CASE WHEN {snr_valid_sql()} AND snr > 0 AND snr <= 5 THEN 1 ELSE 0 END) as snr_fair,
+                SUM(CASE WHEN {snr_valid_sql()} AND snr <= 0 THEN 1 ELSE 0 END) as snr_poor,
+                -- SNR average over RF receptions only (rows with a real RSSI):
+                -- gateway self-uplinks store snr=0 "not provided", which would
+                -- otherwise pile a fake spike at 0 in the histogram panel.
+                AVG(CASE WHEN {snr_valid_sql()} AND {rssi_valid_sql()}
+                    THEN snr END) as rf_avg_snr
             FROM packet_history
             WHERE {where_clause}
         """,
@@ -297,6 +306,50 @@ class AnalyticsService:
         )
 
         row = cursor.fetchone()
+
+        # Fine-grained histograms so the dashboard panel shows the real
+        # distribution shape instead of four coarse buckets. Bin edges align
+        # to clean values via a fixed origin; the SNR histogram counts RF
+        # receptions only (rows with a real RSSI) so the snr=0 "not provided"
+        # sentinel can't pile a fake spike at 0.
+        # Receptions at or above -60 dBm are all "node sitting next to the
+        # gateway" — a sparse, meaningless long tail if binned individually —
+        # so the last bin accumulates everything above that threshold and the
+        # main body keeps its horizontal resolution. Symmetrically, readings
+        # below -130 dBm sit at/under the LoRa sensitivity floor (0.03% of
+        # traffic, quantization noise like -141): the first bin accumulates
+        # them so the axis doesn't jitter with each stray reading.
+        rssi_overflow_start = -60
+        rssi_underflow_end = -130
+        overflow_bin = (rssi_overflow_start - (-150)) // 5
+        underflow_bin = (rssi_underflow_end - (-150)) // 5 - 1
+        cursor.execute(
+            f"""
+            SELECT MIN(MAX(CAST((rssi + 150) / 5 AS INTEGER), ?), ?) AS bin,
+                   COUNT(*) AS count
+            FROM packet_history
+            WHERE {where_clause} AND {rssi_valid_sql()}
+            GROUP BY bin
+            """,
+            [underflow_bin, overflow_bin, *params],
+        )
+        rssi_bins = AnalyticsService._zero_filled_bins(
+            cursor.fetchall(), origin=-150, width=5
+        )
+
+        cursor.execute(
+            f"""
+            SELECT CAST((snr + 30.0) / 2 AS INTEGER) AS bin, COUNT(*) AS count
+            FROM packet_history
+            WHERE {where_clause} AND {snr_valid_sql()} AND {rssi_valid_sql()}
+            GROUP BY bin
+            """,
+            params,
+        )
+        snr_bins = AnalyticsService._zero_filled_bins(
+            cursor.fetchall(), origin=-30, width=2
+        )
+
         conn.close()
 
         if not row or (row["rssi_count"] == 0 and row["snr_count"] == 0):
@@ -305,6 +358,13 @@ class AnalyticsService:
                 "avg_snr": None,
                 "rssi_distribution": {},
                 "snr_distribution": {},
+                "rssi_histogram": {
+                    "bin_width": 5,
+                    "bins": [],
+                    "overflow_start": rssi_overflow_start,
+                    "underflow_end": rssi_underflow_end,
+                },
+                "snr_histogram": {"bin_width": 2, "bins": [], "rf_avg_snr": None},
                 "total_measurements": 0,
             }
 
@@ -327,8 +387,40 @@ class AnalyticsService:
             "avg_snr": round(row["avg_snr"], 2) if row["avg_snr"] else None,
             "rssi_distribution": rssi_distribution,
             "snr_distribution": snr_distribution,
+            "rssi_histogram": {
+                "bin_width": 5,
+                "bins": rssi_bins,
+                "overflow_start": rssi_overflow_start,
+                "underflow_end": rssi_underflow_end,
+            },
+            "snr_histogram": {
+                "bin_width": 2,
+                "bins": snr_bins,
+                "rf_avg_snr": round(row["rf_avg_snr"], 2)
+                if row["rf_avg_snr"] is not None
+                else None,
+            },
             "total_measurements": max(row["rssi_count"] or 0, row["snr_count"] or 0),
         }
+
+    @staticmethod
+    def _zero_filled_bins(
+        rows: Any, origin: float, width: float
+    ) -> list[dict[str, Any]]:
+        """Convert GROUP BY bin rows into a dense [{start, count}] list.
+
+        Bins are indexed from ``origin`` in steps of ``width``; gaps between
+        the lowest and highest observed bins are zero-filled so the histogram
+        keeps honest holes instead of collapsing them.
+        """
+        counts = {int(r["bin"]): r["count"] for r in rows}
+        if not counts:
+            return []
+        lo, hi = min(counts), max(counts)
+        return [
+            {"start": origin + b * width, "count": counts.get(b, 0)}
+            for b in range(lo, hi + 1)
+        ]
 
     @staticmethod
     def _get_temporal_patterns(filters: dict, since_timestamp: float) -> dict[str, Any]:
@@ -793,9 +885,10 @@ class AnalyticsService:
 
         where_conditions: list[str] = [
             "timestamp >= ?",
-            "hop_start IS NOT NULL",
-            "hop_limit IS NOT NULL",
-            # Guard against malformed packets reporting negative hop counts.
+            # Meshtastic hop fields are 3-bit (0..7); corrupt frames report
+            # values like 173, and negative diffs are malformed too.
+            "hop_start BETWEEN 0 AND 7",
+            "hop_limit BETWEEN 0 AND 7",
             "hop_start >= hop_limit",
         ]
         params: list[Any] = [since_timestamp]

--- a/src/malla/services/gateway_service.py
+++ b/src/malla/services/gateway_service.py
@@ -13,6 +13,7 @@ from typing import Any
 from ..database.connection import get_db_connection
 from ..database.repositories import PacketRepository
 from ..utils.node_utils import get_bulk_node_names
+from ..utils.signal_quality import rssi_valid_sql, snr_valid_sql
 
 logger = logging.getLogger(__name__)
 
@@ -74,13 +75,13 @@ class GatewayService:
 
             # Get gateway distribution (top 20)
             cursor.execute(
-                """
+                f"""
                 SELECT
                     gateway_id,
                     COUNT(*) as packet_count,
                     COUNT(DISTINCT from_node_id) as unique_sources,
-                    AVG(CAST(rssi AS FLOAT)) as avg_rssi,
-                    AVG(CAST(snr AS FLOAT)) as avg_snr,
+                    AVG(CASE WHEN {rssi_valid_sql()} THEN CAST(rssi AS FLOAT) END) as avg_rssi,
+                    AVG(CASE WHEN {snr_valid_sql()} THEN CAST(snr AS FLOAT) END) as avg_snr,
                     MAX(timestamp) as last_seen
                 FROM packet_history
                 WHERE gateway_id IS NOT NULL

--- a/src/malla/services/location_service.py
+++ b/src/malla/services/location_service.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from ..database.repositories import LocationRepository
+from ..utils.signal_quality import rssi_valid_sql, snr_valid_sql
 
 logger = logging.getLogger(__name__)
 
@@ -948,8 +949,8 @@ class LocationService:
                     from_node_id,
                     gateway_id,
                     COUNT(*)               AS packet_count,
-                    AVG(rssi) AS avg_rssi,
-                    AVG(snr) AS avg_snr,
+                    AVG(CASE WHEN {rssi_valid_sql()} THEN rssi END) AS avg_rssi,
+                    AVG(CASE WHEN {snr_valid_sql()} THEN snr END) AS avg_snr,
                     MAX(timestamp)         AS last_seen
                 FROM packet_history
                 {where_sql}

--- a/src/malla/services/traceroute_service.py
+++ b/src/malla/services/traceroute_service.py
@@ -23,6 +23,7 @@ from ..models.traceroute import (
     TraceroutePacket,  # Use the correct TraceroutePacket class
 )
 from ..utils.node_utils import get_bulk_node_names
+from ..utils.signal_quality import is_plausible_traceroute_snr
 from ..utils.traceroute_utils import parse_traceroute_payload
 
 logger = logging.getLogger(__name__)
@@ -686,7 +687,7 @@ class TracerouteService:
                         for hop in rf_hops:
                             # Early filtering: skip hops that won't meet criteria
                             if (
-                                hop.snr is None
+                                not is_plausible_traceroute_snr(hop.snr)
                                 or hop.snr == 0
                                 or hop.snr < min_snr
                                 or not hop.distance_km
@@ -762,9 +763,11 @@ class TracerouteService:
                             if path_distance_km < min_distance_km:
                                 pass  # too short – ignore
                             else:
-                                # Average SNR across hops (ignore None values)
+                                # Average SNR across hops (ignore missing/garbage values)
                                 valid_snrs = [
-                                    h.snr for h in rf_hops if h.snr is not None
+                                    h.snr
+                                    for h in rf_hops
+                                    if is_plausible_traceroute_snr(h.snr)
                                 ]
                                 avg_path_snr = (
                                     (sum(valid_snrs) / len(valid_snrs))
@@ -1109,8 +1112,10 @@ class TracerouteService:
 
                     # Process direct RF links
                     for hop in rf_hops:
-                        # Filter by SNR - if min_snr is -200, it means "no limit" so only filter None values
-                        if hop.snr is None or (min_snr != -200 and hop.snr < min_snr):
+                        # Filter by SNR - if min_snr is -200, it means "no limit" so only filter missing/garbage values
+                        if not is_plausible_traceroute_snr(hop.snr) or (
+                            min_snr != -200 and hop.snr < min_snr
+                        ):
                             stats["links_filtered_by_snr"] += 1
                             continue
                         # filter 0db links (MQTT or UDP)
@@ -1182,15 +1187,19 @@ class TracerouteService:
                         # Only add if it's not already a direct link
                         if indirect_key not in direct_links:
                             if indirect_key not in indirect_connections:
+                                path_snrs = [
+                                    h.snr
+                                    for h in rf_hops
+                                    if h.snr and is_plausible_traceroute_snr(h.snr)
+                                ]
                                 indirect_connections[indirect_key] = {
                                     "source": indirect_key[0],
                                     "target": indirect_key[1],
                                     "hop_count": len(rf_hops),
                                     "path_count": 1,
-                                    "avg_snr": sum(
-                                        hop.snr for hop in rf_hops if hop.snr
-                                    )
-                                    / len([h for h in rf_hops if h.snr]),
+                                    "avg_snr": (sum(path_snrs) / len(path_snrs))
+                                    if path_snrs
+                                    else None,
                                     "last_seen": tr_data["timestamp"],
                                     "last_packet_id": tr_data["id"],
                                 }

--- a/src/malla/templates/dashboard.html
+++ b/src/malla/templates/dashboard.html
@@ -263,7 +263,24 @@
                             <span class="visually-hidden">Loading...</span>
                         </div>
                     </div>
-                    <canvas id="signalDistributionChart" style="height: 300px; display: none;"></canvas>
+                    <!-- Two small-multiple histograms sharing one card: real
+                         distribution shape instead of four coarse buckets. -->
+                    <div id="signalDistributionChart" style="display: none;">
+                        <div class="d-flex justify-content-between align-items-baseline">
+                            <span class="small fw-semibold">RSSI</span>
+                            <span id="rssiHistogramCaption" class="small text-body-secondary"></span>
+                        </div>
+                        <div style="height: 120px;">
+                            <canvas id="rssiHistogramChart"></canvas>
+                        </div>
+                        <div class="d-flex justify-content-between align-items-baseline mt-2">
+                            <span class="small fw-semibold">SNR</span>
+                            <span id="snrHistogramCaption" class="small text-body-secondary"></span>
+                        </div>
+                        <div style="height: 120px;">
+                            <canvas id="snrHistogramChart"></canvas>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -283,7 +300,17 @@
                             <span class="visually-hidden">Loading...</span>
                         </div>
                     </div>
-                    <canvas id="hopDistributionChart" style="height: 300px; display: none;"></canvas>
+                    <!-- Ordered hop-count columns (0..7): the doughnut hid the
+                         order and buried everything past 2 hops in one slice. -->
+                    <div id="hopDistributionChart" style="display: none;">
+                        <div class="d-flex justify-content-between align-items-baseline">
+                            <span class="small fw-semibold">Hops to gateway</span>
+                            <span id="hopDistributionCaption" class="small text-body-secondary"></span>
+                        </div>
+                        <div style="height: 272px;">
+                            <canvas id="hopDistributionCanvas"></canvas>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -908,63 +935,260 @@ function createGatewayActivityChart(gatewayData) {
     });
 }
 
+// Two small-multiple histograms (RSSI/SNR as measured at the reporting
+// gateway) replace the old four-bucket bars: fine 5 dB / 2 dB bins show the
+// actual distribution shape, gaps included.
 function createSignalDistributionChart(signalData) {
-    if (!signalData || !signalData.rssi_distribution) return;
+    if (!signalData) return;
 
     hideLoadingSpinner('signalDistributionChart');
-    const ctx = document.getElementById('signalDistributionChart');
-    if (!ctx) return;
 
-    const rssiDist = signalData.rssi_distribution;
-    const colors = getChartColors();
-    const options = getDefaultChartOptions();
-
-    chartInstances.signalDistributionChart = new Chart(ctx, {
-        type: 'bar',
-        data: {
-            labels: ['Excellent (>-70dBm)', 'Good (-70 to -80dBm)', 'Fair (-80 to -90dBm)', 'Poor (<-90dBm)'],
-            datasets: [{
-                label: 'Signal Quality Distribution',
-                data: [rssiDist.excellent || 0, rssiDist.good || 0, rssiDist.fair || 0, rssiDist.poor || 0],
-                backgroundColor: [colors.success, colors.warning, colors.info, colors.danger]
-            }]
-        },
-        options: options
+    createHistogramChart('rssiHistogramChart', signalData.rssi_histogram, {
+        unit: 'dBm',
+        tickEvery: 20,
+        captionId: 'rssiHistogramCaption',
+        avg: signalData.avg_rssi,
+        quality: { good: -70, bad: -125 },
+    });
+    createHistogramChart('snrHistogramChart', signalData.snr_histogram, {
+        unit: 'dB',
+        tickEvery: 8,
+        captionId: 'snrHistogramCaption',
+        avg: signalData.snr_histogram ? signalData.snr_histogram.rf_avg_snr : null,
+        quality: { good: 5, bad: -15 },
     });
 }
 
-function createHopDistributionChart(hopDistribution) {
-    hideLoadingSpinner('hopDistributionChart');
-    const ctx = document.getElementById('hopDistributionChart');
-    if (!ctx) return;
-    if (!hopDistribution || hopDistribution.length === 0) return;
+// Per-bar signal-quality ramp: theme success → warning → danger, using the
+// same good/bad semantics as the quality badges elsewhere in the UI. The
+// x-axis already encodes the value, so color is a redundant cue (the chart
+// stays readable under color-vision deficiency via position alone).
+function parseCssColor(str) {
+    if (!str) return null;
+    str = str.trim();
+    let m = str.match(/^#([0-9a-f]{3})$/i);
+    if (m) return m[1].split('').map(c => parseInt(c + c, 16));
+    m = str.match(/^#([0-9a-f]{6})$/i);
+    if (m) return [0, 2, 4].map(i => parseInt(m[1].slice(i, i + 2), 16));
+    m = str.match(/^rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)/i);
+    if (m) return [+m[1], +m[2], +m[3]];
+    return null;
+}
 
+// Mix in linear light so the green→amber→red midpoints stay vivid instead
+// of dipping through dark olive.
+function mixRgb(c1, c2, t) {
+    const ch = (i) => {
+        const a = Math.pow(c1[i] / 255, 2.2);
+        const b = Math.pow(c2[i] / 255, 2.2);
+        return Math.round(255 * Math.pow(a + (b - a) * t, 1 / 2.2));
+    };
+    return `rgb(${ch(0)}, ${ch(1)}, ${ch(2)})`;
+}
+
+function createHistogramChart(canvasId, histogram, opts) {
+    const ctx = document.getElementById(canvasId);
+    if (!ctx) return;
+
+    if (chartInstances[canvasId]) {
+        chartInstances[canvasId].destroy();
+        delete chartInstances[canvasId];
+    }
+
+    const bins = (histogram && histogram.bins) || [];
+    const total = bins.reduce((sum, b) => sum + b.count, 0);
     const colors = getChartColors();
 
-    // Real hop counts (hop_start - hop_limit) over the last 24h, bucketed
-    // into direct / 1 / 2 / 3+ hops.
-    const totals = [0, 0, 0, 0];
-    hopDistribution.forEach(d => {
-        totals[Math.min(d.hops, 3)] += d.count;
+    const caption = document.getElementById(opts.captionId);
+    if (caption) {
+        caption.textContent = (total > 0 && opts.avg !== null && opts.avg !== undefined)
+            ? `avg ${opts.avg.toFixed(1)} ${opts.unit} · ${total.toLocaleString()} pkts`
+            : 'no data';
+    }
+    if (!bins.length) return;
+
+    const width = histogram.bin_width;
+    // The edge bins may be accumulators: everything above overflow_start
+    // (RSSI ≥ -60 dBm: co-located nodes) and everything below underflow_end
+    // (RSSI < -130 dBm: stray sub-sensitivity readings) collapse into one
+    // bar each, so the main body keeps its resolution and a stable axis.
+    const overflowStart = histogram.overflow_start;
+    const underflowEnd = histogram.underflow_end;
+    const isOverflowBin = (index) =>
+        overflowStart !== undefined && bins[index].start === overflowStart;
+    const isUnderflowBin = (index) =>
+        underflowEnd !== undefined && bins[index].start === underflowEnd - width;
+
+    // Color each bar by where its bin center sits on the good→bad scale.
+    // Full success at the "Excellent" boundary the badges use (RSSI -70 dBm /
+    // SNR +5 dB), full danger near the LoRa demodulation floor (-125 dBm /
+    // -15 dB), warning halfway; accumulator bins clamp to the nearest end.
+    const ramp = [colors.success, colors.warning, colors.danger].map(parseCssColor);
+    const rampOk = opts.quality && ramp.every(Boolean);
+    const barColors = bins.map((b) => {
+        if (!rampOk) return colors.primary;
+        const q = opts.quality;
+        const t = Math.min(1, Math.max(0,
+            (q.good - (b.start + width / 2)) / (q.good - q.bad)));
+        return t < 0.5
+            ? mixRgb(ramp[0], ramp[1], t * 2)
+            : mixRgb(ramp[1], ramp[2], (t - 0.5) * 2);
     });
 
-    chartInstances.hopDistributionChart = new Chart(ctx, {
-        type: 'doughnut',
+    chartInstances[canvasId] = new Chart(ctx, {
+        type: 'bar',
         data: {
-            labels: ['Direct (0 hops)', '1 hop', '2 hops', '3+ hops'],
+            labels: bins.map(b => b.start),
             datasets: [{
-                data: totals,
-                backgroundColor: [colors.success, colors.info, colors.warning, colors.danger]
+                data: bins.map(b => b.count),
+                backgroundColor: barColors,
+                borderRadius: { topLeft: 3, topRight: 3 },
+                borderSkipped: 'bottom',
+                categoryPercentage: 1.0,
+                barPercentage: 0.9
             }]
         },
         options: {
             responsive: true,
             maintainAspectRatio: false,
             plugins: {
-                legend: {
-                    position: 'bottom',
-                    labels: {
-                        color: colors.textColor
+                legend: { display: false },
+                tooltip: {
+                    callbacks: {
+                        title: (items) => {
+                            const start = bins[items[0].dataIndex].start;
+                            if (isOverflowBin(items[0].dataIndex)) {
+                                return `${start} ${opts.unit} and above`;
+                            }
+                            if (isUnderflowBin(items[0].dataIndex)) {
+                                return `below ${start + width} ${opts.unit}`;
+                            }
+                            return `${start} to ${start + width} ${opts.unit}`;
+                        },
+                        label: (item) => {
+                            const count = bins[item.dataIndex].count;
+                            const pct = total ? (100 * count / total).toFixed(1) : '0';
+                            return `${count.toLocaleString()} packets (${pct}%)`;
+                        }
+                    }
+                }
+            },
+            scales: {
+                x: {
+                    grid: { display: false },
+                    ticks: {
+                        color: colors.mutedTextColor,
+                        maxRotation: 0,
+                        autoSkip: false,
+                        // Label only clean bin edges (every 20 dBm / 8 dB —
+                        // the card is narrow at every breakpoint) plus the
+                        // overflow accumulator; the tooltip carries the
+                        // exact per-bin ranges.
+                        callback: function (value, index) {
+                            const start = bins[index].start;
+                            if (isOverflowBin(index)) return '≥' + start;
+                            if (isUnderflowBin(index)) return '<' + (start + width);
+                            return start % opts.tickEvery === 0 ? start : '';
+                        }
+                    }
+                },
+                y: {
+                    beginAtZero: true,
+                    grid: { color: colors.gridColor },
+                    border: { display: false },
+                    ticks: {
+                        color: colors.mutedTextColor,
+                        maxTicksLimit: 4,
+                        precision: 0
+                    }
+                }
+            }
+        }
+    });
+}
+
+// Real hop counts (hop_start - hop_limit) over the last 24h as an ordered
+// column chart. The old doughnut lost the ordering and collapsed everything
+// past 2 hops into a single "3+" slice, which on this network hid ~78% of
+// the traffic; the full 0..7 spread is the actual routing story.
+function createHopDistributionChart(hopDistribution) {
+    hideLoadingSpinner('hopDistributionChart');
+    const ctx = document.getElementById('hopDistributionCanvas');
+    if (!ctx) return;
+    if (!hopDistribution || hopDistribution.length === 0) return;
+
+    if (chartInstances.hopDistributionChart) {
+        chartInstances.hopDistributionChart.destroy();
+        delete chartInstances.hopDistributionChart;
+    }
+
+    const colors = getChartColors();
+
+    // Dense 0..N axis (Meshtastic hop fields are 3-bit, so N <= 7);
+    // zero-fill so absent hop counts keep their slot.
+    const byHops = new Map(hopDistribution.map(d => [d.hops, d.count]));
+    const maxHops = Math.max(...byHops.keys(), 3);
+    const hops = [];
+    for (let h = 0; h <= maxHops; h++) {
+        hops.push({ hops: h, count: byHops.get(h) || 0 });
+    }
+
+    const total = hops.reduce((sum, d) => sum + d.count, 0);
+    const direct = byHops.get(0) || 0;
+    const avgHops = total
+        ? hops.reduce((sum, d) => sum + d.hops * d.count, 0) / total
+        : 0;
+
+    const caption = document.getElementById('hopDistributionCaption');
+    if (caption && total) {
+        caption.textContent =
+            `direct ${(100 * direct / total).toFixed(1)}% · avg ${avgHops.toFixed(1)} hops · ${total.toLocaleString()} pkts`;
+    }
+
+    chartInstances.hopDistributionChart = new Chart(ctx, {
+        type: 'bar',
+        data: {
+            labels: hops.map(d => d.hops === 0 ? 'direct' : String(d.hops)),
+            datasets: [{
+                data: hops.map(d => d.count),
+                backgroundColor: colors.primary,
+                borderRadius: { topLeft: 3, topRight: 3 },
+                borderSkipped: 'bottom',
+                maxBarThickness: 24
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: { display: false },
+                tooltip: {
+                    callbacks: {
+                        title: (items) => {
+                            const h = hops[items[0].dataIndex].hops;
+                            return h === 0 ? 'Direct (0 hops)' : `${h} hop${h > 1 ? 's' : ''}`;
+                        },
+                        label: (item) => {
+                            const count = hops[item.dataIndex].count;
+                            const pct = total ? (100 * count / total).toFixed(1) : '0';
+                            return `${count.toLocaleString()} packets (${pct}%)`;
+                        }
+                    }
+                }
+            },
+            scales: {
+                x: {
+                    grid: { display: false },
+                    ticks: { color: colors.mutedTextColor, maxRotation: 0 }
+                },
+                y: {
+                    beginAtZero: true,
+                    grid: { color: colors.gridColor },
+                    border: { display: false },
+                    ticks: {
+                        color: colors.mutedTextColor,
+                        maxTicksLimit: 5,
+                        precision: 0
                     }
                 }
             }

--- a/src/malla/utils/signal_quality.py
+++ b/src/malla/utils/signal_quality.py
@@ -1,0 +1,76 @@
+"""Plausibility bounds for LoRa signal metrics (RSSI/SNR).
+
+Corrupt gateway frames occasionally survive protobuf parsing and land in
+packet_history with garbage signal values (rx_rssi like -1386841926, rx_snr
+like 2.8e-36). A single such row is enough to drag an unguarded AVG(rssi)
+to five-digit nonsense. packet_history deliberately stores whatever the
+frame contained — it is the faithful raw record — so every read-side
+aggregate over these columns must restrict itself to the plausible LoRa
+range using the predicates below.
+
+Conventions shared with Meshtastic firmware:
+- rssi == 0 means "not provided" (e.g. the gateway's own uplinked packets);
+  real LoRa receptions are always negative and above the sensitivity floor.
+- snr is reported in quarter-dB steps within roughly [-20, 15] dB; the
+  bounds here are deliberately generous so no real reception is rejected.
+"""
+
+import math
+from typing import TypeGuard
+
+RSSI_PLAUSIBLE_MIN = -150  # dBm; below any LoRa sensitivity floor (~-137)
+RSSI_PLAUSIBLE_MAX = -1  # dBm; 0 is the "not provided" sentinel, positive is garbage
+SNR_PLAUSIBLE_MIN = -30.0  # dB
+SNR_PLAUSIBLE_MAX = 30.0  # dB
+
+# Traceroute RouteDiscovery payloads encode "SNR unknown" as INT8_MIN (-128),
+# which parse_traceroute_payload scales to -128/4 = -32.0 dB. That sentinel
+# marks a real hop whose SNR simply wasn't recorded, so traceroute-payload
+# consumers must not reclassify it as garbage.
+TRACEROUTE_UNKNOWN_SNR = -32.0
+
+
+def rssi_valid_sql(column: str = "rssi") -> str:
+    """SQL predicate matching plausible RSSI values.
+
+    NULL and the 0 "not provided" sentinel both fail the predicate, so this
+    subsumes the older ``rssi IS NOT NULL AND rssi != 0`` guards.
+    """
+    return f"{column} BETWEEN {RSSI_PLAUSIBLE_MIN} AND {RSSI_PLAUSIBLE_MAX}"
+
+
+def snr_valid_sql(column: str = "snr") -> str:
+    """SQL predicate matching plausible SNR values (NULL fails it)."""
+    return f"{column} BETWEEN {SNR_PLAUSIBLE_MIN} AND {SNR_PLAUSIBLE_MAX}"
+
+
+def is_plausible_rssi(value: float | int | None) -> bool:
+    """True when ``value`` is a real reception RSSI (0 sentinel excluded)."""
+    return (
+        value is not None
+        and math.isfinite(value)
+        and RSSI_PLAUSIBLE_MIN <= value <= RSSI_PLAUSIBLE_MAX
+    )
+
+
+def is_plausible_snr(value: float | int | None) -> bool:
+    """True when ``value`` is a plausible SNR (0.0 is allowed here)."""
+    return (
+        value is not None
+        and math.isfinite(value)
+        and SNR_PLAUSIBLE_MIN <= value <= SNR_PLAUSIBLE_MAX
+    )
+
+
+def is_plausible_traceroute_snr(value: float | int | None) -> TypeGuard[float]:
+    """True for plausible traceroute hop SNR, including the -32.0 "unknown" sentinel.
+
+    Use this (not :func:`is_plausible_snr`) when filtering SNR values parsed
+    from RouteDiscovery payloads, so hops whose SNR wasn't recorded keep
+    appearing in graphs exactly as they did before the plausibility guards.
+    The ``TypeGuard`` return type lets callers use a passing value as a plain
+    ``float`` without re-checking for ``None``.
+    """
+    return value is not None and (
+        value == TRACEROUTE_UNKNOWN_SNR or is_plausible_snr(value)
+    )

--- a/src/malla/utils/traceroute_graph.py
+++ b/src/malla/utils/traceroute_graph.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from ..models.traceroute import TraceroutePacket
 from .node_utils import get_bulk_node_names
+from .signal_quality import is_plausible_traceroute_snr
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +99,9 @@ def build_combined_traceroute_graph(packets: list[dict[str, Any]]) -> dict[str, 
             "gateway_node_id": gateway_node_id,
             "timestamp": pkt.get("timestamp"),
             "mesh_packet_id": pkt.get("mesh_packet_id"),
-            "snr_values": [hop.snr for hop in rf_hops if hop.snr is not None],
+            "snr_values": [
+                hop.snr for hop in rf_hops if is_plausible_traceroute_snr(hop.snr)
+            ],
         }
 
         # Collect nodes from RF hops only (what physically happened on air)
@@ -113,7 +116,7 @@ def build_combined_traceroute_graph(packets: list[dict[str, Any]]) -> dict[str, 
             edge_stats[undirected_key]["packet_ids"].append(packet_id)
             edge_stats[undirected_key]["directions"].append([n1, n2])
             edge_stats[undirected_key]["paths"].add(packet_id)
-            if hop.snr is not None:
+            if is_plausible_traceroute_snr(hop.snr):
                 edge_stats[undirected_key]["snr_values"].append(hop.snr)
 
     # Get node names for all nodes (RF nodes + gateway nodes)

--- a/tests/unit/test_network_coverage_stats.py
+++ b/tests/unit/test_network_coverage_stats.py
@@ -203,15 +203,18 @@ def test_timeline_24h_hourly_buckets(temp_database, monkeypatch):
     AnalyticsService._TIMELINE_CACHE.clear()
 
     now = time.time()
+    # Clamp into the current hour: a plain ``now - 60`` lands in the previous
+    # hour's bucket when the test runs within the first minute of an hour.
+    ts_current_hour = max(now - 60, (int(now) // HOUR) * HOUR + 1)
     _reset_data(
         temp_database,
         packets=[
-            (now - 60, 1, "!gw1", 3, 3),  # current hour
+            (ts_current_hour, 1, "!gw1", 3, 3),  # current hour
             (now - 5 * HOUR, 2, "!gw1", 3, 3),
             (now - 5 * HOUR + 30, 2, "!gw1", 3, 3),
             (now - 30 * HOUR, 3, "!gw1", 3, 3),  # outside the window
         ],
-        nodes=[(1, now - 60, now)],
+        nodes=[(1, ts_current_hour, now)],
     )
 
     timeline = AnalyticsService.get_activity_timeline("24h", 0)
@@ -322,6 +325,7 @@ def test_hop_distribution_counts_real_hops(temp_database, monkeypatch):
             (now - HOUR, 3, "!gw1", 5, 2),  # 3 hops
             (now - HOUR, 4, "!gw1", 2, 3),  # malformed (negative), excluded
             (now - HOUR, 5, "!gw1", None, None),  # unknown hops, excluded
+            (now - HOUR, 7, "!gw1", 173, 0),  # corrupt frame (3-bit field), excluded
             (now - 2 * DAY, 6, "!gw1", 3, 3),  # outside 24h window
         ],
         nodes=[(1, now - DAY, now)],

--- a/tests/unit/test_signal_quality_guard.py
+++ b/tests/unit/test_signal_quality_guard.py
@@ -1,0 +1,402 @@
+"""Tests pinning the plausibility guards for RSSI/SNR signal metrics.
+
+Corrupt gateway frames occasionally survive protobuf parsing and land in
+packet_history with garbage signal values (observed in production: rssi
+-1386841926, snr 2.8e-36, from a text frame misparsed as a MeshPacket).
+One such row dragged the dashboard's 24h average RSSI to -29606 dBm.
+These tests pin the fix: packet_history stores whatever the frame
+contained (the faithful raw record — ingest does NOT sanitize), and every
+read-side aggregate ignores implausible values.
+"""
+
+import sqlite3
+import time
+
+import malla.database.repositories as repositories
+from malla.database.repositories import DashboardRepository
+from malla.services.analytics_service import AnalyticsService
+from malla.utils.signal_quality import (
+    TRACEROUTE_UNKNOWN_SNR,
+    is_plausible_rssi,
+    is_plausible_snr,
+    is_plausible_traceroute_snr,
+    rssi_valid_sql,
+    snr_valid_sql,
+)
+
+HOUR = 3600
+
+# The exact garbage values observed in the production database.
+GARBAGE_RSSI = -1386841926
+GARBAGE_SNR = 2.8616148667626044e-36
+
+
+def _insert_packets(db_path: str, rows):
+    """Insert (timestamp, from_node_id, rssi, snr) rows into packet_history."""
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute("DELETE FROM packet_history")
+    cursor.executemany(
+        """INSERT INTO packet_history
+           (timestamp, topic, from_node_id, gateway_id, rssi, snr,
+            processed_successfully)
+           VALUES (?, 'test', ?, '!gw1', ?, ?, 1)""",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+class TestPlausibilityPredicates:
+    def test_real_values_are_plausible(self):
+        assert is_plausible_rssi(-98)
+        assert is_plausible_rssi(-137)
+        assert is_plausible_rssi(-1)
+        assert is_plausible_snr(-21.25)
+        assert is_plausible_snr(15.5)
+        assert is_plausible_snr(0.0)
+
+    def test_sentinels_and_garbage_are_not_plausible_rssi(self):
+        assert not is_plausible_rssi(None)
+        assert not is_plausible_rssi(0)  # "not provided" sentinel
+        assert not is_plausible_rssi(255)
+        assert not is_plausible_rssi(GARBAGE_RSSI)
+        assert not is_plausible_rssi(1070308180)
+        assert not is_plausible_rssi(float("nan"))
+        assert not is_plausible_rssi(float("-inf"))
+
+    def test_garbage_is_not_plausible_snr(self):
+        assert not is_plausible_snr(None)
+        assert not is_plausible_snr(1e9)
+        assert not is_plausible_snr(-1e9)
+        assert not is_plausible_snr(float("nan"))
+        assert not is_plausible_snr(float("inf"))
+
+    def test_traceroute_unknown_snr_sentinel_is_kept(self):
+        """Firmware encodes 'SNR unknown' as -128 (scaled -32.0 dB); traceroute
+        consumers must keep those hops while the column-level predicate stays
+        strict."""
+        assert TRACEROUTE_UNKNOWN_SNR == -32.0
+        assert is_plausible_traceroute_snr(TRACEROUTE_UNKNOWN_SNR)
+        assert is_plausible_traceroute_snr(5.25)
+        assert is_plausible_traceroute_snr(0.0)
+        assert not is_plausible_traceroute_snr(None)
+        assert not is_plausible_traceroute_snr(-1e9)
+        assert not is_plausible_traceroute_snr(3.5e8)
+        assert not is_plausible_snr(TRACEROUTE_UNKNOWN_SNR)
+
+    def test_sql_predicates_match_python_predicates(self):
+        """The SQL fragments must agree with the Python predicates."""
+        conn = sqlite3.connect(":memory:")
+        conn.execute("CREATE TABLE t (rssi INTEGER, snr REAL)")
+        values = [
+            (-98, 5.25),
+            (-150, -30.0),
+            (-1, 30.0),
+            (0, 0.0),
+            (None, None),
+            (GARBAGE_RSSI, GARBAGE_SNR),
+            (1070308180, 1e9),
+            (255, -1e9),
+        ]
+        conn.executemany("INSERT INTO t VALUES (?, ?)", values)
+        for rssi, _snr in values:
+            sql_rssi = conn.execute(
+                f"SELECT COUNT(*) FROM t WHERE {rssi_valid_sql()} AND rssi IS ?",
+                (rssi,),
+            ).fetchone()[0]
+            assert bool(sql_rssi) == is_plausible_rssi(rssi), f"rssi={rssi}"
+        # GARBAGE_SNR (2.8e-36) is within [-30, 30]: numerically harmless,
+        # so the range predicate deliberately lets it through.
+        for _rssi, snr in values:
+            sql_snr = conn.execute(
+                f"SELECT COUNT(*) FROM t WHERE {snr_valid_sql()} AND snr IS ?",
+                (snr,),
+            ).fetchone()[0]
+            assert bool(sql_snr) == is_plausible_snr(snr), f"snr={snr}"
+        conn.close()
+
+
+class TestDashboardStatsGuard:
+    def test_garbage_rssi_does_not_poison_avg(self, temp_database, monkeypatch):
+        """Reproduces the -29606 dBm bug: one garbage row must not move the avg."""
+        monkeypatch.setenv("MALLA_DATABASE_FILE", temp_database)
+        repositories._dashboard_stats_cache.clear()
+
+        now = time.time()
+        _insert_packets(
+            temp_database,
+            [
+                (now - HOUR, 1, -80, 5.0),
+                (now - HOUR, 2, -100, -3.5),
+                (now - HOUR, 3, GARBAGE_RSSI, GARBAGE_SNR),
+                (now - HOUR, 4, 0, 0.0),  # "not provided" sentinel row
+            ],
+        )
+
+        stats = DashboardRepository.get_stats()
+
+        assert stats["avg_rssi"] == -90.0
+        # snr averages over the two real rows plus the 0.0 sentinel and the
+        # in-range garbage denormal (~0): (5.0 - 3.5 + 0 + 0) / 4
+        assert stats["avg_snr"] == round((5.0 - 3.5 + 0.0 + GARBAGE_SNR) / 4, 1)
+
+    def test_all_rows_garbage_yields_zero_avg(self, temp_database, monkeypatch):
+        monkeypatch.setenv("MALLA_DATABASE_FILE", temp_database)
+        repositories._dashboard_stats_cache.clear()
+
+        now = time.time()
+        _insert_packets(temp_database, [(now - HOUR, 1, GARBAGE_RSSI, 1e9)])
+
+        stats = DashboardRepository.get_stats()
+
+        # No valid measurement -> the pre-existing "or 0" fallback applies.
+        assert stats["avg_rssi"] == 0
+        assert stats["avg_snr"] == 0
+
+
+class TestAnalyticsSignalQualityGuard:
+    def test_distribution_excludes_garbage_and_sentinel(
+        self, temp_database, monkeypatch
+    ):
+        """rssi=0 sentinel and garbage rows must not count as 'excellent'."""
+        monkeypatch.setenv("MALLA_DATABASE_FILE", temp_database)
+
+        now = time.time()
+        _insert_packets(
+            temp_database,
+            [
+                (now - HOUR, 1, -65, 12.0),  # excellent
+                (now - HOUR, 2, -95, -2.0),  # poor
+                (now - HOUR, 3, 0, 0.0),  # sentinel: previously "excellent"
+                (now - HOUR, 4, GARBAGE_RSSI, 1e9),  # garbage
+                (now - HOUR, 5, 1070308180, -1e9),  # positive garbage
+            ],
+        )
+
+        stats = AnalyticsService._get_signal_quality_statistics({}, now - 24 * HOUR)
+
+        assert stats["avg_rssi"] == -80.0
+        assert stats["rssi_distribution"] == {
+            "excellent": 1,
+            "good": 0,
+            "fair": 0,
+            "poor": 1,
+        }
+        # snr keeps its existing "0.0 included" semantics: 12.0, -2.0 and the
+        # sentinel 0.0 are counted, the +/-1e9 garbage is not.
+        assert stats["total_measurements"] == 3
+        snr_dist = stats["snr_distribution"]
+        assert snr_dist["excellent"] == 1
+        assert snr_dist["poor"] == 2  # -2.0 and the 0.0 sentinel; garbage excluded
+
+
+class TestSignalHistograms:
+    def test_histograms_bin_and_zero_fill(self, temp_database, monkeypatch):
+        """5 dB RSSI / 2 dB SNR bins, zero-filled gaps, garbage excluded."""
+        monkeypatch.setenv("MALLA_DATABASE_FILE", temp_database)
+
+        now = time.time()
+        _insert_packets(
+            temp_database,
+            [
+                (now - HOUR, 1, -87, 5.5),  # rssi bin -90, snr bin 4
+                (now - HOUR, 2, -86, 5.0),  # rssi bin -90, snr bin 4
+                (now - HOUR, 3, -71, -3.25),  # rssi bin -75, snr bin -4
+                (now - HOUR, 4, 0, 9.0),  # sentinel: excluded from both
+                (now - HOUR, 5, GARBAGE_RSSI, 1e9),  # garbage: excluded
+            ],
+        )
+
+        stats = AnalyticsService._get_signal_quality_statistics({}, now - 24 * HOUR)
+
+        rssi_hist = stats["rssi_histogram"]
+        assert rssi_hist["bin_width"] == 5
+        by_start = {b["start"]: b["count"] for b in rssi_hist["bins"]}
+        assert by_start[-90] == 2
+        assert by_start[-75] == 1
+        # Dense range with zero-filled gaps between the observed extremes.
+        starts = [b["start"] for b in rssi_hist["bins"]]
+        assert starts == list(range(-90, -70, 5))
+        assert by_start[-85] == 0 and by_start[-80] == 0
+
+        snr_hist = stats["snr_histogram"]
+        assert snr_hist["bin_width"] == 2
+        snr_by_start = {b["start"]: b["count"] for b in snr_hist["bins"]}
+        assert snr_by_start[4] == 2
+        assert snr_by_start[-4] == 1
+        assert snr_hist["rf_avg_snr"] == round((5.5 + 5.0 - 3.25) / 3, 2)
+
+    def test_rssi_edge_bins_accumulate_both_tails(self, temp_database, monkeypatch):
+        """>= -60 dBm collapses into one right accumulator, < -130 dBm into one
+        left accumulator, so stray readings can't stretch the axis."""
+        monkeypatch.setenv("MALLA_DATABASE_FILE", temp_database)
+
+        now = time.time()
+        _insert_packets(
+            temp_database,
+            [
+                (now - HOUR, 1, -95, 3.0),
+                (now - HOUR, 2, -58, 8.0),  # already in the [-60,-55) bin
+                (now - HOUR, 3, -30, 9.0),  # co-located node
+                (now - HOUR, 4, -12, 10.0),  # co-located node
+                (now - HOUR, 5, -133, -19.0),  # below sensitivity floor
+                (now - HOUR, 6, -141, -20.0),  # below sensitivity floor
+            ],
+        )
+
+        stats = AnalyticsService._get_signal_quality_statistics({}, now - 24 * HOUR)
+
+        hist = stats["rssi_histogram"]
+        assert hist["overflow_start"] == -60
+        assert hist["underflow_end"] == -130
+        starts = [b["start"] for b in hist["bins"]]
+        # Dense from the underflow accumulator ([-135) = "< -130") through
+        # the overflow accumulator ([-60] = ">= -60"), nothing beyond either.
+        assert starts == list(range(-135, -55, 5))
+        by_start = {b["start"]: b["count"] for b in hist["bins"]}
+        assert by_start[-135] == 2  # both sub-floor readings
+        assert by_start[-60] == 3
+        assert by_start[-95] == 1
+
+    def test_snr_histogram_ignores_snr_only_sentinel_rows(
+        self, temp_database, monkeypatch
+    ):
+        """Rows without a real RSSI (gateway self-uplinks) must not spike at 0."""
+        monkeypatch.setenv("MALLA_DATABASE_FILE", temp_database)
+
+        now = time.time()
+        _insert_packets(
+            temp_database,
+            [(now - HOUR, 1, -80, 7.0)] + [(now - HOUR, n, 0, 0.0) for n in range(50)],
+        )
+
+        stats = AnalyticsService._get_signal_quality_statistics({}, now - 24 * HOUR)
+
+        snr_bins = {b["start"]: b["count"] for b in stats["snr_histogram"]["bins"]}
+        assert snr_bins == {6: 1}
+        assert stats["snr_histogram"]["rf_avg_snr"] == 7.0
+
+    def test_histograms_empty_when_no_valid_measurements(
+        self, temp_database, monkeypatch
+    ):
+        monkeypatch.setenv("MALLA_DATABASE_FILE", temp_database)
+
+        now = time.time()
+        _insert_packets(temp_database, [(now - HOUR, 1, GARBAGE_RSSI, 1e9)])
+
+        stats = AnalyticsService._get_signal_quality_statistics({}, now - 24 * HOUR)
+
+        assert stats["rssi_histogram"]["bins"] == []
+        assert stats["snr_histogram"]["bins"] == []
+        assert stats["snr_histogram"]["rf_avg_snr"] is None
+
+
+class TestIngestStoresRawValues:
+    def test_log_packet_stores_garbage_signal_fields_verbatim(
+        self, tmp_path, monkeypatch
+    ):
+        """packet_history is the faithful raw record: even garbage rx_rssi/rx_snr
+        from a corrupt frame is stored as-is; filtering happens read-side only."""
+        import malla.mqtt_capture as mqtt_capture
+
+        db_path = str(tmp_path / "capture.db")
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            """CREATE TABLE packet_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp REAL, topic TEXT, from_node_id INTEGER,
+                to_node_id INTEGER, portnum INTEGER, portnum_name TEXT,
+                gateway_id TEXT, channel_id TEXT, mesh_packet_id INTEGER,
+                rssi INTEGER, snr REAL, hop_limit INTEGER, hop_start INTEGER,
+                payload_length INTEGER, raw_payload BLOB,
+                processed_successfully INTEGER, via_mqtt INTEGER,
+                want_ack INTEGER, priority INTEGER, delayed INTEGER,
+                channel_index INTEGER, rx_time INTEGER, pki_encrypted INTEGER,
+                next_hop INTEGER, relay_node INTEGER, tx_after INTEGER,
+                message_type TEXT, raw_service_envelope BLOB,
+                parsing_error TEXT
+            )"""
+        )
+        conn.commit()
+        conn.close()
+        monkeypatch.setattr(mqtt_capture, "DATABASE_FILE", db_path)
+
+        class FakeDecoded:
+            portnum = 1
+            payload = b"x"
+
+        class FakeMeshPacket:
+            id = 42
+            hop_limit = 3
+            hop_start = 3
+            rx_rssi = GARBAGE_RSSI
+            rx_snr = 1e9
+            decoded = FakeDecoded()
+
+        setattr(FakeMeshPacket, "from", 123)
+        FakeMeshPacket.to = 456
+
+        mqtt_capture.log_packet_to_database(
+            topic="msh/TW/2/e/LongFast/!deadbeef",
+            service_envelope=None,
+            mesh_packet=FakeMeshPacket(),
+        )
+
+        conn = sqlite3.connect(db_path)
+        rssi, snr = conn.execute("SELECT rssi, snr FROM packet_history").fetchone()
+        conn.close()
+        assert rssi == GARBAGE_RSSI
+        assert snr == 1e9
+
+    def test_log_packet_keeps_real_signal_values(self, tmp_path, monkeypatch):
+        import malla.mqtt_capture as mqtt_capture
+
+        db_path = str(tmp_path / "capture.db")
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            """CREATE TABLE packet_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp REAL, topic TEXT, from_node_id INTEGER,
+                to_node_id INTEGER, portnum INTEGER, portnum_name TEXT,
+                gateway_id TEXT, channel_id TEXT, mesh_packet_id INTEGER,
+                rssi INTEGER, snr REAL, hop_limit INTEGER, hop_start INTEGER,
+                payload_length INTEGER, raw_payload BLOB,
+                processed_successfully INTEGER, via_mqtt INTEGER,
+                want_ack INTEGER, priority INTEGER, delayed INTEGER,
+                channel_index INTEGER, rx_time INTEGER, pki_encrypted INTEGER,
+                next_hop INTEGER, relay_node INTEGER, tx_after INTEGER,
+                message_type TEXT, raw_service_envelope BLOB,
+                parsing_error TEXT
+            )"""
+        )
+        conn.commit()
+        conn.close()
+        monkeypatch.setattr(mqtt_capture, "DATABASE_FILE", db_path)
+
+        class FakeDecoded:
+            portnum = 1
+            payload = b"x"
+
+        class FakeMeshPacket:
+            id = 43
+            hop_limit = 3
+            hop_start = 3
+            rx_rssi = -87
+            rx_snr = 6.75
+            decoded = FakeDecoded()
+
+        setattr(FakeMeshPacket, "from", 123)
+        FakeMeshPacket.to = 456
+
+        mqtt_capture.log_packet_to_database(
+            topic="msh/TW/2/e/LongFast/!deadbeef",
+            service_envelope=None,
+            mesh_packet=FakeMeshPacket(),
+        )
+
+        conn = sqlite3.connect(db_path)
+        rssi, snr = conn.execute("SELECT rssi, snr FROM packet_history").fetchone()
+        conn.close()
+        assert rssi == -87
+        assert snr == 6.75


### PR DESCRIPTION
The Signal Quality panel showed only four coarse RSSI buckets (SNR was never displayed), and the routing doughnut collapsed
everything past 2 hops into a "3+" slice.

  - Ingest now stores rx_rssi/rx_snr verbatim; implausible values (corrupt-frame garbage, 0 sentinels) are filtered read-side
  in every RSSI/SNR aggregate, with tests
  - Real 5 dB / 2 dB histograms with accumulator bins at both ends (>= -60 dBm co-located nodes, < -130 dBm sub-sensitivity
  strays); SNR counts RF receptions only, so the snr=0 "not provided" sentinel no longer piles a fake spike at 0
  - Histogram bars are colored on a good-to-bad quality gradient derived from the theme colors
  - Ordered 0-7 hop-count columns replace the routing doughnut

Running live at https://meshmap.pro
<img width="857" height="840" alt="meshpro_screenshot" src="https://github.com/user-attachments/assets/c0c0cf27-7eff-487e-b77a-2d10ab4a12c4" />

