### PR TITLE
Map basemaps: OpenFreeMap vector tiles + client-side LOS terrain

### DIFF
--- a/src/malla/static/js/openfreemap.js
+++ b/src/malla/static/js/openfreemap.js
@@ -1,0 +1,61 @@
+// OpenFreeMap vector-tile basemap for Leaflet maps, rendered via a MapLibre GL WebGL overlay.
+const OFM_LIGHT_STYLE = 'https://tiles.openfreemap.org/styles/liberty';
+const OFM_DARK_STYLE = 'https://tiles.openfreemap.org/styles/dark';
+const OFM_ATTRIBUTION = '© <a href="https://openfreemap.org" target="_blank" rel="noopener">OpenFreeMap</a> © <a href="https://www.openmaptiles.org/" target="_blank" rel="noopener">OpenMapTiles</a> © <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap</a> contributors';
+const TERRAIN_DEM_URL = 'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png';
+
+// Recommended Leaflet map options for the GL adapter (see plugin README: maxBounds avoids
+// the latitude-sync issue, minZoom avoids zoom-0 sync issues).
+window.openFreeMapLeafletMapOptions = {
+    maxBounds: [[180, -Infinity], [-180, Infinity]],
+    maxBoundsViscosity: 1,
+    minZoom: 1,
+    maxZoom: 20,
+};
+
+function addTerrainLayers(glMap, contourSource) {
+    try {
+        glMap.addSource('terrarium-dem', { type: 'raster-dem', tiles: [TERRAIN_DEM_URL], tileSize: 256, encoding: 'terrarium', maxzoom: 15 });
+        glMap.addLayer({ id: 'terrain-hillshade', type: 'hillshade', source: 'terrarium-dem',
+            paint: { 'hillshade-exaggeration': 0.6, 'hillshade-illumination-direction': 315,
+                     'hillshade-shadow-color': '#263238', 'hillshade-highlight-color': '#ffffff',
+                     'hillshade-accent-color': '#607d8b' } });
+        if (contourSource) {
+            glMap.addSource('contours-dem', { type: 'raster-dem', tiles: [contourSource.sharedDemProtocolUrl], encoding: 'terrarium', tileSize: 256, maxzoom: 12 });
+            glMap.addSource('contours', { type: 'vector', tiles: [contourSource.contourProtocolUrl({ thresholds: { 11: [200, 1000], 12: [100, 500], 13: [100, 500], 14: [50, 200], 15: [20, 100] } })], maxzoom: 15 });
+            glMap.addLayer({ id: 'terrain-contours', type: 'line', source: 'contours', 'source-layer': 'contours',
+                paint: { 'line-color': '#444444', 'line-opacity': 0.5, 'line-width': ['match', ['get', 'level'], 1, 1.2, 0.6] } });
+        }
+    } catch (err) {
+        console.warn('OpenFreeMap terrain layers failed; continuing with plain basemap.', err);
+    }
+}
+
+window.createOpenFreeMapOverlay = function (options = {}) {
+    const isDark = document.documentElement.getAttribute('data-bs-theme') === 'dark';
+
+    // maplibre-contour must register its tile protocol BEFORE the GL map is created.
+    let contourSource = null;
+    if (options.terrain && window.mlcontour) {
+        contourSource = new mlcontour.DemSource({ url: TERRAIN_DEM_URL, encoding: 'terrarium', maxzoom: 12, worker: true });
+        contourSource.setupMaplibre(maplibregl);
+    }
+
+    if (typeof L.maplibreGL !== 'function') {
+        console.warn('maplibre-gl-leaflet failed to load; map basemap disabled.');
+        return null;
+    }
+    const overlay = L.maplibreGL({
+        style: isDark ? OFM_DARK_STYLE : OFM_LIGHT_STYLE,
+        attributionControl: { customAttribution: OFM_ATTRIBUTION },
+    });
+    if (options.terrain) {
+        // Inner GL map is created in Leaflet's onAdd, i.e. only after overlay.addTo(map):
+        // attach the terrain 'load' listener once the layer is actually added to the map.
+        overlay.once('add', () => {
+            const glMap = overlay.getMaplibreMap();
+            if (glMap) glMap.on('load', () => addTerrainLayers(glMap, contourSource));
+        });
+    }
+    return overlay;
+};

--- a/src/malla/static/js/terrain-elevation.js
+++ b/src/malla/static/js/terrain-elevation.js
@@ -1,0 +1,356 @@
+/**
+ * terrain-elevation.js
+ *
+ * Client-side terrain elevation sampling for the Line of Sight page.
+ *
+ * Samples the same Mapzen/AWS terrarium DEM tiles that the page's terrain
+ * overlay already uses:
+ *
+ *     https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png
+ *
+ * A terrarium tile is a 256x256 RGB PNG encoding elevation in meters:
+ *
+ *     elevation = (r * 256 + g + b / 256) - 32768
+ *
+ * Tiles are fetched, decoded once into Float32Array buffers, and cached in
+ * memory (keyed by z/x/y) so concurrent samplePath() calls share fetches.
+ * In-flight tile fetches are capped at MAX_INFLIGHT_FETCHES.
+ *
+ * Public API:
+ *     window.TerrainElevation.samplePath({ lat1, lon1, lat2, lon2 })
+ *         -> Promise<{
+ *              geoPoints: [{ latitude, longitude, elevation,
+ *                            distanceFromOriginMeters }, ...],
+ *              metrics: { distance, climb, descent },
+ *              dataSet: { description, resolutionMeters, publicUrl }
+ *            }>
+ *
+ * If any tile fetch returns non-200 (including 404) or fails to decode, the
+ * samplePath() promise rejects with an Error naming the failing tile, which
+ * the template's existing try/catch surfaces as the terrain error state.
+ */
+(function () {
+    'use strict';
+
+    var TILE_SIZE = 256;
+    var MAX_ZOOM = 15;
+    var MAX_INFLIGHT_FETCHES = 6;
+    var TILE_URL = 'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/';
+    var EARTH_RADIUS_METERS = 6371008.8;
+    var METERS_PER_PX_EQUATOR = 156543.03392; // Web-Mercator meters per pixel at z0
+    var MAX_SAMPLES = 700;
+
+    // z/x/y -> Promise<Float32Array> (tile decoded once; shared across samples)
+    var tileCache = new Map();
+
+    // Simple semaphore state for the in-flight fetch cap.
+    var inflightFetches = 0;
+    var fetchQueue = [];
+
+    // Diagnostic counter: number of actual HTTP tile fetches issued (cache misses).
+    var tileFetchCount = 0;
+
+    /** Great-circle distance between two points, in meters (haversine). */
+    function haversineMeters(lat1, lon1, lat2, lon2) {
+        var toRad = Math.PI / 180;
+        var dLat = (lat2 - lat1) * toRad;
+        var dLon = (lon2 - lon1) * toRad;
+        var a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+            Math.cos(lat1 * toRad) * Math.cos(lat2 * toRad) *
+            Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        return 2 * EARTH_RADIUS_METERS * Math.asin(Math.sqrt(a));
+    }
+
+    /**
+     * Fractional slippy-map tile coordinates for a lat/lon at zoom z.
+     * x and y are NOT floored; the integer part selects the tile, the
+     * fractional part addresses pixels within it.
+     */
+    function fractionalTileCoords(lat, lon, z) {
+        var n = Math.pow(2, z);
+        var latRad = lat * Math.PI / 180;
+        var fx = ((lon + 180) / 360) * n;
+        var fy = ((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) * n;
+        return { fx: fx, fy: fy, n: n };
+    }
+
+    /** Positive modulo (handles longitudes outside [-180, 180]). */
+    function positiveModulo(value, modulus) {
+        return ((value % modulus) + modulus) % modulus;
+    }
+
+    /** Clamp a value to [min, max]. */
+    function clamp(value, min, max) {
+        return Math.max(min, Math.min(max, value));
+    }
+
+    /** Choose a DEM zoom from the great-circle path distance in meters. */
+    function zoomForDistance(distanceMeters) {
+        var km = distanceMeters / 1000;
+        if (km <= 2) {
+            return MAX_ZOOM; // 15
+        }
+        if (km <= 10) {
+            return 14;
+        }
+        if (km <= 60) {
+            return 13;
+        }
+        return 12;
+    }
+
+    /** Free a fetch slot and wake the next queued fetch, if any. */
+    function releaseFetchSlot() {
+        inflightFetches -= 1;
+        if (fetchQueue.length > 0) {
+            fetchQueue.shift()();
+        }
+    }
+
+    /**
+     * Run `task` under the in-flight fetch cap: wait for a free slot, run,
+     * then release the slot when the task settles.
+     */
+    function withFetchSlot(task) {
+        return new Promise(function (resolve, reject) {
+            var start = function () {
+                if (inflightFetches >= MAX_INFLIGHT_FETCHES) {
+                    fetchQueue.push(start);
+                    return;
+                }
+                inflightFetches += 1;
+                task().then(
+                    function (value) { releaseFetchSlot(); resolve(value); },
+                    function (err) { releaseFetchSlot(); reject(err); }
+                );
+            };
+            start();
+        });
+    }
+
+    /** Fetch + decode one terrarium tile into a Float32Array of 256*256 elevations. */
+    function decodeTile(z, x, y) {
+        var url = TILE_URL + z + '/' + x + '/' + y + '.png';
+        tileFetchCount += 1;
+        return fetch(url)
+            .then(function (response) {
+                if (!response.ok) {
+                    throw new Error('HTTP ' + response.status);
+                }
+                return response.blob();
+            })
+            .then(function (blob) {
+                if (typeof createImageBitmap !== 'function') {
+                    throw new Error('createImageBitmap unsupported');
+                }
+                return createImageBitmap(blob);
+            })
+            .then(function (bitmap) {
+                try {
+                    var canvas = document.createElement('canvas');
+                    canvas.width = TILE_SIZE;
+                    canvas.height = TILE_SIZE;
+                    var ctx = canvas.getContext('2d', { willReadFrequently: true });
+                    if (!ctx) {
+                        throw new Error('2d canvas context unavailable');
+                    }
+                    ctx.drawImage(bitmap, 0, 0, TILE_SIZE, TILE_SIZE);
+                    var imageData = ctx.getImageData(0, 0, TILE_SIZE, TILE_SIZE);
+                    var rgba = imageData.data;
+                    var elevations = new Float32Array(TILE_SIZE * TILE_SIZE);
+                    for (var i = 0, j = 0; i < rgba.length; i += 4, j += 1) {
+                        elevations[j] = (rgba[i] * 256 + rgba[i + 1] + rgba[i + 2] / 256) - 32768;
+                    }
+                    return elevations;
+                } finally {
+                    if (typeof bitmap.close === 'function') {
+                        bitmap.close();
+                    }
+                }
+            });
+    }
+
+    /**
+     * Get the decoded tile for z/x/y, sharing fetches via the in-memory cache.
+     * Returns a Promise resolving to the Float32Array.
+     */
+    function loadTile(z, x, y) {
+        var key = z + '/' + x + '/' + y;
+        var cached = tileCache.get(key);
+        if (cached) {
+            return cached;
+        }
+        var promise = withFetchSlot(function () {
+            return decodeTile(z, x, y);
+        });
+        tileCache.set(key, promise);
+        return promise;
+    }
+
+    /**
+     * Like loadTile, but rejects with the required user-facing error message
+     * (including the tile id) if the tile fails to load or decode.
+     */
+    function loadTileChecked(z, x, y) {
+        return loadTile(z, x, y).catch(function () {
+            throw new Error(
+                'Terrain data unavailable (tile ' + z + '/' + x + '/' + y + ' failed to load)'
+            );
+        });
+    }
+
+    /**
+     * Bilinear elevation sample for a lat/lon from its fractional tile coords.
+     * `tileData` is the Float32Array of the tile containing the sample.
+     * Pixel positions are derived from the fractional tile coords; the four
+     * surrounding pixels are interpolated with nearest-clamp at tile edges.
+     */
+    function sampleElevation(tileData, fx, fy, n) {
+        // Clamp y to the valid tile range (paths near the poles).
+        var fyClamped = clamp(fy, 0, n - 1);
+        // Wrap x around the antimeridian so any longitude maps to a valid tile.
+        var fxMod = positiveModulo(fx, n);
+
+        // Pixel position within the 256x256 tile: [0, 256).
+        var px = (fxMod - Math.floor(fxMod)) * TILE_SIZE;
+        var py = (fyClamped - Math.floor(fyClamped)) * TILE_SIZE;
+
+        var x0 = clamp(Math.floor(px), 0, TILE_SIZE - 1);
+        var y0 = clamp(Math.floor(py), 0, TILE_SIZE - 1);
+        var x1 = clamp(x0 + 1, 0, TILE_SIZE - 1);
+        var y1 = clamp(y0 + 1, 0, TILE_SIZE - 1);
+
+        var wx = px - Math.floor(px); // [0, 1)
+        var wy = py - Math.floor(py); // [0, 1)
+
+        var idx00 = y0 * TILE_SIZE + x0;
+        var idx01 = y0 * TILE_SIZE + x1;
+        var idx10 = y1 * TILE_SIZE + x0;
+        var idx11 = y1 * TILE_SIZE + x1;
+
+        var top = tileData[idx00] * (1 - wx) + tileData[idx01] * wx;
+        var bottom = tileData[idx10] * (1 - wx) + tileData[idx11] * wx;
+        return top * (1 - wy) + bottom * wy;
+    }
+
+    /**
+     * Build the elevation profile for the path (lat1, lon1) -> (lat2, lon2).
+     * Returns a Promise resolving to the contract object consumed by the
+     * Line of Sight template.
+     */
+    function samplePath(params) {
+        var lat1 = params.lat1;
+        var lon1 = params.lon1;
+        var lat2 = params.lat2;
+        var lon2 = params.lon2;
+
+        return Promise.resolve().then(function () {
+            var distanceMeters = haversineMeters(lat1, lon1, lat2, lon2);
+            var z = zoomForDistance(distanceMeters);
+
+            // Meters per pixel at the path's mid-latitude and chosen zoom.
+            var midLatRad = ((lat1 + lat2) / 2) * Math.PI / 180;
+            var metersPerPx = METERS_PER_PX_EQUATOR * Math.cos(midLatRad) / Math.pow(2, z);
+
+            // Sample spacing: 2 x meters-per-pixel; cap sample count at 700.
+            var spacing = 2 * metersPerPx;
+            var sampleCount = clamp(Math.round(distanceMeters / spacing), 2, MAX_SAMPLES);
+
+            // Compute the fractional tile coords of every sample and collect
+            // the set of unique tiles the path needs.
+            var samples = [];
+            var uniqueTiles = new Map(); // "z/x/y" -> { z, x, y }
+            for (var i = 0; i < sampleCount; i += 1) {
+                var t = i / (sampleCount - 1);
+                var lat = lat1 + (lat2 - lat1) * t;
+                var lon = lon1 + (lon2 - lon1) * t;
+                var frac = fractionalTileCoords(lat, lon, z);
+                var tx = Math.floor(positiveModulo(frac.fx, frac.n));
+                var ty = clamp(Math.floor(frac.fy), 0, frac.n - 1);
+                var key = z + '/' + tx + '/' + ty;
+                if (!uniqueTiles.has(key)) {
+                    uniqueTiles.set(key, { z: z, x: tx, y: ty });
+                }
+                samples.push({ lat: lat, lon: lon, frac: frac, tileKey: key });
+            }
+
+            // Preload every required tile (bounded by the fetch cap); any
+            // failure rejects the whole profile.
+            var tileEntries = [];
+            var tileIndex = new Map(); // "z/x/y" -> index into tileEntries
+            uniqueTiles.forEach(function (tile, key) {
+                tileIndex.set(key, tileEntries.length);
+                tileEntries.push({ z: tile.z, x: tile.x, y: tile.y, data: null });
+            });
+
+            var tileLoads = tileEntries.map(function (entry) {
+                return loadTileChecked(entry.z, entry.x, entry.y).then(function (data) {
+                    entry.data = data;
+                });
+            });
+            return Promise.all(tileLoads).then(function () {
+                return buildProfile(samples, tileIndex, tileEntries, z, distanceMeters, metersPerPx);
+            });
+        });
+    }
+
+    /** Assemble geoPoints + metrics from preloaded tile data (synchronous). */
+    function buildProfile(samples, tileIndex, tileEntries, z, distanceMeters, metersPerPx) {
+        var geoPoints = [];
+        var cumulativeMeters = 0;
+        var previous = null;
+        var climb = 0;
+        var descent = 0;
+
+        for (var s = 0; s < samples.length; s += 1) {
+            var sample = samples[s];
+            if (previous) {
+                cumulativeMeters += haversineMeters(
+                    previous.lat, previous.lon, sample.lat, sample.lon
+                );
+            }
+            var tile = tileEntries[tileIndex.get(sample.tileKey)];
+            var elevation = sampleElevation(tile.data, sample.frac.fx, sample.frac.fy, sample.frac.n);
+
+            if (previous) {
+                var delta = elevation - previous.elevation;
+                if (delta > 0) {
+                    climb += delta;
+                } else {
+                    descent += delta;
+                }
+            }
+
+            geoPoints.push({
+                latitude: sample.lat,
+                longitude: sample.lon,
+                elevation: elevation,
+                distanceFromOriginMeters: cumulativeMeters
+            });
+            previous = { lat: sample.lat, lon: sample.lon, elevation: elevation };
+        }
+
+        return {
+            geoPoints: geoPoints,
+            metrics: {
+                distance: distanceMeters,
+                climb: climb,
+                descent: descent
+            },
+            dataSet: {
+                description: 'Mapzen Terrain Tiles (SRTM/NASADEM via AWS Open Data)',
+                resolutionMeters: Math.round(metersPerPx),
+                publicUrl: 'https://registry.opendata.aws/terrain-tiles/'
+            }
+        };
+    }
+
+    // Public surface.
+    window.TerrainElevation = {
+        samplePath: samplePath,
+        // Internal diagnostic counter (cache-miss tile fetches), used by tests.
+        _tileFetchCount: function () {
+            return tileFetchCount;
+        }
+    };
+})();

--- a/src/malla/templates/components/openfreemap_css.html
+++ b/src/malla/templates/components/openfreemap_css.html
@@ -1,0 +1,2 @@
+<!-- MapLibre GL CSS (OpenFreeMap vector-tile overlay) -->
+<link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css" />

--- a/src/malla/templates/components/openfreemap_js.html
+++ b/src/malla/templates/components/openfreemap_js.html
@@ -1,0 +1,2 @@
+<script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"></script>
+<script src="https://unpkg.com/@maplibre/maplibre-gl-leaflet@0.1.4/leaflet-maplibre-gl.js"></script>

--- a/src/malla/templates/line_of_sight.html
+++ b/src/malla/templates/line_of_sight.html
@@ -8,6 +8,7 @@
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
     integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
     crossorigin=""/>
+{% include 'components/openfreemap_css.html' %}
 
 <link rel="stylesheet" href="{{ url_for('static', filename='css/node-picker.css') }}">
 <style>
@@ -268,11 +269,9 @@
                 <hr>
                 <p class="mb-2"><strong>Data sources:</strong></p>
                 <ul class="mb-2 small">
-                    <li><strong>DEM Net Elevation API</strong> - <a href="https://elevationapi.com" target="_blank" rel="noopener">elevationapi.com</a></li>
+                    <li><strong>Elevation Tiles</strong> - © <a href="https://registry.opendata.aws/terrain-tiles/" target="_blank" rel="noopener">Mapzen Terrain Tiles (AWS Open Data)</a></li>
                     <li id="demDataSource"></li>
                     <li><strong>Map Tiles</strong> - © <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap</a> contributors,
-                        © <a href="https://www.stadiamaps.com/" target="_blank" rel="noopener">Stadia Maps</a>,
-                        © <a href="https://www.stamen.com/" target="_blank" rel="noopener">Stamen Design</a>,
                         © <a href="https://openmaptiles.org/" target="_blank" rel="noopener">OpenMapTiles</a></li>
                     <li><strong>Terrain Data</strong> - SRTM (Shuttle Radar Topography Mission)</li>
                 </ul>
@@ -288,6 +287,10 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
     integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
     crossorigin=""></script>
+{% include 'components/openfreemap_js.html' %}
+<script src="https://unpkg.com/maplibre-contour@0.1.0/dist/index.min.js"></script>
+<script src="{{ url_for('static', filename='js/openfreemap.js') }}?v={{ ASSET_VERSION }}"></script>
+<script src="{{ url_for('static', filename='js/terrain-elevation.js') }}?v={{ ASSET_VERSION }}"></script>
 
 <!-- Chart.js for elevation profiles -->
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
@@ -550,15 +553,11 @@ function checkAnalyzeButton() {
 
 // Initialize map with terrain-aware tiles
 function initializeMap() {
-    map = L.map('line-of-sight-map').setView([40.4168, -3.7038], 6); // Default to Spain
+    map = L.map('line-of-sight-map', {...window.openFreeMapLeafletMapOptions}).setView([40.4168, -3.7038], 6); // Default to Spain
 
-    // Stamen Terrain (via Stadia Maps) - Shows terrain, contours, and elevation
-    L.tileLayer('https://tiles.stadiamaps.com/tiles/stamen_terrain/{z}/{x}/{y}{r}.{ext}', {
-        minZoom: 0,
-        maxZoom: 18,
-        attribution: '&copy; <a href="https://www.stadiamaps.com/" target="_blank">Stadia Maps</a> &copy; <a href="https://www.stamen.com/" target="_blank">Stamen Design</a> &copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-        ext: 'png'
-    }).addTo(map);
+    // OpenFreeMap vector basemap + WebGL hillshade terrain overlay
+    const overlay = createOpenFreeMapOverlay({ terrain: true });
+    if (overlay) overlay.addTo(map);
 }
 
 // Perform line of sight analysis
@@ -623,16 +622,13 @@ async function performAnalysis() {
     }
 }
 
-// Fetch elevation data from API
+// Fetch elevation data along the path by sampling Mapzen/AWS terrarium DEM tiles
+// client-side (the previous elevationapi.com server API returns HTTP 500).
 async function fetchElevationData(lat1, lon1, lat2, lon2) {
-    const url = `https://api.elevationapi.com/api/Elevation/line/${lat1},${lon1}/${lat2},${lon2}`;
-
-    const response = await fetch(url);
-    if (!response.ok) {
-        throw new Error(`API returned status ${response.status}`);
+    if (!window.TerrainElevation) {
+        throw new Error('Terrain elevation module failed to load');
     }
-
-    return await response.json();
+    return window.TerrainElevation.samplePath({ lat1, lon1, lat2, lon2 });
 }
 
 // Calculate Fresnel zone radius
@@ -965,14 +961,20 @@ function updateMap(fromNode, toNode, geoPoints, obstacles) {
         maxZoom: 13  // Limit maximum zoom to prevent zooming in too close
     };
 
-    map.fitBounds(bounds, fitBoundsOptions);
+    // Skip zero-area bounds (single point along the line): fitBounds on them computes
+    // an infinite zoom and can crash ('Invalid LatLng (NaN, NaN)')
+    if (bounds.isValid() && !bounds.getNorthEast().equals(bounds.getSouthWest())) {
+        map.fitBounds(bounds, fitBoundsOptions);
+    }
 
 
     // Force map to invalidate size and refit bounds (fixes rendering issues)
     setTimeout(() => {
         map.invalidateSize();
         // Reapply the bounds after invalidateSize to ensure correct view
-        map.fitBounds(bounds, fitBoundsOptions);
+        if (bounds.isValid() && !bounds.getNorthEast().equals(bounds.getSouthWest())) {
+            map.fitBounds(bounds, fitBoundsOptions);
+        }
     }, 100);
 
     // Initialize hover marker (hidden by default)

--- a/src/malla/templates/map.html
+++ b/src/malla/templates/map.html
@@ -9,6 +9,7 @@
 <!-- Leaflet MarkerCluster CSS -->
 <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css" />
 <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css" />
+{% include 'components/openfreemap_css.html' %}
 {% endblock %}
 
 {% block content %}
@@ -414,6 +415,8 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <!-- Leaflet MarkerCluster JS -->
 <script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js"></script>
+{% include 'components/openfreemap_js.html' %}
+<script src="{{ url_for('static', filename='js/openfreemap.js') }}?v={{ ASSET_VERSION }}"></script>
 
 <script>
 let map;
@@ -437,22 +440,14 @@ let allNodes = [];
 let linkData = [];
 let firstDisplay = true; // prevent recenter after initial load
 let currentHopDepth = 1; // max hop depth to display around selected node
+let currentOverlay = null;
 
 // Update map theme based on current theme setting
 function updateMapTheme() {
-    if (!map || !lightTileLayer || !darkTileLayer) return;
-
-    const isDark = document.documentElement.getAttribute('data-bs-theme') === 'dark';
-    const newTileLayer = isDark ? darkTileLayer : lightTileLayer;
-
-    // Remove current tile layer if it exists
-    if (currentTileLayer) {
-        map.removeLayer(currentTileLayer);
-    }
-
-    // Add new tile layer
-    newTileLayer.addTo(map);
-    currentTileLayer = newTileLayer;
+    if (!map) return;
+    if (currentOverlay) { map.removeLayer(currentOverlay); currentOverlay = null; }
+    const overlay = createOpenFreeMapOverlay();
+    if (overlay) { overlay.addTo(map); currentOverlay = overlay; }
 }
 
 // Initialize the page
@@ -672,26 +667,10 @@ function initializeInterface() {
     });
 }
 
-// Map tile layers for different themes
-let lightTileLayer, darkTileLayer, currentTileLayer;
-
 // Initialize the map
 function initMap() {
     // Create map centered on a default location (will be updated when data loads)
-    map = L.map('map').setView([40.0, -95.0], 4);
-
-    // Create light and dark tile layers
-    lightTileLayer = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
-        attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors © <a href="https://carto.com/attributions">CARTO</a>',
-        subdomains: 'abcd',
-        maxZoom: 20
-    });
-
-    darkTileLayer = L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
-        attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors © <a href="https://carto.com/attributions">CARTO</a>',
-        subdomains: 'abcd',
-        maxZoom: 20
-    });
+    map = L.map('map', {...window.openFreeMapLeafletMapOptions}).setView([40.0, -95.0], 4);
 
     // Add appropriate tile layer based on current theme
     updateMapTheme();
@@ -1340,10 +1319,14 @@ function fitMapToNodes() {
         }
     }
 
-    map.fitBounds(bounds, {
-        paddingTopLeft: paddingTopLeft,
-        paddingBottomRight: paddingBottomRight,
-    });
+    // Skip zero-area bounds (single node, or all nodes at identical coordinates):
+    // fitBounds on them computes an infinite zoom and can crash ('Invalid LatLng (NaN, NaN)')
+    if (bounds.isValid() && !bounds.getNorthEast().equals(bounds.getSouthWest())) {
+        map.fitBounds(bounds, {
+            paddingTopLeft: paddingTopLeft,
+            paddingBottomRight: paddingBottomRight,
+        });
+    }
 }
 
 function toggleTracerouteLinks() {

--- a/src/malla/templates/node_detail.html
+++ b/src/malla/templates/node_detail.html
@@ -6,6 +6,7 @@
 {% block extra_css %}
 <!-- Leaflet CSS -->
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+{% include 'components/openfreemap_css.html' %}
 <style>
     .card-metric {
         text-align: center;
@@ -759,6 +760,8 @@
 {% block extra_js %}
 <!-- Leaflet JS -->
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+{% include 'components/openfreemap_js.html' %}
+<script src="{{ url_for('static', filename='js/openfreemap.js') }}?v={{ ASSET_VERSION }}"></script>
 
 <!-- Direct Receptions Chart Component -->
 <script src="{{ url_for('static', filename='js/direct_receptions.js') }}"></script>
@@ -886,23 +889,14 @@ function loadCurrentLocationMap() {
     const currentLocation = JSON.parse(locationDataScript.textContent);
 
     // Initialize map centered on current location
-    const currentMap = L.map('current-location-map').setView([
+    const currentMap = L.map('current-location-map', {...window.openFreeMapLeafletMapOptions}).setView([
         currentLocation.latitude,
         currentLocation.longitude
     ], 15);
 
-    // Add OpenStreetMap tiles
-    // Add theme-appropriate tile layer
-    const isDark = document.documentElement.getAttribute('data-bs-theme') === 'dark';
-    const tileUrl = isDark
-        ? 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png'
-        : 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png';
-
-    L.tileLayer(tileUrl, {
-        attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors © <a href="https://carto.com/attributions">CARTO</a>',
-        subdomains: 'abcd',
-        maxZoom: 20
-    }).addTo(currentMap);
+    // Add OpenFreeMap vector basemap (WebGL)
+    const overlay = createOpenFreeMapOverlay();
+    if (overlay) overlay.addTo(currentMap);
 
     // Add marker for current location
     const marker = L.marker([currentLocation.latitude, currentLocation.longitude]).addTo(currentMap);
@@ -939,23 +933,14 @@ async function loadLocationHistoryMap() {
 
         // Initialize map centered on the most recent location
         const mostRecentLocation = data.location_history[0];
-        const map = L.map('location-history-map').setView([
+        const map = L.map('location-history-map', {...window.openFreeMapLeafletMapOptions}).setView([
             mostRecentLocation.latitude,
             mostRecentLocation.longitude
         ], 13);
 
-        // Add OpenStreetMap tiles
-        // Add theme-appropriate tile layer
-        const isDark = document.documentElement.getAttribute('data-bs-theme') === 'dark';
-        const tileUrl = isDark
-            ? 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png'
-            : 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png';
-
-        L.tileLayer(tileUrl, {
-            attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors © <a href="https://carto.com/attributions">CARTO</a>',
-            subdomains: 'abcd',
-            maxZoom: 20
-        }).addTo(map);
+        // Add OpenFreeMap vector basemap (WebGL)
+        const overlay = createOpenFreeMapOverlay();
+        if (overlay) overlay.addTo(map);
 
         // Calculate age-based colors and add markers
         const now = Date.now() / 1000; // Current time in seconds
@@ -1023,10 +1008,13 @@ async function loadLocationHistoryMap() {
             }).addTo(map);
         }
 
-        // Fit map to show all markers
+        // Fit map to show all markers (skip zero-area bounds: a stationary node makes
+        // fitBounds compute an infinite zoom, which crashes with "Invalid LatLng (NaN, NaN)")
         if (data.location_history.length > 1) {
             const bounds = L.latLngBounds(data.location_history.map(loc => [loc.latitude, loc.longitude]));
-            map.fitBounds(bounds, { padding: [20, 20] });
+            if (bounds.isValid() && !bounds.getNorthEast().equals(bounds.getSouthWest())) {
+                map.fitBounds(bounds, { padding: [20, 20] });
+            }
         }
 
         // Update location count

--- a/src/malla/templates/packet_detail.html
+++ b/src/malla/templates/packet_detail.html
@@ -6,6 +6,7 @@
 {% block extra_css %}
 <!-- Leaflet CSS -->
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+{% include 'components/openfreemap_css.html' %}
 <style>
     .card-metric {
         text-align: center;
@@ -888,6 +889,8 @@
 {% block extra_js %}
 <!-- Leaflet JS -->
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+{% include 'components/openfreemap_js.html' %}
+<script src="{{ url_for('static', filename='js/openfreemap.js') }}?v={{ ASSET_VERSION }}"></script>
 <!-- D3.js for graph visualisation -->
 <script src="https://d3js.org/d3.v7.min.js"></script>
 
@@ -1178,23 +1181,14 @@ async function loadTracerouteMap(routeNodes) {
         }
 
         // Initialize map
-        const map = L.map('traceroute-map').setView([
+        const map = L.map('traceroute-map', {...window.openFreeMapLeafletMapOptions}).setView([
             routeLocations[0].latitude,
             routeLocations[0].longitude
         ], 10);
 
-        // Add tile layer
-        // Add theme-appropriate tile layer
-        const isDark = document.documentElement.getAttribute('data-bs-theme') === 'dark';
-        const tileUrl = isDark
-            ? 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png'
-            : 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png';
-
-        L.tileLayer(tileUrl, {
-            attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors © <a href="https://carto.com/attributions">CARTO</a>',
-            subdomains: 'abcd',
-            maxZoom: 20
-        }).addTo(map);
+        // Add OpenFreeMap vector basemap (WebGL)
+        const overlay = createOpenFreeMapOverlay();
+        if (overlay) overlay.addTo(map);
 
         // Add markers and route line
         const routeCoords = [];
@@ -1276,9 +1270,12 @@ async function loadTracerouteMap(routeNodes) {
             }
         }
 
-        // Fit map to show all markers
+        // Fit map to show all markers (skip zero-area bounds: a single-point route makes
+        // fitBounds compute an infinite zoom, which crashes with "Invalid LatLng (NaN, NaN)")
         const bounds = L.latLngBounds(routeCoords);
-        map.fitBounds(bounds, { padding: [20, 20] });
+        if (bounds.isValid() && !bounds.getNorthEast().equals(bounds.getSouthWest())) {
+            map.fitBounds(bounds, { padding: [20, 20] });
+        }
 
     } catch (error) {
         console.error('Error loading traceroute map:', error);
@@ -1371,23 +1368,14 @@ async function loadReceptionMap(primaryGateway, otherReceptions, gatewayLocation
         }
 
         // Initialize map
-        const map = L.map('receptions-map').setView([
+        const map = L.map('receptions-map', {...window.openFreeMapLeafletMapOptions}).setView([
             gatewayMapData[0].latitude,
             gatewayMapData[0].longitude
         ], 10);
 
-        // Add tile layer
-        // Add theme-appropriate tile layer
-        const isDark = document.documentElement.getAttribute('data-bs-theme') === 'dark';
-        const tileUrl = isDark
-            ? 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png'
-            : 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png';
-
-        L.tileLayer(tileUrl, {
-            attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors © <a href="https://carto.com/attributions">CARTO</a>',
-            subdomains: 'abcd',
-            maxZoom: 20
-        }).addTo(map);
+        // Add OpenFreeMap vector basemap (WebGL)
+        const overlay = createOpenFreeMapOverlay();
+        if (overlay) overlay.addTo(map);
 
         // Add markers for each gateway
         gatewayMapData.forEach((gateway, index) => {
@@ -1521,9 +1509,13 @@ async function loadReceptionMap(primaryGateway, otherReceptions, gatewayLocation
             }
         }
 
-        // Fit map to show all markers (including relay candidates)
+        // Fit map to show all markers (including relay candidates) (skip zero-area bounds:
+        // a single identical-coordinate set makes fitBounds compute an infinite zoom,
+        // which crashes with "Invalid LatLng (NaN, NaN)")
         const bounds = L.latLngBounds(coords);
-        map.fitBounds(bounds, { padding: [20, 20] });
+        if (bounds.isValid() && !bounds.getNorthEast().equals(bounds.getSouthWest())) {
+            map.fitBounds(bounds, { padding: [20, 20] });
+        }
 
     } catch (error) {
         console.error('Error loading reception map:', error);

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -91,6 +91,7 @@ def browser_type_launch_args():
             "--disable-gpu",
             "--disable-web-security",
             "--disable-features=VizDisplayCompositor",
+            "--enable-unsafe-swiftshader",
         ],
     }
 

--- a/tests/e2e/test_line_of_sight_e2e.py
+++ b/tests/e2e/test_line_of_sight_e2e.py
@@ -155,6 +155,12 @@ class TestLineOfSightE2E:
         map_container = page.locator("#line-of-sight-map")
         expect(map_container).to_be_attached()
 
+        # WebGL vector basemap overlay must have mounted (map sits in a container that is
+        # hidden until an analysis runs, so assert attached rather than visible)
+        expect(
+            page.locator("#line-of-sight-map .leaflet-gl-layer canvas")
+        ).to_be_attached()
+
     def test_line_of_sight_attribution_present(self, page: Page, test_server_url):
         """Test that proper attribution is displayed."""
         page.goto(f"{test_server_url}/line-of-sight")
@@ -167,8 +173,8 @@ class TestLineOfSightE2E:
 
         # The attribution box content should contain the required text even if hidden
         attribution_html = attribution.inner_html()
-        assert "DEM Net Elevation API" in attribution_html
-        assert "elevationapi.com" in attribution_html
+        assert "Mapzen" in attribution_html
+        assert "Open Data" in attribution_html
         assert "OpenStreetMap" in attribution_html
 
     def test_line_of_sight_from_tools_menu(self, page: Page, test_server_url):

--- a/tests/e2e/test_map_layout.py
+++ b/tests/e2e/test_map_layout.py
@@ -30,6 +30,11 @@ class TestMapLayout:
         # Verify no error state
         expect(page.locator("#mapError")).to_be_hidden()
 
+        # WebGL vector basemap overlay must have mounted (canvas exists even before tiles load)
+        expect(page.locator(".leaflet-gl-layer canvas")).to_be_visible(
+            timeout=DEFAULT_TIMEOUT
+        )
+
     @pytest.mark.e2e
     def test_map_loads_node_data(self, page: Page, test_server_url):
         """Test that the map loads and displays node data."""


### PR DESCRIPTION
## What

Replace Carto raster basemaps (now requiring API keys, issue #107) with keyless OpenFreeMap vector tiles rendered in a MapLibre GL overlay (`@maplibre/maplibre-gl-leaflet@0.1.4`) over Leaflet. All existing interactions — marker clustering/spiderfy, divIcon markers, popups, precision circles, polylines, fitBounds, theme switching — keep working unchanged on `map`, `node_detail`, `packet_detail`.

Line of Sight:
- Stadia terrain basemap → OpenFreeMap + WebGL hillshade + maplibre-contour vector lines from Mapzen/AWS `terrarium` DEM tiles (same tileset, no new dependencies).
- Elevation profile: the previous `elevationapi.com` endpoint returns HTTP 500, so the profile is now sampled client-side from those same DEM tiles (`terrain-elevation.js`, terrarium decode + bilinear interpolation, in-memory tile cache, 6-way fetch cap). `performAnalysis`, Fresnel/obstacle logic, chart, and colored segments unchanged — `fetchElevationData` keeps its signature and the data contract `{geoPoints, metrics, dataSet}`.

## Fixes surfaced by verification

- `maxZoom: 20` on the shared `openFreeMapLeafletMapOptions` — MarkerCluster's `onAdd` throws "Map has no maxZoom specified" on an infinite `getMaxZoom` (33 e2e failures without it); restores the old Carto layers' maxZoom.
- Terrain layer hookup moved to the overlay's Leaflet `'add'` event — `maplibre-gl-leaflet@0.1.4` creates the inner GL map only in `onAdd`, so attaching at factory time threw.
- Zero-area `fitBounds` guards (node_detail history, `fitMapToNodes`, packet maps, LOS updateMap) — a stationary node's all-identical points made Leaflet compute an infinite zoom → `Invalid LatLng (NaN, NaN)` crash.
- `?v={{ ASSET_VERSION }}` cache-busting on the new static JS so stale iterations can't resurface.

## Validation

- `make lint` / `make format` clean.
- `make check`: **645 passed, 3 skipped, exit 0** — includes the new canvas-mount e2e assertions (`/map` visible, `/line-of-sight` attached) and the pre-existing Leaflet-coupled marker/popup/circle tests (regression proof).
- Live smoke on `/map`, `/node`, `/packet`, `/line-of-sight`: GL canvas mounted on all, markers/lines/arrows render, `mapLoading` hides, no maplibre console errors; both tile CDNs reachable (HTTP 200).
- Attribution shown on every map (`© OpenFreeMap © OpenMapTiles © OpenStreetMap contributors`) and on LOS for Mapzen terrain tiles, per their respective licenses/terms.

## Notes

- No backend or DB changes; frontend + e2e only.
- Draft: no changelog/docs landed yet.
- Residual (pre-existing, unrelated): a swallowed `clearLayers` pageerror on `/map` from synthetic form change events dispatched before `initMap` — present before this change, left as-is.