### PR TITLE
Escape mesh node names in Plotly chart labels

### DIFF
--- a/src/malla/services/gateway_service.py
+++ b/src/malla/services/gateway_service.py
@@ -17,6 +17,22 @@ from ..utils.node_utils import get_bulk_node_names
 logger = logging.getLogger(__name__)
 
 
+def _plotly_escape(value: object) -> str:
+    """Escape untrusted text for Plotly's HTML-like hover/label grammar.
+
+    Node names originate from the mesh and are attacker-controllable, so encode
+    the markup delimiters before they are concatenated into hover text; the
+    surrounding template tags (e.g. ``<br>``) stay literal because we own them
+    (CWE-79).
+    """
+    return (
+        str(value)
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+
+
 class GatewayService:
     """Service for gateway analysis and statistics with caching."""
 
@@ -408,7 +424,7 @@ class GatewayService:
             "x": gateway1_rssi,
             "y": gateway2_rssi,
             "text": [
-                f"Packet from {p.get('from_node_name', 'Unknown')}<br>Time: {p['timestamp_str']}"
+                f"Packet from {_plotly_escape(p.get('from_node_name', 'Unknown'))}<br>Time: {p['timestamp_str']}"
                 for p in common_packets
                 if p["gateway1_rssi"] is not None and p["gateway2_rssi"] is not None
             ],
@@ -418,7 +434,7 @@ class GatewayService:
             "x": gateway1_snr,
             "y": gateway2_snr,
             "text": [
-                f"Packet from {p.get('from_node_name', 'Unknown')}<br>Time: {p['timestamp_str']}"
+                f"Packet from {_plotly_escape(p.get('from_node_name', 'Unknown'))}<br>Time: {p['timestamp_str']}"
                 for p in common_packets
                 if p["gateway1_snr"] is not None and p["gateway2_snr"] is not None
             ],

--- a/src/malla/static/js/direct_receptions.js
+++ b/src/malla/static/js/direct_receptions.js
@@ -2,6 +2,20 @@
  * Direct Receptions Chart Component
  * Handles loading and displaying direct receptions data with interactive charts
  */
+
+/**
+ * Escape untrusted text for Plotly's HTML-like hover/label grammar. Node names
+ * come from the mesh and are attacker-controllable, and the trace name is
+ * interpolated into a `<b>%{fullData.name}</b>` hovertemplate, so encode the
+ * markup delimiters before it reaches Plotly (CWE-79).
+ */
+function escapePlotlyText(value) {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
 class DirectReceptionsChart {
     constructor(nodeId) {
         this.nodeId = nodeId;
@@ -194,7 +208,7 @@ class DirectReceptionsChart {
                 y: rssiValues, // default metric is RSSI
                 mode: 'lines+markers',
                 type: 'scatter',
-                name: nodeData.from_node_name,
+                name: escapePlotlyText(nodeData.from_node_name),
                 line: { color: color, width: 2 },
                 marker: { color: color, size: 4 },
                 visible: true,


### PR DESCRIPTION
Node names come from the mesh and can contain anything, but they were put straight into Plotly's hover/label text, which understands HTML-like markup. A crafted name could therefore spoof or distort a chart tooltip.

This escapes the markup characters (`&`, `<`, `>`) in node names before they reach Plotly, in the two places names are used as chart labels:

- **Server:** gateway-comparison hover text (`gateway_service.py`)
- **Client:** direct-reception trace names (`direct_receptions.js`)

The surrounding template tags (e.g. `<br>`, `<b>`) still work because they're written by the code, not by the node name. Names display exactly as before, just as plain text.