### PR TITLE
Clamp API pagination limits to bound per-request work

### DIFF
--- a/src/malla/routes/api_routes.py
+++ b/src/malla/routes/api_routes.py
@@ -43,6 +43,29 @@ _chat_relay_candidate_cache: dict[
 ] = {}
 
 
+def _clamp_limit(default: int, maximum: int) -> int:
+    """Read and bound the untrusted ``?limit=`` query parameter to [1, maximum].
+
+    ``limit`` is passed through to a SQL ``LIMIT`` clause, where SQLite treats a
+    negative value as "no limit" (returning the entire table) and an oversized
+    value forces the database to materialise an unbounded result set. Clamp it,
+    falling back to ``default`` when the parameter is missing or non-numeric.
+    """
+    raw = request.args.get("limit", default, type=int)
+    if raw is None or raw < 1:
+        return default
+    return min(raw, maximum)
+
+
+def _clamp_page() -> int:
+    """Read the untrusted ``?page=`` parameter, forcing it to be >= 1.
+
+    Guards against a negative ``(page - 1) * limit`` offset.
+    """
+    raw = request.args.get("page", 1, type=int)
+    return raw if raw is not None and raw >= 1 else 1
+
+
 def _prune_chat_relay_candidate_cache(now: float) -> None:
     expired_keys = [
         key
@@ -191,8 +214,8 @@ def api_packets():
     """API endpoint for packet data."""
     logger.info("API packets endpoint accessed")
     try:
-        limit = request.args.get("limit", 100, type=int)
-        page = request.args.get("page", 1, type=int)
+        limit = _clamp_limit(default=100, maximum=1000)
+        page = _clamp_page()
         offset = (page - 1) * limit
 
         # Build filters
@@ -285,8 +308,8 @@ def api_nodes():
     """API endpoint for node data (with optional search)."""
     logger.info("API nodes endpoint accessed")
     try:
-        limit = request.args.get("limit", 100, type=int)
-        page = request.args.get("page", 1, type=int)
+        limit = _clamp_limit(default=100, maximum=10000)
+        page = _clamp_page()
         search = request.args.get("search", "").strip()
         offset = (page - 1) * limit
 
@@ -335,10 +358,9 @@ def api_nodes_search():
     logger.info("API nodes search endpoint accessed")
     try:
         query = request.args.get("q", "").strip()
-        limit = request.args.get("limit", 20, type=int)
+        limit = _clamp_limit(default=20, maximum=100)
 
-        # Limit the search limit to prevent abuse
-        limit = min(limit, 100)
+        # limit is already clamped to [1, 100] by _clamp_limit above
 
         # Check if database tables exist before calling NodeRepository
         db_ready = False
@@ -441,10 +463,9 @@ def api_gateways_search():
     logger.info("API gateways search endpoint accessed")
     try:
         query = request.args.get("q", "").strip()
-        limit = request.args.get("limit", 20, type=int)
+        limit = _clamp_limit(default=20, maximum=100)
 
-        # Limit the search limit to prevent abuse
-        limit = min(limit, 100)
+        # limit is already clamped to [1, 100] by _clamp_limit above
 
         # Get all gateways first
         all_gateways = PacketRepository.get_unique_gateway_ids()
@@ -843,7 +864,7 @@ def api_node_location_history(node_id):
     """API endpoint for node location history."""
     logger.info(f"API node location history endpoint accessed for node {node_id}")
     try:
-        limit = request.args.get("limit", 100, type=int)
+        limit = _clamp_limit(default=100, maximum=2000)
         history = NodeService.get_node_location_history(node_id, limit=limit)
         return safe_jsonify(history)
     except ValueError as e:
@@ -883,7 +904,7 @@ def api_node_direct_receptions(node_id):
     """API endpoint for bidirectional direct receptions (0-hop packets)."""
     logger.info(f"API direct receptions endpoint accessed for node {node_id}")
     try:
-        limit = request.args.get("limit", 1000, type=int)
+        limit = _clamp_limit(default=1000, maximum=5000)
         direction = request.args.get("direction", "received", type=str)
 
         # Validate direction parameter
@@ -923,7 +944,7 @@ def api_node_relay_node_analysis(node_id):
     """
     logger.info(f"API relay node analysis endpoint accessed for node {node_id}")
     try:
-        limit = request.args.get("limit", 50, type=int)
+        limit = _clamp_limit(default=50, maximum=1000)
 
         # Convert node_id using helper to support hex strings or int
         node_id_int = convert_node_id(node_id)
@@ -1337,8 +1358,8 @@ def api_packets_data():
     logger.info("API packets modern endpoint accessed")
     try:
         # Get parameters
-        page = request.args.get("page", type=int, default=1)
-        limit = request.args.get("limit", type=int, default=100)
+        page = _clamp_page()
+        limit = _clamp_limit(default=100, maximum=1000)
         search = request.args.get("search", default="")
         sort_by = request.args.get("sort_by", default="timestamp")
         sort_order = request.args.get("sort_order", default="desc")
@@ -1631,8 +1652,8 @@ def api_nodes_data():
     logger.info("API nodes modern endpoint accessed")
     try:
         # Get parameters
-        page = request.args.get("page", type=int, default=1)
-        limit = request.args.get("limit", type=int, default=100)
+        page = _clamp_page()
+        limit = _clamp_limit(default=100, maximum=10000)
         search = request.args.get("search", default="")
         sort_by = request.args.get("sort_by", default="last_packet_time")
         sort_order = request.args.get("sort_order", default="desc")
@@ -1715,8 +1736,8 @@ def api_traceroute_data():
     logger.info("API traceroute modern endpoint accessed")
     try:
         # Get parameters
-        page = request.args.get("page", type=int, default=1)
-        limit = request.args.get("limit", type=int, default=100)
+        page = _clamp_page()
+        limit = _clamp_limit(default=100, maximum=1000)
         search = request.args.get("search", default="")
         sort_by = request.args.get("sort_by", default="timestamp")
         sort_order = request.args.get("sort_order", default="desc")

--- a/tests/integration/test_limit_clamping.py
+++ b/tests/integration/test_limit_clamping.py
@@ -1,0 +1,56 @@
+"""Regression tests for pagination limit clamping (resource-exhaustion guard).
+
+An unbounded ``?limit=`` is interpolated into SQL ``LIMIT``, where SQLite treats
+a negative value as "no limit" (whole table) and a huge value forces an
+unbounded result set. Endpoints must clamp it.
+"""
+
+import pytest
+
+
+@pytest.mark.integration
+@pytest.mark.api
+def test_packets_data_clamps_huge_limit(client):
+    resp = client.get(
+        "/api/packets/data", query_string={"limit": 99999999, "group_packets": "false"}
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["limit"] <= 1000
+
+
+@pytest.mark.integration
+@pytest.mark.api
+def test_packets_data_negative_limit_falls_back(client):
+    # SQLite LIMIT -1 means "no limit"; a negative value must not reach SQL.
+    resp = client.get(
+        "/api/packets/data", query_string={"limit": -1, "group_packets": "false"}
+    )
+    assert resp.status_code == 200
+    assert 1 <= resp.get_json()["limit"] <= 1000
+
+
+@pytest.mark.integration
+@pytest.mark.api
+def test_nodes_data_allows_full_roster_limit(client):
+    # The nodes table legitimately loads up to 10000 rows; that must still work.
+    resp = client.get("/api/nodes/data", query_string={"limit": 10000})
+    assert resp.status_code == 200
+    assert resp.get_json()["limit"] == 10000
+
+
+@pytest.mark.integration
+@pytest.mark.api
+def test_nodes_data_caps_above_max(client):
+    resp = client.get("/api/nodes/data", query_string={"limit": 10_000_000})
+    assert resp.status_code == 200
+    assert resp.get_json()["limit"] <= 10000
+
+
+@pytest.mark.integration
+@pytest.mark.api
+def test_packets_negative_page_does_not_error(client):
+    resp = client.get(
+        "/api/packets", query_string={"limit": 10, "page": -5}
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["page"] >= 1


### PR DESCRIPTION
## What

Applies a hard upper bound to the `limit` (page-size) parameter across the public JSON API endpoints, so a single request cannot ask for an unbounded result set.

## Why

Several unauthenticated endpoints read `limit` straight from the query string with no maximum, so one crafted request (e.g. `?limit=99999999`) can make the server materialise a very large result set from a multi-million-row `packet_history`, exhausting SQLite, CPU and response memory. Sibling endpoints already capped their limits; this makes the cap consistent and centralised.

This is uncontrolled resource consumption (CWE-400 / CWE-770) — an availability issue reachable without authentication.

## Changes

- Clamp every pagination `limit` to a sane maximum before it reaches the repository / query layer; reject or normalise out-of-range values.
- Add `tests/integration/test_limit_clamping.py` asserting oversized `limit` values are clamped rather than executed.

## Testing

`ruff check` clean; new `test_limit_clamping.py` plus the existing API route and sorting suites pass.

## Note

Part of the same security review that produced the SQL-injection fix (GHSA-x7fv-wxrh-ggp5), the MQTT ingest hardening (#100) and the Plotly label escaping (#101 / GHSA-ch57-39q2-4crm); this is the remaining resource-exhaustion item.