### PR TITLE
Harden MQTT ingest against untrusted publishers

### DIFF
--- a/src/malla/mqtt_capture.py
+++ b/src/malla/mqtt_capture.py
@@ -99,7 +99,9 @@ logging.basicConfig(
 # largest legitimate ServiceEnvelope observed across 15M+ captured packets is
 # ~1.25 KB, so 4 KB leaves generous headroom while stopping a publisher on the
 # public broker from flooding the DB with oversized blobs (CWE-400/770).
-MAX_MQTT_PAYLOAD_BYTES: int = int(os.environ.get("MALLA_MAX_MQTT_PAYLOAD_BYTES", "4096"))
+MAX_MQTT_PAYLOAD_BYTES: int = int(
+    os.environ.get("MALLA_MAX_MQTT_PAYLOAD_BYTES", "4096")
+)
 
 # Cap the in-memory node cache so a stream of attacker-chosen node/gateway IDs
 # on the public broker cannot grow process memory without bound. Legitimate
@@ -521,9 +523,9 @@ def _evict_stale_node_cache_entries() -> None:
     if overflow < 0:
         return
     drop = overflow + _NODE_CACHE_EVICT_BATCH
-    stale = sorted(
-        node_cache.items(), key=lambda kv: kv[1].get("last_updated", 0.0)
-    )[:drop]
+    stale = sorted(node_cache.items(), key=lambda kv: kv[1].get("last_updated", 0.0))[
+        :drop
+    ]
     for nid, _ in stale:
         node_cache.pop(nid, None)
     logging.info(
@@ -652,7 +654,7 @@ def update_node_cache(
             )
 
             logging.debug(
-                f"Updated existing node in database: {node_id} ({final_hex_id})"
+                f"Updated existing node in database: {node_id} ({_sanitize_for_log(final_hex_id)})"
             )
         else:
             # New node, insert it
@@ -678,7 +680,9 @@ def update_node_cache(
                 ),
             )
 
-            logging.debug(f"Added new node to database: {node_id} ({hex_id})")
+            logging.debug(
+                f"Added new node to database: {node_id} ({_sanitize_for_log(hex_id)})"
+            )
 
         conn.commit()
         conn.close()
@@ -1028,9 +1032,7 @@ def get_node_statistics() -> dict[str, Any]:
         # stall packet ingestion as history grows. This is an upper bound; if row
         # deletion (data retention) is ever enabled it slightly overcounts, which
         # is acceptable for a log line.
-        cursor.execute(
-            "SELECT seq FROM sqlite_sequence WHERE name = 'packet_history'"
-        )
+        cursor.execute("SELECT seq FROM sqlite_sequence WHERE name = 'packet_history'")
         seq_row = cursor.fetchone()
         total_packets = seq_row[0] if seq_row else 0
 
@@ -1128,7 +1130,7 @@ def on_message(client: mqtt.Client, userdata: Any, msg: mqtt.MQTTMessage) -> Non
         topic_parts = msg.topic.split("/")
         if len(topic_parts) >= 4:
             message_type = topic_parts[3]  # Should be 'e', 'c', 'p', etc.
-            logging.debug(f"Message type from topic: {message_type}")
+            logging.debug(f"Message type from topic: {_sanitize_for_log(message_type)}")
     except Exception:
         pass
 
@@ -1178,7 +1180,7 @@ def on_message(client: mqtt.Client, userdata: Any, msg: mqtt.MQTTMessage) -> Non
             # If primary channel decryption failed and we have a channel name, try with channel-specific keys
             if not decryption_successful and channel_name:
                 logging.debug(
-                    f"Primary channel decryption failed, trying channel-specific keys for: {channel_name}"
+                    f"Primary channel decryption failed, trying channel-specific keys for: {_sanitize_for_log(channel_name)}"
                 )
                 decryption_successful = try_decrypt_mesh_packet(
                     mesh_packet,
@@ -1187,7 +1189,7 @@ def on_message(client: mqtt.Client, userdata: Any, msg: mqtt.MQTTMessage) -> Non
 
             if decryption_successful:
                 logging.info(
-                    f"🔓 Successfully decrypted packet from {get_node_display_name(from_node_id_numeric)}"
+                    f"🔓 Successfully decrypted packet from {_sanitize_for_log(get_node_display_name(from_node_id_numeric))}"
                 )
             else:
                 logging.debug(
@@ -1206,9 +1208,11 @@ def on_message(client: mqtt.Client, userdata: Any, msg: mqtt.MQTTMessage) -> Non
         # Process different packet types
         if mesh_packet.decoded.portnum == portnums_pb2.PortNum.TEXT_MESSAGE_APP:
             text_content = mesh_packet.decoded.payload.decode("utf-8", errors="replace")
-            from_node_display = get_node_display_name(from_node_id_numeric)
+            from_node_display = _sanitize_for_log(
+                get_node_display_name(from_node_id_numeric)
+            )
             to_node_display = (
-                get_node_display_name(to_node_id_numeric)
+                _sanitize_for_log(get_node_display_name(to_node_id_numeric))
                 if to_node_id_numeric != 0 and to_node_id_numeric != 0xFFFFFFFF
                 else "Broadcast"
             )
@@ -1237,7 +1241,9 @@ def on_message(client: mqtt.Client, userdata: Any, msg: mqtt.MQTTMessage) -> Non
             lon = position_data.longitude_i / 1e7
             alt = position_data.altitude
 
-            from_node_display = get_node_display_name(from_node_id_numeric)
+            from_node_display = _sanitize_for_log(
+                get_node_display_name(from_node_id_numeric)
+            )
             via_mqtt_str = (
                 " (via MQTT)" if getattr(mesh_packet, "via_mqtt", False) else ""
             )
@@ -1284,12 +1290,14 @@ def on_message(client: mqtt.Client, userdata: Any, msg: mqtt.MQTTMessage) -> Non
                 else None,
             )
 
-            from_node_display = get_node_display_name(from_node_id_numeric)
+            from_node_display = _sanitize_for_log(
+                get_node_display_name(from_node_id_numeric)
+            )
             via_mqtt_str = (
                 " (via MQTT)" if getattr(mesh_packet, "via_mqtt", False) else ""
             )
             logging.info(
-                f"ℹ️ NodeInfo for {node_id_from_payload} from {from_node_display}{via_mqtt_str}: {long_name or short_name or 'No name'}"
+                f"ℹ️ NodeInfo for {_sanitize_for_log(node_id_from_payload)} from {from_node_display}{via_mqtt_str}: {_sanitize_for_log(long_name or short_name or 'No name')}"
             )
             processed_successfully = True
 
@@ -1297,7 +1305,9 @@ def on_message(client: mqtt.Client, userdata: Any, msg: mqtt.MQTTMessage) -> Non
             telemetry_data = telemetry_pb2.Telemetry()
             telemetry_data.ParseFromString(mesh_packet.decoded.payload)
 
-            from_node_display = get_node_display_name(from_node_id_numeric)
+            from_node_display = _sanitize_for_log(
+                get_node_display_name(from_node_id_numeric)
+            )
             via_mqtt_str = (
                 " (via MQTT)" if getattr(mesh_packet, "via_mqtt", False) else ""
             )
@@ -1341,7 +1351,9 @@ def on_message(client: mqtt.Client, userdata: Any, msg: mqtt.MQTTMessage) -> Non
 
         elif mesh_packet.decoded.portnum == portnums_pb2.PortNum.MAP_REPORT_APP:
             # Handle MAP_REPORT_APP packets specifically
-            from_node_display = get_node_display_name(from_node_id_numeric)
+            from_node_display = _sanitize_for_log(
+                get_node_display_name(from_node_id_numeric)
+            )
             via_mqtt_str = (
                 " (via MQTT)" if getattr(mesh_packet, "via_mqtt", False) else ""
             )
@@ -1357,7 +1369,9 @@ def on_message(client: mqtt.Client, userdata: Any, msg: mqtt.MQTTMessage) -> Non
             port_name = get_enum_name(
                 portnums_pb2.PortNum.DESCRIPTOR, mesh_packet.decoded.portnum
             )
-            from_node_display = get_node_display_name(from_node_id_numeric)
+            from_node_display = _sanitize_for_log(
+                get_node_display_name(from_node_id_numeric)
+            )
             via_mqtt_str = (
                 " (via MQTT)" if getattr(mesh_packet, "via_mqtt", False) else ""
             )
@@ -1412,7 +1426,9 @@ def on_message(client: mqtt.Client, userdata: Any, msg: mqtt.MQTTMessage) -> Non
         elif message_type == "p":
             logging.debug("📍 Processed position message")
         else:
-            logging.debug(f"📦 Processed message type: {message_type}")
+            logging.debug(
+                f"📦 Processed message type: {_sanitize_for_log(message_type)}"
+            )
 
 
 def on_disconnect(

--- a/src/malla/mqtt_capture.py
+++ b/src/malla/mqtt_capture.py
@@ -33,6 +33,7 @@ Data Cleanup:
 import base64
 import hashlib
 import logging
+import os
 import socket
 import sqlite3
 import threading
@@ -90,6 +91,39 @@ logging.basicConfig(
     level=getattr(logging, LOG_LEVEL, logging.INFO),
     format="%(asctime)s - %(levelname)s - %(message)s",
 )
+
+# ---------------------------------------------------------------------------
+# Abuse / resource-exhaustion guards
+# ---------------------------------------------------------------------------
+# Reject MQTT payloads larger than this before parsing or persisting them. The
+# largest legitimate ServiceEnvelope observed across 15M+ captured packets is
+# ~1.25 KB, so 4 KB leaves generous headroom while stopping a publisher on the
+# public broker from flooding the DB with oversized blobs (CWE-400/770).
+MAX_MQTT_PAYLOAD_BYTES: int = int(os.environ.get("MALLA_MAX_MQTT_PAYLOAD_BYTES", "4096"))
+
+# Cap the in-memory node cache so a stream of attacker-chosen node/gateway IDs
+# on the public broker cannot grow process memory without bound. Legitimate
+# rosters are a few thousand nodes; once the cache exceeds this size the
+# least-recently-updated entries are evicted (they reload from the DB on demand).
+MAX_NODE_CACHE_SIZE: int = int(os.environ.get("MALLA_MAX_NODE_CACHE_SIZE", "200000"))
+# How many entries to drop when the cache is full, so eviction is amortised
+# rather than scanning on every insert.
+_NODE_CACHE_EVICT_BATCH: int = max(1, MAX_NODE_CACHE_SIZE // 20)
+
+
+def _sanitize_for_log(value: object, limit: int = 200) -> str:
+    """Make untrusted text safe for a single line-oriented log record.
+
+    MQTT topics and decoded message text are attacker-influenced; strip CR/LF
+    and other control characters so a crafted value cannot forge extra log
+    lines or inject terminal escape sequences (CWE-117). Printable Unicode
+    (including CJK names) is preserved.
+    """
+    text = str(value)
+    if len(text) > limit:
+        text = text[:limit] + "…"
+    return "".join(ch if ch.isprintable() else "�" for ch in text)
+
 
 # --- Global Variables ---
 db_lock = threading.Lock()  # Thread lock for database access
@@ -475,6 +509,29 @@ def load_node_cache() -> None:
         logging.info(f"Loaded {len(node_cache)} nodes into cache from database")
 
 
+def _evict_stale_node_cache_entries() -> None:
+    """Drop the least-recently-updated node_cache entries when it is full.
+
+    Bounds process memory against a stream of attacker-chosen node/gateway IDs
+    on the public broker (CWE-400/770). Entries are only a cache of node_info,
+    so an evicted node simply reloads from the DB the next time it is seen.
+    """
+    global node_cache
+    overflow = len(node_cache) - MAX_NODE_CACHE_SIZE
+    if overflow < 0:
+        return
+    drop = overflow + _NODE_CACHE_EVICT_BATCH
+    stale = sorted(
+        node_cache.items(), key=lambda kv: kv[1].get("last_updated", 0.0)
+    )[:drop]
+    for nid, _ in stale:
+        node_cache.pop(nid, None)
+    logging.info(
+        f"node_cache full (> {MAX_NODE_CACHE_SIZE}); evicted {len(stale)} "
+        f"least-recently-updated entries"
+    )
+
+
 def update_node_cache(
     node_id: int,
     hex_id: str | None = None,
@@ -495,6 +552,8 @@ def update_node_cache(
 
     # Update in-memory cache
     if is_new_node:
+        if len(node_cache) >= MAX_NODE_CACHE_SIZE:
+            _evict_stale_node_cache_entries()
         node_cache[node_id] = {
             "hex_id": hex_id,
             "long_name": long_name,
@@ -1034,14 +1093,26 @@ def on_connect(
 
 def on_message(client: mqtt.Client, userdata: Any, msg: mqtt.MQTTMessage) -> None:
     """Callback for when a PUBLISH message is received from the server."""
-    logging.debug(f"Received message on topic {msg.topic}: {len(msg.payload)} bytes")
+    # msg.topic is attacker-influenced; sanitise before it ever hits a log line.
+    safe_topic = _sanitize_for_log(msg.topic)
+    logging.debug(f"Received message on topic {safe_topic}: {len(msg.payload)} bytes")
+
+    # Reject oversized payloads before parsing or storing anything. A publisher
+    # on the public broker must not be able to convert one PUBLISH into an
+    # arbitrarily large protobuf parse and a durable DB blob (CWE-400/770).
+    if len(msg.payload) > MAX_MQTT_PAYLOAD_BYTES:
+        logging.warning(
+            f"Dropping oversized MQTT payload on topic {safe_topic}: "
+            f"{len(msg.payload)} bytes > {MAX_MQTT_PAYLOAD_BYTES} limit"
+        )
+        return
 
     # Skip JSON messages - we only want protobuf messages
     if "/json/" in msg.topic:
-        logging.debug(f"Skipping JSON message on topic {msg.topic}")
+        logging.debug(f"Skipping JSON message on topic {safe_topic}")
         return
 
-    logging.debug(f"Processing protobuf message on topic {msg.topic}")
+    logging.debug(f"Processing protobuf message on topic {safe_topic}")
 
     # Always store the raw message data first, regardless of parsing success
     raw_service_envelope_data = msg.payload
@@ -1093,7 +1164,9 @@ def on_message(client: mqtt.Client, userdata: Any, msg: mqtt.MQTTMessage) -> Non
                     potential_channel = topic_parts[4]
                     if not potential_channel.startswith("!"):
                         channel_name = potential_channel
-                        logging.debug(f"Using channel name from topic: {channel_name}")
+                        logging.debug(
+                            f"Using channel name from topic: {_sanitize_for_log(channel_name)}"
+                        )
             except Exception:
                 pass
 
@@ -1152,7 +1225,7 @@ def on_message(client: mqtt.Client, userdata: Any, msg: mqtt.MQTTMessage) -> Non
             flags_str = f" ({', '.join(flags)})" if flags else ""
 
             logging.info(
-                f"💬 Text message from {from_node_display} to {to_node_display}{flags_str}: {text_content[:50]}{'...' if len(text_content) > 50 else ''}"
+                f"💬 Text message from {from_node_display} to {to_node_display}{flags_str}: {_sanitize_for_log(text_content, limit=50)}"
             )
             processed_successfully = True
 
@@ -1307,11 +1380,13 @@ def on_message(client: mqtt.Client, userdata: Any, msg: mqtt.MQTTMessage) -> Non
 
     except UnicodeDecodeError as e:
         parsing_error = f"Unicode decode error: {str(e)}"
-        logging.warning(f"Could not decode payload as UTF-8 on topic {msg.topic}: {e}")
+        logging.warning(
+            f"Could not decode payload as UTF-8 on topic {_sanitize_for_log(msg.topic)}: {e}"
+        )
     except Exception as e:
         parsing_error = f"Parsing error: {str(e)}"
         logging.error(
-            f"Error processing MQTT protobuf message on topic {msg.topic}: {e}"
+            f"Error processing MQTT protobuf message on topic {_sanitize_for_log(msg.topic)}: {e}"
         )
         logging.debug(f"Raw payload length: {len(msg.payload)} bytes")
 

--- a/tests/unit/test_mqtt_capture_hardening.py
+++ b/tests/unit/test_mqtt_capture_hardening.py
@@ -1,0 +1,340 @@
+"""Tests for the MQTT-ingest abuse guards.
+
+Pins the "Harden MQTT ingest against untrusted publishers" guards:
+
+- payloads larger than ``MAX_MQTT_PAYLOAD_BYTES`` are dropped before any
+  parsing or persistence (CWE-400/770);
+- the in-memory node cache evicts least-recently-updated entries once it
+  exceeds ``MAX_NODE_CACHE_SIZE`` (CWE-400/770);
+- attacker-controlled values (node names, NODEINFO fields, topics, channel
+  names, message text) can never forge extra log lines or inject terminal
+  control sequences (CWE-117).
+"""
+
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+from meshtastic import config_pb2, mesh_pb2, mqtt_pb2, portnums_pb2
+
+from src.malla import mqtt_capture
+
+pytestmark = pytest.mark.unit
+
+
+def build_nodeinfo_message(long_name: str = "Gabriela") -> SimpleNamespace:
+    """Create a minimal MQTT message containing a NODEINFO packet."""
+    user = mesh_pb2.User()
+    user.id = "!7f6e5d4c"
+    user.long_name = long_name
+    user.short_name = "GAB"
+    user.hw_model = mesh_pb2.HardwareModel.THINKNODE_M3
+    user.role = config_pb2.Config.DeviceConfig.Role.CLIENT
+
+    mesh_packet = mesh_pb2.MeshPacket()
+    # Generated protobuf field is named "from"; use setattr because "from" is a keyword.
+    setattr(mesh_packet, "from", 0x7F6E5D4C)
+    mesh_packet.to = 0
+    mesh_packet.decoded.portnum = portnums_pb2.PortNum.NODEINFO_APP
+    mesh_packet.decoded.payload = user.SerializeToString()
+
+    service_envelope = mqtt_pb2.ServiceEnvelope()
+    service_envelope.channel_id = "LongFast"
+    service_envelope.packet.CopyFrom(mesh_packet)
+
+    return SimpleNamespace(
+        topic="msh/TW/2/e/LongFast/!a2e96b40",
+        payload=service_envelope.SerializeToString(),
+    )
+
+
+def build_text_message() -> SimpleNamespace:
+    """Create a minimal MQTT message containing a TEXT_MESSAGE packet."""
+    mesh_packet = mesh_pb2.MeshPacket()
+    setattr(mesh_packet, "from", 123)
+    mesh_packet.to = 0  # broadcast
+    mesh_packet.decoded.portnum = portnums_pb2.PortNum.TEXT_MESSAGE_APP
+    mesh_packet.decoded.payload = b"hello"
+
+    service_envelope = mqtt_pb2.ServiceEnvelope()
+    service_envelope.channel_id = "LongFast"
+    service_envelope.packet.CopyFrom(mesh_packet)
+
+    return SimpleNamespace(
+        topic="msh/TW/2/e/LongFast/!abc",
+        payload=service_envelope.SerializeToString(),
+    )
+
+
+class TestSanitizeForLog:
+    def test_passes_through_plain_text(self):
+        assert mqtt_capture._sanitize_for_log("node-42") == "node-42"
+
+    def test_replaces_line_and_control_characters(self):
+        out = mqtt_capture._sanitize_for_log("line1\nline2\r\n\x1b[31m\x00end")
+        assert "\n" not in out
+        assert "\r" not in out
+        assert "\x1b" not in out
+        assert "\x00" not in out
+        assert out == "line1�line2���[31m�end"
+
+    def test_preserves_printable_unicode(self):
+        assert mqtt_capture._sanitize_for_log("台北節點") == "台北節點"
+        assert mqtt_capture._sanitize_for_log("Node !a2e96b40") == "Node !a2e96b40"
+
+    def test_truncates_at_limit(self):
+        out = mqtt_capture._sanitize_for_log("x" * 300, limit=50)
+        assert out == "x" * 50 + "…"
+
+    def test_default_limit_is_200(self):
+        assert len(mqtt_capture._sanitize_for_log("y" * 500)) == 201
+
+    def test_coerces_non_string_values(self):
+        assert mqtt_capture._sanitize_for_log(42) == "42"
+        assert mqtt_capture._sanitize_for_log(None) == "None"
+        assert mqtt_capture._sanitize_for_log(b"raw") == "b'raw'"
+
+
+class TestPayloadSizeLimit:
+    @staticmethod
+    def _msg(topic: str, payload: bytes) -> SimpleNamespace:
+        return SimpleNamespace(topic=topic, payload=payload)
+
+    def test_oversized_payload_is_dropped_before_any_processing(
+        self, monkeypatch, caplog
+    ):
+        monkeypatch.setattr(mqtt_capture, "MAX_MQTT_PAYLOAD_BYTES", 10)
+
+        def _must_not_be_called(*_args, **_kwargs):  # pragma: no cover
+            raise AssertionError("processing must not start for oversized payloads")
+
+        monkeypatch.setattr(mqtt_capture, "log_packet_to_database", _must_not_be_called)
+        with caplog.at_level("WARNING"):
+            mqtt_capture.on_message(
+                None, None, self._msg("msh/TW/2/e/LongFast/!abc", b"x" * 11)
+            )
+        assert "Dropping oversized MQTT payload" in caplog.text
+
+    def test_payload_at_the_limit_is_not_dropped(self, monkeypatch):
+        monkeypatch.setattr(mqtt_capture, "MAX_MQTT_PAYLOAD_BYTES", 10)
+        stored = []
+        monkeypatch.setattr(
+            mqtt_capture,
+            "log_packet_to_database",
+            lambda *args, **kwargs: stored.append(args),
+        )
+        # Exactly at the limit on a JSON topic: passes the size guard, then is
+        # skipped by the JSON check - nothing reaches the store.
+        mqtt_capture.on_message(
+            None, None, self._msg("msh/TW/2/json/LongFast/!abc", b"x" * 10)
+        )
+        assert stored == []
+
+    def test_within_limit_protobuf_topic_reaches_store(self, monkeypatch):
+        monkeypatch.setattr(mqtt_capture, "MAX_MQTT_PAYLOAD_BYTES", 4096)
+        stored = []
+        monkeypatch.setattr(
+            mqtt_capture,
+            "log_packet_to_database",
+            lambda *args, **kwargs: stored.append(args),
+        )
+        # Empty-but-legal ServiceEnvelope: parses, then the missing packet is a
+        # parse error - but the raw bytes are still handed to the store (small
+        # malformed packets are kept for debugging).
+        mqtt_capture.on_message(None, None, self._msg("msh/TW/2/e/LongFast/!abc", b""))
+        assert len(stored) == 1
+        # The raw (unsanitised) topic is what gets persisted.
+        assert stored[0][0] == "msh/TW/2/e/LongFast/!abc"
+
+
+class TestNodeCacheEviction:
+    @staticmethod
+    def _entry(ts: float) -> dict:
+        return {
+            "hex_id": "!deadbeef",
+            "long_name": "n",
+            "short_name": "n",
+            "last_updated": ts,
+        }
+
+    def test_evicts_least_recently_updated_when_full(self, monkeypatch):
+        monkeypatch.setattr(
+            mqtt_capture, "node_cache", {i: self._entry(float(i)) for i in range(10)}
+        )
+        monkeypatch.setattr(mqtt_capture, "MAX_NODE_CACHE_SIZE", 6)
+        monkeypatch.setattr(mqtt_capture, "_NODE_CACHE_EVICT_BATCH", 2)
+
+        mqtt_capture._evict_stale_node_cache_entries()
+
+        assert set(mqtt_capture.node_cache) == {6, 7, 8, 9}
+
+    def test_no_eviction_below_capacity(self, monkeypatch):
+        monkeypatch.setattr(
+            mqtt_capture, "node_cache", {i: self._entry(float(i)) for i in range(5)}
+        )
+        monkeypatch.setattr(mqtt_capture, "MAX_NODE_CACHE_SIZE", 10)
+        monkeypatch.setattr(mqtt_capture, "_NODE_CACHE_EVICT_BATCH", 1)
+
+        mqtt_capture._evict_stale_node_cache_entries()
+
+        assert set(mqtt_capture.node_cache) == {0, 1, 2, 3, 4}
+
+    def test_eviction_keeps_size_bounded(self, monkeypatch):
+        monkeypatch.setattr(
+            mqtt_capture, "node_cache", {i: self._entry(float(i)) for i in range(100)}
+        )
+        monkeypatch.setattr(mqtt_capture, "MAX_NODE_CACHE_SIZE", 10)
+        monkeypatch.setattr(mqtt_capture, "_NODE_CACHE_EVICT_BATCH", 3)
+
+        mqtt_capture._evict_stale_node_cache_entries()
+
+        assert set(mqtt_capture.node_cache) == set(range(93, 100))
+
+    def test_update_node_cache_triggers_eviction_when_full(self, tmp_path, monkeypatch):
+        db_path = str(tmp_path / "capture.db")
+        monkeypatch.setattr(mqtt_capture, "DATABASE_FILE", db_path)
+        monkeypatch.setattr(
+            mqtt_capture, "node_cache", {i: self._entry(float(i)) for i in range(10)}
+        )
+        monkeypatch.setattr(mqtt_capture, "MAX_NODE_CACHE_SIZE", 8)
+        monkeypatch.setattr(mqtt_capture, "_NODE_CACHE_EVICT_BATCH", 2)
+
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            """CREATE TABLE node_info (
+                node_id INTEGER PRIMARY KEY,
+                hex_id TEXT, long_name TEXT, short_name TEXT,
+                hw_model TEXT, role TEXT, primary_channel TEXT,
+                is_licensed BOOLEAN, mac_address TEXT,
+                first_seen REAL NOT NULL, last_updated REAL NOT NULL
+            )"""
+        )
+        conn.commit()
+        conn.close()
+
+        mqtt_capture.update_node_cache(node_id=1000, hex_id="!new0001", long_name="new")
+
+        assert 1000 in mqtt_capture.node_cache
+        assert len(mqtt_capture.node_cache) <= 8
+        # The four oldest entries were evicted to make room for the newcomer.
+        assert all(nid not in mqtt_capture.node_cache for nid in (0, 1, 2, 3))
+
+
+class TestLogSanitisationEndToEnd:
+    """Attacker-controlled values must never produce a second log line."""
+
+    def test_nodeinfo_long_name_cannot_forge_log_lines(self, monkeypatch, caplog):
+        monkeypatch.setattr(mqtt_capture, "update_node_cache", lambda **kwargs: None)
+        monkeypatch.setattr(
+            mqtt_capture, "log_packet_to_database", lambda *args, **kwargs: None
+        )
+
+        msg = build_nodeinfo_message(long_name="EVE\nFORGED LOG LINE")
+
+        with caplog.at_level("INFO"):
+            mqtt_capture.on_message(None, None, msg)
+
+        # The raw name (with its newline) never appears in the log.
+        assert "EVE\nFORGED" not in caplog.text
+        # The sanitised name is logged on a single line.
+        assert "EVE�FORGED LOG LINE" in caplog.text
+        # The forged fragment must not appear as its own line.
+        assert not any(
+            line.strip().startswith("FORGED LOG LINE")
+            for line in caplog.text.splitlines()
+        )
+
+    def test_nodeinfo_escape_sequence_cannot_inject_terminal_codes(
+        self, monkeypatch, caplog
+    ):
+        monkeypatch.setattr(mqtt_capture, "update_node_cache", lambda **kwargs: None)
+        monkeypatch.setattr(
+            mqtt_capture, "log_packet_to_database", lambda *args, **kwargs: None
+        )
+
+        msg = build_nodeinfo_message(long_name="EVE\x1b[31mRED")
+
+        with caplog.at_level("INFO"):
+            mqtt_capture.on_message(None, None, msg)
+
+        assert "\x1b" not in caplog.text
+        assert "EVE�[31mRED" in caplog.text
+
+    def test_text_message_node_names_cannot_forge_log_lines(self, monkeypatch, caplog):
+        monkeypatch.setattr(
+            mqtt_capture, "get_node_display_name", lambda nid: "EVE\nFORGED LOG LINE"
+        )
+        monkeypatch.setattr(
+            mqtt_capture, "log_packet_to_database", lambda *args, **kwargs: None
+        )
+
+        msg = build_text_message()
+
+        with caplog.at_level("INFO"):
+            mqtt_capture.on_message(None, None, msg)
+
+        assert "EVE\nFORGED" not in caplog.text
+        assert "EVE�FORGED LOG LINE" in caplog.text
+        assert not any(
+            line.strip().startswith("FORGED LOG LINE")
+            for line in caplog.text.splitlines()
+        )
+
+    def test_text_message_content_cannot_forge_log_lines(self, monkeypatch, caplog):
+        monkeypatch.setattr(mqtt_capture, "get_node_display_name", lambda nid: "Alice")
+        monkeypatch.setattr(
+            mqtt_capture, "log_packet_to_database", lambda *args, **kwargs: None
+        )
+
+        msg = build_text_message()
+
+        # Rebuild the envelope with hostile text content.
+        mesh_packet = mesh_pb2.MeshPacket()
+        setattr(mesh_packet, "from", 123)
+        mesh_packet.to = 0
+        mesh_packet.decoded.portnum = portnums_pb2.PortNum.TEXT_MESSAGE_APP
+        mesh_packet.decoded.payload = b"hello\nFORGED LOG LINE"
+        service_envelope = mqtt_pb2.ServiceEnvelope()
+        service_envelope.channel_id = "LongFast"
+        service_envelope.packet.CopyFrom(mesh_packet)
+        msg.payload = service_envelope.SerializeToString()
+
+        with caplog.at_level("INFO"):
+            mqtt_capture.on_message(None, None, msg)
+
+        assert "hello\nFORGED" not in caplog.text
+        assert "hello�FORGED LOG LINE" in caplog.text
+        assert not any(
+            line.strip().startswith("FORGED LOG LINE")
+            for line in caplog.text.splitlines()
+        )
+
+    def test_channel_name_cannot_forge_log_lines(self, monkeypatch, caplog):
+        """The decrypt-failure debug line sanitises topic-derived channel names."""
+        # Force the UNKNOWN_APP decryption path so channel_name is logged.
+        mesh_packet = mesh_pb2.MeshPacket()
+        setattr(mesh_packet, "from", 123)
+        mesh_packet.to = 456
+        mesh_packet.id = 7
+        mesh_packet.decoded.portnum = portnums_pb2.PortNum.UNKNOWN_APP
+        mesh_packet.encrypted = b"\x01\x02\x03"
+        service_envelope = mqtt_pb2.ServiceEnvelope()
+        service_envelope.channel_id = "LongFast"
+        service_envelope.packet.CopyFrom(mesh_packet)
+        msg = SimpleNamespace(
+            topic="msh/TW/2/e/EVIL\nCHANNEL/!abc",
+            payload=service_envelope.SerializeToString(),
+        )
+
+        monkeypatch.setattr(
+            mqtt_capture, "try_decrypt_mesh_packet", lambda *args, **kwargs: False
+        )
+        monkeypatch.setattr(
+            mqtt_capture, "log_packet_to_database", lambda *args, **kwargs: None
+        )
+
+        with caplog.at_level("DEBUG"):
+            mqtt_capture.on_message(None, None, msg)
+
+        assert "EVIL\nCHANNEL" not in caplog.text
+        assert "EVIL�CHANNEL" in caplog.text


### PR DESCRIPTION
Malla subscribes to a public MQTT broker, so any publisher can send arbitrary bytes into the capture path. This adds three small guards so a single publisher can't exhaust the server.

- **Payload size limit.** Reject MQTT messages larger than 4 KB before parsing or storing them. The biggest real ServiceEnvelope in 15M+ captured packets is ~1.25 KB, so nothing legitimate is affected. Small malformed packets are still stored for debugging. (env: `MALLA_MAX_MQTT_PAYLOAD_BYTES`)
- **Node-cache cap.** The in-memory node cache had no limit, so a stream of made-up node/gateway IDs could grow memory forever. It now evicts the least-recently-seen entries once it gets large. (env: `MALLA_MAX_NODE_CACHE_SIZE`)
- **Log sanitising.** Strip newlines and control characters from MQTT topics and message text before logging them, so crafted values can't forge log lines. Normal text (including non-ASCII names) is unchanged.

No behaviour change for legitimate traffic. Thresholds are configurable via env vars.
