### PR TITLE
Fix Most Active Nodes signal column showing N/A for every node

### DIFF
--- a/src/malla/database/repositories.py
+++ b/src/malla/database/repositories.py
@@ -1349,13 +1349,26 @@ class NodeRepository:
                         COALESCE(stats.packet_count_24h, 0) as packet_count_24h,
                         COALESCE(gstats.gateway_packet_count_24h, 0) as gateway_packet_count_24h,
                         COALESCE(stats.last_packet_time, ni.last_updated) as last_packet_time,
-                        datetime(COALESCE(stats.last_packet_time, ni.last_updated), 'unixepoch') as last_packet_str
+                        datetime(COALESCE(stats.last_packet_time, ni.last_updated), 'unixepoch') as last_packet_str,
+                        stats.avg_rssi,
+                        stats.avg_snr
                     FROM node_info ni
                     LEFT JOIN (
                         SELECT
                             from_node_id as node_id,
                             COUNT(*) as packet_count_24h,
-                            MAX(timestamp) as last_packet_time
+                            MAX(timestamp) as last_packet_time,
+                            -- RSSI/SNR only mean anything on direct (0-hop)
+                            -- receptions; relayed packets carry the last
+                            -- relay's signal, not this node's.
+                            AVG(CASE WHEN hop_start BETWEEN 0 AND 7
+                                      AND hop_start = hop_limit
+                                      AND {rssi_valid_sql()}
+                                     THEN CAST(rssi AS FLOAT) END) as avg_rssi,
+                            AVG(CASE WHEN hop_start BETWEEN 0 AND 7
+                                      AND hop_start = hop_limit
+                                      AND {snr_valid_sql()}
+                                     THEN CAST(snr AS FLOAT) END) as avg_snr
                         FROM packet_history
                         WHERE timestamp > (strftime('%s', 'now') - 86400)
                         GROUP BY from_node_id
@@ -1396,7 +1409,9 @@ class NodeRepository:
                         0 as packet_count_24h,
                         0 as gateway_packet_count_24h,
                         ni.last_updated as last_packet_time,
-                        datetime(ni.last_updated, 'unixepoch') as last_packet_str
+                        datetime(ni.last_updated, 'unixepoch') as last_packet_str,
+                        NULL as avg_rssi,
+                        NULL as avg_snr
                     FROM node_info ni
                     {where_clause}
                     ORDER BY {order_column} {order_dir}

--- a/src/malla/templates/dashboard.html
+++ b/src/malla/templates/dashboard.html
@@ -1252,22 +1252,43 @@ function populateTopNodesTable(topNodes) {
         const nodeName = node.display_name || `!${node.node_id.toString(16).padStart(8, '0')}`;
         const row = document.createElement('tr');
 
-        let signalClass = 'text-muted';
-        let signalText = 'N/A';
-        if (node.avg_rssi && node.avg_rssi !== 0) {
-            if (node.avg_rssi > -70) {
+        // Averages cover only direct (0-hop) receptions in the last 24h —
+        // relayed packets carry the relay's signal, not this node's.
+        const rssi = Number.isFinite(node.avg_rssi) ? node.avg_rssi : null;
+        const snr = Number.isFinite(node.avg_snr) ? node.avg_snr : null;
+        let signalCell;
+        if (rssi !== null) {
+            let signalClass, quality;
+            if (rssi > -70) {
                 signalClass = 'text-success';
-                signalText = 'Excellent';
-            } else if (node.avg_rssi > -80) {
+                quality = 'Excellent';
+            } else if (rssi > -80) {
                 signalClass = 'text-warning';
-                signalText = 'Good';
-            } else if (node.avg_rssi > -90) {
+                quality = 'Good';
+            } else if (rssi > -90) {
                 signalClass = 'text-info';
-                signalText = 'Fair';
+                quality = 'Fair';
             } else {
                 signalClass = 'text-danger';
-                signalText = 'Poor';
+                quality = 'Poor';
             }
+            let title = `${quality} — avg RSSI of direct receptions (24h)`;
+            if (snr !== null) title += `, SNR ${snr.toFixed(1)} dB`;
+            signalCell = el('span', { className: signalClass, title },
+                `${Math.round(rssi)} dBm`);
+        } else if (snr !== null) {
+            const signalClass = snr >= 5 ? 'text-success'
+                : snr >= 0 ? 'text-warning'
+                : snr >= -5 ? 'text-info' : 'text-danger';
+            signalCell = el('span', {
+                className: signalClass,
+                title: 'Avg SNR of direct receptions (24h); no valid RSSI reported'
+            }, `SNR ${snr.toFixed(1)} dB`);
+        } else {
+            signalCell = el('span', {
+                className: 'text-muted',
+                title: 'No gateway heard this node directly in the last 24h, so there is no signal reading for the node itself'
+            }, 'Relayed only');
         }
 
         row.append(
@@ -1278,7 +1299,7 @@ function populateTopNodesTable(topNodes) {
                 }, nodeName)
             ),
             el('td', null, badge(String(node.packet_count || 0), 'bg-primary')),
-            el('td', null, el('span', { className: signalClass }, signalText))
+            el('td', null, signalCell)
         );
 
         tbody.appendChild(row);


### PR DESCRIPTION
## Bug

The signal column in the dashboard's **Most Active Nodes** table showed `N/A` for every node. The frontend reads `node.avg_rssi`, but the query behind that table never returned `avg_rssi` / `avg_snr`, so the value was always undefined and the column fell through to `N/A` — no signal strength was ever displayed.

## Fix

Compute the averages in the node query and render them, using **direct (0-hop) receptions only**. A node's own signal can only be judged from packets a gateway heard directly from it; relayed packets carry the *last relay's* signal, not the originating node's, so including them would be misleading. The column now shows:

- `-XX dBm` (colour-graded Excellent/Good/Fair/Poor) when a valid direct RSSI exists, with SNR in the tooltip.
- `SNR x.x dB` when no valid RSSI was reported but SNR was.
- **"Relayed only"** when no gateway heard the node directly in the last 24h, with a tooltip explaining there is no signal reading for the node itself.

Implausible RSSI/SNR values are filtered with the existing signal-quality guards.

## Changes

- `repositories.py`: compute `avg_rssi` / `avg_snr` in the node query, restricted to `hop_start = hop_limit` (0-hop) direct receptions in the last 24h — the values the table was already trying to display.
- `dashboard.html`: render the signal cell with the dBm / SNR / "Relayed only" states and tooltips instead of the always-`N/A` path.

Builds on the dashboard signal-quality work already merged in #97.

## Testing

`ruff check` clean; existing dashboard / node / sorting test suites pass.