### PR TITLE
fix(los): resolve nodes outside top 1000 in line of sight and allow decimal search

### DIFF
--- a/src/malla/database/repositories.py
+++ b/src/malla/database/repositories.py
@@ -1255,6 +1255,7 @@ class NodeRepository:
                     "ni.long_name LIKE ?",
                     "ni.short_name LIKE ?",
                     "ni.hw_model LIKE ?",
+                    "CAST(ni.node_id AS TEXT) LIKE ?",
                     "printf('!%08x', ni.node_id) LIKE ?",
                 ]
                 search_param = f"%{search}%"

--- a/src/malla/static/js/node-cache.js
+++ b/src/malla/static/js/node-cache.js
@@ -1,5 +1,5 @@
 (function () {
-    const CACHE_KEY = 'malla_nodes_cache_v1';
+    const CACHE_KEY = 'malla_nodes_cache_v2';
     const CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes
 
     // Internal state shared across the page
@@ -59,9 +59,9 @@
                     return;
                 }
 
-                // 2. Fetch from API
+                // 2. Fetch from API (request up to 10,000 nodes to cover all mesh nodes)
                 try {
-                    const resp = await fetch('/api/nodes?limit=1000');
+                    const resp = await fetch('/api/nodes?limit=10000');
                     if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
                     const data = await resp.json();
                     _nodes = data.nodes || [];
@@ -83,21 +83,38 @@
          * Resolves to null if not found.
          */
         async getNode(nodeId) {
+            if (nodeId === null || nodeId === undefined || nodeId === '') return null;
             await this.load();
             const idStr = nodeId.toString();
-            return _nodes.find((n) => n.node_id.toString() === idStr) || null;
+            const found = _nodes ? _nodes.find((n) => n.node_id.toString() === idStr) : null;
+            if (found) return found;
+
+            // Fallback: fetch from API directly
+            try {
+                const resp = await fetch(`/api/node/${encodeURIComponent(nodeId)}/info`);
+                if (resp.ok) {
+                    const data = await resp.json();
+                    if (data && data.node) {
+                        this.addNode(data.node);
+                        return data.node;
+                    }
+                }
+            } catch (err) {
+                console.warn(`NodeCache: Failed to fetch node ${nodeId} from API:`, err);
+            }
+            return null;
         },
 
         /**
-         * Search nodes (client-side). Returns array matching the query.
+         * Search nodes (client-side with API fallback). Returns array matching the query.
          * Matches against long_name, short_name, decimal ID and hex ID (with leading '!').
          * Limit optional.
          */
         async search(query, limit = 20) {
-            // If we already have the full list, search locally
-            if (_loaded) {
+            let results = [];
+            if (_loaded && _nodes) {
                 const lower = query.toLowerCase();
-                const results = _nodes.filter((node) => {
+                results = _nodes.filter((node) => {
                     const nameLong = (node.long_name || '').toLowerCase();
                     const nameShort = (node.short_name || '').toLowerCase();
                     const hexId = `!${node.node_id.toString(16).padStart(8, '0')}`.toLowerCase();
@@ -109,16 +126,17 @@
                         decId.includes(lower)
                     );
                 });
-                return results.slice(0, limit);
+                if (results.length > 0) {
+                    return results.slice(0, limit);
+                }
             }
 
-            // If we're still loading the big list, perform a quick focused query to the API
+            // If no local matches or not yet loaded, query API directly
             try {
                 const resp = await fetch(`/api/nodes?search=${encodeURIComponent(query)}&limit=${limit}`);
                 if (resp.ok) {
                     const data = await resp.json();
-                    if (Array.isArray(data.nodes)) {
-                        // Merge the quick results into our cache for future lookups
+                    if (Array.isArray(data.nodes) && data.nodes.length > 0) {
                         data.nodes.forEach((n) => {
                             if (n && n.node_id !== undefined) {
                                 NodeCache.addNode(n);
@@ -131,9 +149,7 @@
                 console.warn('NodeCache.search: fallback API search failed', err);
             }
 
-            // As a last resort, wait for the full load to finish then search
-            await this.load();
-            return this.search(query, limit);
+            return results.slice(0, limit);
         },
 
         /**

--- a/src/malla/templates/line_of_sight.html
+++ b/src/malla/templates/line_of_sight.html
@@ -366,27 +366,59 @@ document.addEventListener('DOMContentLoaded', async function() {
 // Set node picker values from URL params
 async function setNodePickerValues(fromNodeId, toNodeId) {
     try {
-        const fromNode = await window.NodeCache.getNode(parseInt(fromNodeId));
-        const toNode = await window.NodeCache.getNode(parseInt(toNodeId));
+        let fromNode = await window.NodeCache.getNode(parseInt(fromNodeId));
+        let toNode = await window.NodeCache.getNode(parseInt(toNodeId));
 
-        if (fromNode && toNode) {
-            // Set from node
+        // Fallback: check LocationCache if NodeCache did not resolve
+        if (!fromNode && window.LocationCache) {
+            const loc = await window.LocationCache.getLocation(parseInt(fromNodeId));
+            if (loc) {
+                fromNode = {
+                    node_id: loc.node_id,
+                    long_name: loc.long_name || loc.display_name,
+                    short_name: loc.short_name,
+                    hex_id: loc.node_id_hex || loc.hex_id
+                };
+            }
+        }
+        if (!toNode && window.LocationCache) {
+            const loc = await window.LocationCache.getLocation(parseInt(toNodeId));
+            if (loc) {
+                toNode = {
+                    node_id: loc.node_id,
+                    long_name: loc.long_name || loc.display_name,
+                    short_name: loc.short_name,
+                    hex_id: loc.node_id_hex || loc.hex_id
+                };
+            }
+        }
+
+        if (fromNode) {
             document.getElementById('fromNode_value').value = fromNode.node_id;
             document.getElementById('fromNode').value = fromNode.long_name || fromNode.short_name || fromNode.hex_id;
             fromNodePicker.clearButton.style.display = 'block';
+        }
 
-            // Set to node
+        if (toNode) {
             document.getElementById('toNode_value').value = toNode.node_id;
             document.getElementById('toNode').value = toNode.long_name || toNode.short_name || toNode.hex_id;
             toNodePicker.clearButton.style.display = 'block';
+        }
 
+        if (fromNode && toNode) {
             // Enable button and perform analysis
             checkAnalyzeButton();
             await updateDistanceHint();
             setTimeout(() => performAnalysis(), 100);
+        } else {
+            const missing = [];
+            if (!fromNode) missing.push(`Node ID ${fromNodeId}`);
+            if (!toNode) missing.push(`Node ID ${toNodeId}`);
+            showError(`Could not find information for ${missing.join(' and ')}`);
         }
     } catch (error) {
         console.error('Error setting node picker values:', error);
+        showError('Failed to load selected nodes: ' + error.message);
     }
 }
 

--- a/tests/unit/test_node_repository.py
+++ b/tests/unit/test_node_repository.py
@@ -238,3 +238,38 @@ class TestNodeRepository:
         """Test get_bulk_node_names with empty list."""
         result = NodeRepository.get_bulk_node_names([])
         assert result == {}
+
+    @pytest.mark.unit
+    @patch("src.malla.database.repositories.get_db_connection")
+    def test_get_nodes_search_by_decimal_id(self, mock_get_db):
+        """Test that get_nodes includes CAST(ni.node_id AS TEXT) in search query."""
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_get_db.return_value = mock_conn
+        mock_conn.cursor.return_value = mock_cursor
+
+        mock_cursor.fetchone.return_value = {"total": 1}
+        node_row = {
+            "node_id": 554576596,
+            "long_name": "Sierra de Santa Cruz",
+            "short_name": "MA6",
+            "hw_model": "NRF52_PROMICRO_DIY",
+            "role": "ROUTER",
+            "primary_channel": "SFNarrow",
+            "last_updated": 1788550193.0,
+        }
+        mock_cursor.fetchall.return_value = [node_row]
+
+        result = NodeRepository.get_nodes(search="554576596")
+
+        # Verify that count query was executed with search parameter
+        count_call_args = mock_cursor.execute.call_args_list[0]
+        query_sql = count_call_args[0][0]
+        query_params = count_call_args[0][1]
+
+        assert "CAST(ni.node_id AS TEXT) LIKE ?" in query_sql
+        assert "%554576596%" in query_params
+        assert result["total_count"] == 1
+        assert len(result["nodes"]) == 1
+        assert result["nodes"][0]["node_id"] == 554576596
+


### PR DESCRIPTION
On the line-of-sight page you could only pick from the first 1000 nodes the
server sent down — anything deeper in the list was simply unfindable, and you
couldn't paste a decimal coordinate pair to look up a position. Now the page
resolves any node by ID/name on demand and accepts decimal searches.

## What it affects
- Line-of-sight page node pickers only.

## Changes
- `node-cache.js` resolves nodes outside the initial top-1000 list on demand.
- Line-of-sight page accepts decimal coordinate searches.
- Repository-level support + unit tests in `test_node_repository.py`.

## Commits
- fix(los): resolve nodes outside top 1000 in line of sight and allow decimal search
