### PR TITLE
fix(traceroute): keep network graph window from shrinking on busy brokers

### DIFF
--- a/src/malla/routes/api_routes.py
+++ b/src/malla/routes/api_routes.py
@@ -764,7 +764,6 @@ def api_locations():
             hours=hours,
             include_indirect=False,
             filters=network_filters,
-            limit_packets=2000,
         )
 
         # 2. Get packet links (used by get_node_locations and returned in response)

--- a/src/malla/services/location_service.py
+++ b/src/malla/services/location_service.py
@@ -135,7 +135,6 @@ class LocationService:
                     hours=hours,
                     include_indirect=False,
                     filters=network_filters,
-                    limit_packets=2000,
                 )
         except Exception as e:
             logger.warning(f"Failed to get network topology data: {e}")
@@ -386,7 +385,6 @@ class LocationService:
                     hours=hours,
                     include_indirect=False,
                     filters=network_filters,
-                    limit_packets=2000,
                 )
 
             # Convert network links to map-compatible format

--- a/src/malla/services/traceroute_service.py
+++ b/src/malla/services/traceroute_service.py
@@ -32,6 +32,13 @@ _NETWORK_GRAPH_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
 _NETWORK_GRAPH_CACHE_TTL_SECONDS = 60
 _NETWORK_GRAPH_CACHE_MAX_ENTRIES = 32
 
+# Default cap on traceroute packets analyzed per network graph build. The graph
+# advertises a multi-day window (e.g. 168h for the map), so this must be large
+# enough that the newest N packets still span that window; on busy brokers a
+# low cap silently shrinks the analysis to the last few hours and older RF
+# links drop off the map. ~20k packets parse in a couple of seconds.
+DEFAULT_GRAPH_PACKET_LIMIT = 20000
+
 
 def _network_graph_cache_key(
     hours: int,
@@ -1014,7 +1021,7 @@ class TracerouteService:
         min_snr: float = -200.0,
         include_indirect: bool = False,
         filters: dict | None = None,
-        limit_packets: int = 5000,
+        limit_packets: int = DEFAULT_GRAPH_PACKET_LIMIT,
     ) -> dict[str, Any]:
         """
         Extract RF links from traceroute data to build a network connectivity graph.


### PR DESCRIPTION
## Problem

The network graph (map RF links, node neighbor info, traceroute links) caps analysis at the newest **2000** `TRACEROUTE_APP` packets, but advertises a multi-day window (168h for the map). On busy brokers 2000 packets accumulate in a few hours, so the effective window silently shrinks and older RF links drop off the map even though the data is still in the database.

Observed on an instance capturing from `mqtt.meshtastic.org` (~6.5k traceroutes/day): the newest 2000 packets spanned only ~4.7 hours, and `/api/locations` went from 19 traceroute links to 3 overnight with no data deleted.

## Fix

Raise the cap to a shared `DEFAULT_GRAPH_PACKET_LIMIT` (20000) and use it at all three call sites (`api_locations`, `get_node_locations`, `get_traceroute_links`).

## Verification

- With `limit_packets=2000`: 3 links / 4 nodes. With 10000/20000: **100 links / 79 nodes** (the full 7-day window)
- Build cost: ~1.6s for ~6.5k packets, amortized by the existing 60s graph cache
- Map link that had vanished reappeared with correct avg SNR