### PR TITLE
fix(traceroute): accurate hop counts with SQL pagination and query indexes

### DIFF
--- a/src/malla/database/connection.py
+++ b/src/malla/database/connection.py
@@ -72,7 +72,9 @@ _stats_seed_lock = threading.Lock()
 _stats_seed_thread: threading.Thread | None = None
 
 
-def seed_query_planner_stats_async(db_path: str | None = None) -> bool:
+def seed_query_planner_stats_async(
+    db_path: str | None = None, *, force: bool = False
+) -> bool:
     """Seed SQLite planner statistics in a background thread if they are missing.
 
     A bounded ANALYZE still reads ~1000 sample rows per index, which can take
@@ -80,7 +82,8 @@ def seed_query_planner_stats_async(db_path: str | None = None) -> bool:
     synchronously at startup would block web request serving or packet
     ingestion for that whole time, so we do it off-thread instead. When stats
     are already present (the common case after the first run) this is a single
-    fast SELECT and no thread is started.
+    fast SELECT and no thread is started — unless ``force`` is set (used after
+    new indexes are created, so the planner learns about them).
 
     Returns ``True`` if a seeding thread was started.
     """
@@ -91,16 +94,17 @@ def seed_query_planner_stats_async(db_path: str | None = None) -> bool:
 
     # Fast pre-check on the calling thread: usually stats already exist and we
     # return immediately without touching threads.
-    try:
-        conn = sqlite3.connect(path, timeout=30.0)
+    if not force:
         try:
-            if query_planner_stats_present(conn.cursor()):
-                return False
-        finally:
-            conn.close()
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("Could not check query-planner statistics: %s", exc)
-        return False
+            conn = sqlite3.connect(path, timeout=30.0)
+            try:
+                if query_planner_stats_present(conn.cursor()):
+                    return False
+            finally:
+                conn.close()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not check query-planner statistics: %s", exc)
+            return False
 
     with _stats_seed_lock:
         if _stats_seed_thread is not None and _stats_seed_thread.is_alive():
@@ -114,7 +118,7 @@ def seed_query_planner_stats_async(db_path: str | None = None) -> bool:
             try:
                 _apply_connection_pragmas(conn.cursor())
                 started = time.time()
-                if ensure_query_planner_stats(conn.cursor()):
+                if ensure_query_planner_stats(conn.cursor(), force=force):
                     conn.commit()
                     logger.info(
                         "Seeded query-planner statistics in %.1fs",
@@ -176,7 +180,7 @@ def init_database() -> None:
 
         # Test a simple query to verify the database is accessible
         cursor = conn.cursor()
-        ensure_startup_schema(cursor)
+        schema_changed = ensure_startup_schema(cursor)
         conn.commit()
         cursor.execute("SELECT COUNT(*) FROM sqlite_master WHERE type='table'")
         table_count = cursor.fetchone()[0]
@@ -190,8 +194,9 @@ def init_database() -> None:
         # Seed query-planner statistics on first run so the planner picks
         # index-based plans instead of full scans on a large packet_history.
         # Runs in a background thread so a cold ANALYZE (~100s on a multi-GB DB)
-        # never blocks request serving.
-        seed_query_planner_stats_async(db_path)
+        # never blocks request serving. Also re-run when startup created new
+        # indexes: existing statistics no longer describe the available plans.
+        seed_query_planner_stats_async(db_path, force=schema_changed)
 
         logger.info(
             f"Database connection successful - found {table_count} tables, journal_mode: {journal_mode}"

--- a/src/malla/database/repositories.py
+++ b/src/malla/database/repositories.py
@@ -3674,28 +3674,58 @@ class TracerouteRepository:
                             page_group_keys = [
                                 (
                                     r["mesh_packet_id"]
-                                    if isinstance(r, dict)
+                                    if (
+                                        isinstance(r, dict)
+                                        or hasattr(r, "keys")
+                                    )
                                     else r[0],
-                                    r["from_node_id"] if isinstance(r, dict) else r[1],
-                                    r["to_node_id"] if isinstance(r, dict) else r[2],
+                                    r["from_node_id"]
+                                    if (
+                                        isinstance(r, dict)
+                                        or hasattr(r, "keys")
+                                    )
+                                    else r[1],
+                                    r["to_node_id"]
+                                    if (
+                                        isinstance(r, dict)
+                                        or hasattr(r, "keys")
+                                    )
+                                    else r[2],
                                 )
                                 for r in page_group_rows
                             ]
-                            page_mesh_ids = list({key[0] for key in page_group_keys})
-                            placeholders = ",".join("?" for _ in page_mesh_ids)
+
+                            group_values_sql = ", ".join(
+                                ["(?, ?, ?)"] * len(page_group_keys)
+                            )
+                            group_params: list[Any] = []
+                            for k in page_group_keys:
+                                group_params.extend([k[0], k[1], k[2]])
 
                             # Stage 2: Fetch only individual receptions for the current page
+                            # joining using the full composite group key and reapplying original predicates
                             receptions_query = f"""
+                                WITH page_groups(grp_mesh_packet_id, grp_from_node_id, grp_to_node_id) AS (
+                                    VALUES {group_values_sql}
+                                )
                                 SELECT
-                                    id, timestamp, from_node_id, to_node_id, gateway_id,
-                                    channel_id, hop_start, hop_limit, rssi, snr, payload_length, raw_payload,
-                                    processed_successfully, mesh_packet_id,
-                                    datetime(timestamp, 'unixepoch') as timestamp_str
+                                    packet_history.id, packet_history.timestamp, packet_history.from_node_id,
+                                    packet_history.to_node_id, packet_history.gateway_id, packet_history.channel_id,
+                                    packet_history.hop_start, packet_history.hop_limit, packet_history.rssi,
+                                    packet_history.snr, packet_history.payload_length, packet_history.raw_payload,
+                                    packet_history.processed_successfully, packet_history.mesh_packet_id,
+                                    datetime(packet_history.timestamp, 'unixepoch') as timestamp_str
                                 FROM packet_history
-                                WHERE mesh_packet_id IN ({placeholders}) AND portnum_name = 'TRACEROUTE_APP'
-                                ORDER BY timestamp DESC
+                                JOIN page_groups
+                                  ON packet_history.mesh_packet_id = page_groups.grp_mesh_packet_id
+                                 AND packet_history.from_node_id = page_groups.grp_from_node_id
+                                 AND packet_history.to_node_id = page_groups.grp_to_node_id
+                                {where_clause}
+                                ORDER BY packet_history.timestamp DESC
                             """
-                            cursor.execute(receptions_query, page_mesh_ids)
+                            cursor.execute(
+                                receptions_query, group_params + params
+                            )
                             individual_packets = [
                                 dict(row) for row in cursor.fetchall()
                             ]

--- a/src/malla/database/repositories.py
+++ b/src/malla/database/repositories.py
@@ -3384,7 +3384,8 @@ class TracerouteRepository:
                     gateway_id,
                     hop_start,
                     hop_limit,
-                    raw_payload
+                    raw_payload,
+                    mesh_packet_id
                 FROM packet_history
                 {where_clause}
                 ORDER BY timestamp DESC

--- a/src/malla/database/repositories.py
+++ b/src/malla/database/repositories.py
@@ -167,6 +167,7 @@ def _aggregate(
         band.extend(run_band)
     return avg_line, band
 
+
 RELAY_CANDIDATE_CACHE_TTL_SECONDS = 1800
 RELAY_CANDIDATE_CACHE_MAX_ENTRIES = 4096
 _relay_candidate_cache: dict[tuple[int, int], tuple[float, list[dict[str, Any]]]] = {}
@@ -830,7 +831,9 @@ class PacketRepository:
                     "hop_count",
                     "relay_node",
                 }
-                order_column = order_by if order_by in valid_order_columns else "timestamp"
+                order_column = (
+                    order_by if order_by in valid_order_columns else "timestamp"
+                )
                 order_dir_sql = "DESC" if order_dir.lower() == "desc" else "ASC"
 
                 # Main query
@@ -3393,6 +3396,136 @@ class TracerouteRepository:
             raise
 
     @staticmethod
+    def _aggregate_group_packets(
+        packets_in_group: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Aggregate multiple gateway receptions of a single traceroute packet."""
+        packets_in_group.sort(key=lambda x: x["timestamp"], reverse=True)
+        base_packet = packets_in_group[0]
+
+        gateway_ids = [p["gateway_id"] for p in packets_in_group if p.get("gateway_id")]
+        unique_gateways = list(set(gateway_ids))
+
+        rssi_values = [
+            p["rssi"] for p in packets_in_group if is_plausible_rssi(p.get("rssi"))
+        ]
+        snr_values = [
+            p["snr"] for p in packets_in_group if is_plausible_snr(p.get("snr"))
+        ]
+        hop_values = []
+        for p in packets_in_group:
+            if p.get("hop_start") is not None and p.get("hop_limit") is not None:
+                hop_values.append(p["hop_start"] - p["hop_limit"])
+
+        payload_lengths = [
+            p["payload_length"] for p in packets_in_group if p.get("payload_length")
+        ]
+
+        best_payload_packet = max(
+            packets_in_group, key=lambda x: len(x.get("raw_payload") or b"")
+        )
+
+        aggregated = {
+            "id": base_packet["id"],
+            "timestamp": base_packet["timestamp"],
+            "timestamp_str": base_packet.get("timestamp_str"),
+            "from_node_id": base_packet["from_node_id"],
+            "to_node_id": base_packet["to_node_id"],
+            "channel_id": base_packet.get("channel_id"),
+            "mesh_packet_id": base_packet["mesh_packet_id"],
+            "gateway_id": unique_gateways[0] if len(unique_gateways) == 1 else None,
+            "gateway_count": len(unique_gateways),
+            "gateway_list": ",".join(unique_gateways),
+            "reception_count": len(packets_in_group),
+            "processed_successfully": any(
+                p.get("processed_successfully") for p in packets_in_group
+            ),
+            "raw_payload": best_payload_packet.get("raw_payload"),
+            "is_grouped": True,
+        }
+
+        # RSSI aggregation
+        if rssi_values:
+            aggregated["min_rssi"] = min(rssi_values)
+            aggregated["max_rssi"] = max(rssi_values)
+            if aggregated["min_rssi"] == aggregated["max_rssi"]:
+                aggregated["rssi_range"] = f"{aggregated['min_rssi']:.1f} dBm"
+            else:
+                aggregated["rssi_range"] = (
+                    f"{aggregated['min_rssi']:.1f} to {aggregated['max_rssi']:.1f} dBm"
+                )
+            aggregated["rssi"] = aggregated["rssi_range"]
+        else:
+            aggregated["min_rssi"] = None
+            aggregated["max_rssi"] = None
+            aggregated["rssi_range"] = None
+            aggregated["rssi"] = None
+
+        # SNR aggregation
+        if snr_values:
+            aggregated["min_snr"] = min(snr_values)
+            aggregated["max_snr"] = max(snr_values)
+            if aggregated["min_snr"] == aggregated["max_snr"]:
+                aggregated["snr_range"] = f"{aggregated['min_snr']:.2f} dB"
+            else:
+                aggregated["snr_range"] = (
+                    f"{aggregated['min_snr']:.2f} to {aggregated['max_snr']:.2f} dB"
+                )
+            aggregated["snr"] = aggregated["snr_range"]
+        else:
+            aggregated["min_snr"] = None
+            aggregated["max_snr"] = None
+            aggregated["snr_range"] = None
+            aggregated["snr"] = None
+
+        # Hop count aggregation
+        if hop_values:
+            aggregated["min_hops"] = min(hop_values)
+            aggregated["max_hops"] = max(hop_values)
+            if aggregated["min_hops"] == aggregated["max_hops"]:
+                aggregated["hop_range"] = str(aggregated["min_hops"])
+            else:
+                aggregated["hop_range"] = (
+                    f"{aggregated['min_hops']}-{aggregated['max_hops']}"
+                )
+            aggregated["hop_count"] = aggregated["min_hops"]
+        else:
+            aggregated["min_hops"] = None
+            aggregated["max_hops"] = None
+            aggregated["hop_range"] = None
+            aggregated["hop_count"] = None
+
+        # Payload length aggregation
+        if payload_lengths:
+            aggregated["avg_payload_length"] = sum(payload_lengths) / len(
+                payload_lengths
+            )
+        else:
+            aggregated["avg_payload_length"] = None
+
+        aggregated["success"] = aggregated["processed_successfully"]
+        aggregated["route"] = None
+        aggregated["route_display"] = "No route data"
+        if aggregated.get("raw_payload"):
+            try:
+                from ..models.traceroute import TraceroutePacket
+
+                tr_packet = TraceroutePacket(aggregated, resolve_names=True)
+                if tr_packet.route_data.get("route_nodes"):
+                    aggregated["route"] = json.dumps(
+                        tr_packet.route_data["route_nodes"]
+                    )
+                    aggregated["route_display"] = tr_packet.format_path_display(
+                        "display"
+                    )
+            except Exception as e:
+                logger.debug(
+                    f"Failed to parse route for grouped packet {aggregated['id']}: {e}"
+                )
+
+        return aggregated
+
+    @staticmethod
     def get_traceroute_packets(
         limit: int = 100,
         offset: int = 0,
@@ -3478,218 +3611,155 @@ class TracerouteRepository:
 
                 where_clause = "WHERE " + " AND ".join(where_conditions)
 
-                # PERFORMANCE FIX: Skip expensive total count for grouped traceroute queries
-                # The COUNT(DISTINCT ...) query was taking too long on large datasets
-                # Instead, estimate total count based on results (much faster)
-                total_count = None  # Will be estimated after getting results
-
-                # ULTRA-OPTIMIZED: Use much smaller fetch limits for better performance
-                # The original approach was fetching 1k-100k records which is too expensive
-                # Instead, use a more reasonable approach with smaller multipliers
-                if offset == 0:
-                    # For first page, use a smaller multiplier for traceroutes
-                    fetch_limit = min(
-                        limit * 15, 3000
-                    )  # Smaller: 375-3000 instead of 1k-40k
-                else:
-                    # For subsequent pages, use a reasonable multiplier
-                    grouping_ratio = 2.0  # More realistic estimate
-                    estimated_individual_needed = (offset + limit) * grouping_ratio
-
-                    # Cap at much smaller limits for performance
-                    fetch_limit = min(
-                        max(estimated_individual_needed, limit * 8), 8000
-                    )  # Max 8k instead of 100k
-
-                # Fetch individual packets using efficient ORDER BY timestamp DESC LIMIT
-                query = f"""
-                    SELECT
-                        id, timestamp, from_node_id, to_node_id, gateway_id,
-                        channel_id, hop_start, hop_limit, rssi, snr, payload_length, raw_payload,
-                        processed_successfully, mesh_packet_id,
-                        datetime(timestamp, 'unixepoch') as timestamp_str
-                    FROM packet_history
-                    {where_clause}
-                    ORDER BY timestamp DESC
-                    LIMIT ?
-                """
-
-                cursor.execute(query, params + [fetch_limit])
-                rows = cursor.fetchall()
-                individual_packets: list[dict[str, Any]] = [dict(row) for row in rows]
-
-                # Group packets in memory by (mesh_packet_id, from_node_id, to_node_id)
-                groups: dict[tuple[Any, Any, Any], list[dict[str, Any]]] = {}
-                for packet in individual_packets:
-                    # Skip if missing required fields
-                    if not packet.get("mesh_packet_id") or not packet.get(
-                        "from_node_id"
-                    ):
-                        continue
-
-                    # Create grouping key
-                    group_key = (
-                        packet["mesh_packet_id"],
-                        packet["from_node_id"],
-                        packet["to_node_id"],
-                    )
-
-                    if group_key not in groups:
-                        groups[group_key] = []
-                    groups[group_key].append(packet)
-
-                # Convert groups to aggregated packets
-                aggregated_packets = []
-                for _group_key, packets_in_group in groups.items():
-                    # Sort by timestamp (newest first) within group
-                    packets_in_group.sort(key=lambda x: x["timestamp"], reverse=True)
-
-                    # Use the first (newest) packet as the base
-                    base_packet = packets_in_group[0]
-
-                    # Calculate aggregations
-                    gateway_ids = [
-                        p["gateway_id"] for p in packets_in_group if p["gateway_id"]
-                    ]
-                    unique_gateways = list(set(gateway_ids))
-
-                    rssi_values = [
-                        p["rssi"]
-                        for p in packets_in_group
-                        if is_plausible_rssi(p["rssi"])
-                    ]
-                    snr_values = [
-                        p["snr"] for p in packets_in_group if is_plausible_snr(p["snr"])
-                    ]
-                    hop_values = []
-                    for p in packets_in_group:
-                        if (
-                            p.get("hop_start") is not None
-                            and p.get("hop_limit") is not None
-                        ):
-                            hop_values.append(p["hop_start"] - p["hop_limit"])
-
-                    payload_lengths = [
-                        p["payload_length"]
-                        for p in packets_in_group
-                        if p["payload_length"]
-                    ]
-
-                    # Find the packet with the longest payload (most complete route data)
-                    best_payload_packet = max(
-                        packets_in_group, key=lambda x: len(x.get("raw_payload", b""))
-                    )
-
-                    # Create aggregated packet
-                    aggregated = {
-                        "id": base_packet["id"],
-                        "timestamp": base_packet["timestamp"],
-                        "timestamp_str": base_packet["timestamp_str"],
-                        "from_node_id": base_packet["from_node_id"],
-                        "to_node_id": base_packet["to_node_id"],
-                        "channel_id": base_packet.get("channel_id"),
-                        "mesh_packet_id": base_packet["mesh_packet_id"],
-                        "gateway_count": len(unique_gateways),
-                        "gateway_list": ",".join(unique_gateways),
-                        "reception_count": len(packets_in_group),
-                        "processed_successfully": any(
-                            p["processed_successfully"] for p in packets_in_group
-                        ),
-                        "raw_payload": best_payload_packet.get("raw_payload"),
-                        "is_grouped": True,
-                    }
-
-                    # RSSI aggregation
-                    if rssi_values:
-                        aggregated["min_rssi"] = min(rssi_values)
-                        aggregated["max_rssi"] = max(rssi_values)
-                        if aggregated["min_rssi"] == aggregated["max_rssi"]:
-                            aggregated["rssi_range"] = (
-                                f"{aggregated['min_rssi']:.1f} dBm"
-                            )
-                        else:
-                            aggregated["rssi_range"] = (
-                                f"{aggregated['min_rssi']:.1f} to {aggregated['max_rssi']:.1f} dBm"
-                            )
-                        aggregated["rssi"] = aggregated["rssi_range"]
-                    else:
-                        aggregated["min_rssi"] = None
-                        aggregated["max_rssi"] = None
-                        aggregated["rssi_range"] = None
-                        aggregated["rssi"] = None
-
-                    # SNR aggregation
-                    if snr_values:
-                        aggregated["min_snr"] = min(snr_values)
-                        aggregated["max_snr"] = max(snr_values)
-                        if aggregated["min_snr"] == aggregated["max_snr"]:
-                            aggregated["snr_range"] = f"{aggregated['min_snr']:.2f} dB"
-                        else:
-                            aggregated["snr_range"] = (
-                                f"{aggregated['min_snr']:.2f} to {aggregated['max_snr']:.2f} dB"
-                            )
-                        aggregated["snr"] = aggregated["snr_range"]
-                    else:
-                        aggregated["min_snr"] = None
-                        aggregated["max_snr"] = None
-                        aggregated["snr_range"] = None
-                        aggregated["snr"] = None
-
-                    # Hop count aggregation
-                    if hop_values:
-                        aggregated["min_hops"] = min(hop_values)
-                        aggregated["max_hops"] = max(hop_values)
-                        if aggregated["min_hops"] == aggregated["max_hops"]:
-                            aggregated["hop_range"] = str(aggregated["min_hops"])
-                        else:
-                            aggregated["hop_range"] = (
-                                f"{aggregated['min_hops']}-{aggregated['max_hops']}"
-                            )
-                        aggregated["hop_count"] = aggregated["min_hops"]
-                    else:
-                        aggregated["min_hops"] = None
-                        aggregated["max_hops"] = None
-                        aggregated["hop_range"] = None
-                        aggregated["hop_count"] = None
-
-                    # Payload length aggregation
-                    if payload_lengths:
-                        aggregated["avg_payload_length"] = sum(payload_lengths) / len(
-                            payload_lengths
+                if not needs_route_filtering:
+                    # TWO-STAGE HIGH-PERFORMANCE SQL GROUPING & PAGINATION
+                    # 1. Total count of unique groups in time window
+                    count_query = f"""
+                        SELECT count(*) as total FROM (
+                            SELECT 1 FROM packet_history
+                            {where_clause}
+                            GROUP BY mesh_packet_id, from_node_id, to_node_id
                         )
+                    """
+                    cursor.execute(count_query, params)
+                    count_row = cursor.fetchone()
+                    total_count = (
+                        count_row["total"]
+                        if count_row
+                        and (isinstance(count_row, dict) or hasattr(count_row, "keys"))
+                        else (count_row[0] if count_row else 0)
+                    )
+
+                    if total_count == 0:
+                        packets = []
                     else:
-                        aggregated["avg_payload_length"] = None
+                        order_column_map = {
+                            "timestamp": "MAX(timestamp)",
+                            "from_node_id": "from_node_id",
+                            "to_node_id": "to_node_id",
+                            "gateway_id": "COUNT(DISTINCT gateway_id)",
+                            "gateway_count": "COUNT(DISTINCT gateway_id)",
+                            "rssi": "MAX(rssi)",
+                            "snr": "MAX(snr)",
+                            "hop_count": "MIN(hop_start - hop_limit)",
+                            "payload_length": "AVG(payload_length)",
+                        }
+                        order_sql = order_column_map.get(order_by, "MAX(timestamp)")
+                        order_dir_sql = "DESC" if order_dir.lower() == "desc" else "ASC"
 
-                    # Success indicator
-                    aggregated["success"] = aggregated["processed_successfully"]
+                        # Stage 1: Get the exact slice of groups for this page
+                        group_slice_query = f"""
+                            SELECT mesh_packet_id, from_node_id, to_node_id
+                            FROM packet_history
+                            {where_clause}
+                            GROUP BY mesh_packet_id, from_node_id, to_node_id
+                            ORDER BY {order_sql} {order_dir_sql}
+                            LIMIT ? OFFSET ?
+                        """
+                        cursor.execute(group_slice_query, params + [limit, offset])
+                        page_group_rows = cursor.fetchall()
 
-                    # Enhanced route display using TraceroutePacket
-                    aggregated["route"] = None
-                    aggregated["route_display"] = "No route data"
-                    if aggregated.get("raw_payload"):
-                        try:
-                            from ..models.traceroute import TraceroutePacket
-
-                            tr_packet = TraceroutePacket(aggregated, resolve_names=True)
-                            if tr_packet.route_data["route_nodes"]:
-                                aggregated["route"] = json.dumps(
-                                    tr_packet.route_data["route_nodes"]
+                        if not page_group_rows:
+                            packets = []
+                        else:
+                            page_group_keys = [
+                                (
+                                    r["mesh_packet_id"]
+                                    if isinstance(r, dict)
+                                    else r[0],
+                                    r["from_node_id"] if isinstance(r, dict) else r[1],
+                                    r["to_node_id"] if isinstance(r, dict) else r[2],
                                 )
-                                # Get enhanced route display with node names
-                                aggregated["route_display"] = (
-                                    tr_packet.format_path_display("display")
+                                for r in page_group_rows
+                            ]
+                            page_mesh_ids = list({key[0] for key in page_group_keys})
+                            placeholders = ",".join("?" for _ in page_mesh_ids)
+
+                            # Stage 2: Fetch only individual receptions for the current page
+                            receptions_query = f"""
+                                SELECT
+                                    id, timestamp, from_node_id, to_node_id, gateway_id,
+                                    channel_id, hop_start, hop_limit, rssi, snr, payload_length, raw_payload,
+                                    processed_successfully, mesh_packet_id,
+                                    datetime(timestamp, 'unixepoch') as timestamp_str
+                                FROM packet_history
+                                WHERE mesh_packet_id IN ({placeholders}) AND portnum_name = 'TRACEROUTE_APP'
+                                ORDER BY timestamp DESC
+                            """
+                            cursor.execute(receptions_query, page_mesh_ids)
+                            individual_packets = [
+                                dict(row) for row in cursor.fetchall()
+                            ]
+
+                            groups: dict[
+                                tuple[Any, Any, Any], list[dict[str, Any]]
+                            ] = {}
+                            for packet in individual_packets:
+                                if not packet.get("mesh_packet_id") or not packet.get(
+                                    "from_node_id"
+                                ):
+                                    continue
+                                g_key = (
+                                    packet["mesh_packet_id"],
+                                    packet["from_node_id"],
+                                    packet["to_node_id"],
                                 )
-                        except Exception as e:
-                            logger.debug(
-                                f"Failed to parse route for grouped packet {aggregated['id']}: {e}"
-                            )
+                                if g_key not in groups:
+                                    groups[g_key] = []
+                                groups[g_key].append(packet)
 
-                    aggregated_packets.append(aggregated)
+                            aggregated_by_key = {
+                                g_key: TracerouteRepository._aggregate_group_packets(
+                                    p_list
+                                )
+                                for g_key, p_list in groups.items()
+                            }
 
-                if needs_route_filtering:
+                            packets = [
+                                aggregated_by_key[key]
+                                for key in page_group_keys
+                                if key in aggregated_by_key
+                            ]
+
+                else:
+                    # Fallback for route_node filter (requires decoding raw_payload protobufs)
+                    fetch_limit = 50000
+                    query = f"""
+                        SELECT
+                            id, timestamp, from_node_id, to_node_id, gateway_id,
+                            channel_id, hop_start, hop_limit, rssi, snr, payload_length, raw_payload,
+                            processed_successfully, mesh_packet_id,
+                            datetime(timestamp, 'unixepoch') as timestamp_str
+                        FROM packet_history
+                        {where_clause}
+                        ORDER BY timestamp DESC
+                        LIMIT ?
+                    """
+                    cursor.execute(query, params + [fetch_limit])
+                    individual_packets = [dict(row) for row in cursor.fetchall()]
+
+                    groups = {}
+                    for packet in individual_packets:
+                        if not packet.get("mesh_packet_id") or not packet.get(
+                            "from_node_id"
+                        ):
+                            continue
+                        g_key = (
+                            packet["mesh_packet_id"],
+                            packet["from_node_id"],
+                            packet["to_node_id"],
+                        )
+                        if g_key not in groups:
+                            groups[g_key] = []
+                        groups[g_key].append(packet)
+
+                    aggregated_packets = [
+                        TracerouteRepository._aggregate_group_packets(p_list)
+                        for p_list in groups.values()
+                    ]
+
                     filtered_packets: list[dict[str, Any]] = []
                     for packet in aggregated_packets:
-                        # Direct match on source/destination
                         if (
                             packet.get("from_node_id") == route_node_filter
                             or packet.get("to_node_id") == route_node_filter
@@ -3697,8 +3767,6 @@ class TracerouteRepository:
                             filtered_packets.append(packet)
                             continue
 
-                        # Attempt to match within the hop route
-                        # Prefer already extracted route information if available
                         route_nodes: list[int] | None = None
                         if packet.get("route"):
                             try:
@@ -3708,7 +3776,6 @@ class TracerouteRepository:
                             except Exception:
                                 route_nodes = None
 
-                        # If not available, fall back to parsing the raw payload
                         if route_nodes is None and packet.get("raw_payload"):
                             try:
                                 from ..models.traceroute import TraceroutePacket as _TRP
@@ -3724,67 +3791,44 @@ class TracerouteRepository:
                         if route_nodes and route_node_filter in route_nodes:
                             filtered_packets.append(packet)
 
-                    aggregated_packets = filtered_packets
-                    # For grouped queries we can now set an accurate total_count
-                    total_count = len(aggregated_packets)
+                    total_count = len(filtered_packets)
 
-                # Apply sorting to aggregated packets
-                reverse_sort = order_dir.lower() == "desc"
-
-                if order_by == "gateway_id" or order_by == "gateway_count":
-                    # Sort by gateway count
-                    aggregated_packets.sort(
-                        key=lambda x: x["gateway_count"], reverse=reverse_sort
-                    )
-                elif order_by == "timestamp":
-                    aggregated_packets.sort(
-                        key=lambda x: x["timestamp"], reverse=reverse_sort
-                    )
-                elif order_by == "from_node_id":
-                    aggregated_packets.sort(
-                        key=lambda x: x.get("from_node_id", 0), reverse=reverse_sort
-                    )
-                elif order_by == "to_node_id":
-                    aggregated_packets.sort(
-                        key=lambda x: x.get("to_node_id", 0), reverse=reverse_sort
-                    )
-                elif order_by == "rssi":
-                    aggregated_packets.sort(
-                        key=lambda x: x.get("min_rssi", -999), reverse=reverse_sort
-                    )
-                elif order_by == "snr":
-                    aggregated_packets.sort(
-                        key=lambda x: x.get("min_snr", -999), reverse=reverse_sort
-                    )
-                elif order_by == "hop_count":
-                    aggregated_packets.sort(
-                        key=lambda x: x.get("min_hops", 999), reverse=reverse_sort
-                    )
-                elif order_by == "payload_length":
-                    aggregated_packets.sort(
-                        key=lambda x: x.get("avg_payload_length", 0),
-                        reverse=reverse_sort,
-                    )
-                else:
-                    # Default to timestamp
-                    aggregated_packets.sort(
-                        key=lambda x: x["timestamp"], reverse=reverse_sort
-                    )
-
-                # Apply pagination
-                packets = aggregated_packets[offset : offset + limit]
-
-                # Handle None total_count for grouped queries
-                if total_count is None:
-                    # Estimate total_count based on results for grouped queries
-                    if len(packets) == limit:
-                        total_count = (
-                            offset + limit + 1
-                        )  # Estimate at least one more page
+                    reverse_sort = order_dir.lower() == "desc"
+                    if order_by in ("gateway_id", "gateway_count"):
+                        filtered_packets.sort(
+                            key=lambda x: x["gateway_count"], reverse=reverse_sort
+                        )
+                    elif order_by == "from_node_id":
+                        filtered_packets.sort(
+                            key=lambda x: x.get("from_node_id", 0), reverse=reverse_sort
+                        )
+                    elif order_by == "to_node_id":
+                        filtered_packets.sort(
+                            key=lambda x: x.get("to_node_id", 0), reverse=reverse_sort
+                        )
+                    elif order_by == "rssi":
+                        filtered_packets.sort(
+                            key=lambda x: x.get("min_rssi", -999), reverse=reverse_sort
+                        )
+                    elif order_by == "snr":
+                        filtered_packets.sort(
+                            key=lambda x: x.get("min_snr", -999), reverse=reverse_sort
+                        )
+                    elif order_by == "hop_count":
+                        filtered_packets.sort(
+                            key=lambda x: x.get("min_hops", 999), reverse=reverse_sort
+                        )
+                    elif order_by == "payload_length":
+                        filtered_packets.sort(
+                            key=lambda x: x.get("avg_payload_length", 0),
+                            reverse=reverse_sort,
+                        )
                     else:
-                        total_count = offset + len(
-                            packets
-                        )  # Exact count for partial page
+                        filtered_packets.sort(
+                            key=lambda x: x["timestamp"], reverse=reverse_sort
+                        )
+
+                    packets = filtered_packets[offset : offset + limit]
 
             else:
                 # Original ungrouped behavior

--- a/src/malla/database/repositories.py
+++ b/src/malla/database/repositories.py
@@ -3370,6 +3370,10 @@ class TracerouteRepository:
             if filters.get("processed_successfully_only"):
                 where_conditions.append("processed_successfully = 1")
 
+            where_conditions.append(
+                "raw_payload IS NOT NULL AND length(raw_payload) > 0"
+            )
+
             where_clause = "WHERE " + " AND ".join(where_conditions)
             query = f"""
                 SELECT
@@ -3574,6 +3578,11 @@ class TracerouteRepository:
 
             if filters.get("processed_successfully_only"):
                 where_conditions.append("processed_successfully = 1")
+
+            if filters.get("exclude_empty_payload"):
+                where_conditions.append(
+                    "raw_payload IS NOT NULL AND length(raw_payload) > 0"
+                )
 
             # Check if route_node filtering is needed
             route_node_filter = filters.get("route_node")

--- a/src/malla/database/schema.py
+++ b/src/malla/database/schema.py
@@ -107,6 +107,26 @@ INDEX_SPECS: tuple[tuple[str, str, str], ...] = (
         "CREATE INDEX IF NOT EXISTS idx_packet_history_chat_channel ON packet_history(portnum_name, channel_id, id DESC) WHERE raw_payload IS NOT NULL AND payload_length > 0",
     ),
     (
+        # Traceroute window scans (hop-node lists, related-nodes, link analysis,
+        # network graph). TRACEROUTE_APP packets are a tiny fraction of
+        # packet_history, but the plain time-leading indexes force a row lookup
+        # for every packet in the time range. On a database whose entire history
+        # fits inside the requested window that degrades to a near-full scan of
+        # millions of rows; this partial index reduces the scan to the ~few
+        # thousand traceroute rows themselves.
+        "idx_packet_history_traceroute_time",
+        "packet_history",
+        "CREATE INDEX IF NOT EXISTS idx_packet_history_traceroute_time ON packet_history(timestamp DESC) WHERE portnum_name = 'TRACEROUTE_APP' AND processed_successfully = 1 AND raw_payload IS NOT NULL AND length(raw_payload) > 0",
+    ),
+    (
+        # Packet-link map aggregate: GROUP BY from_node_id, gateway_id over
+        # 0-hop packets with AVG(rssi)/AVG(snr)/MAX(channel_id). Covering those
+        # columns turns the aggregate into an index-only scan in group order.
+        "idx_packet_history_packet_links_cover",
+        "packet_history",
+        "CREATE INDEX IF NOT EXISTS idx_packet_history_packet_links_cover ON packet_history(from_node_id, gateway_id, timestamp, rssi, snr, channel_id) WHERE hop_start = hop_limit AND from_node_id IS NOT NULL AND gateway_id IS NOT NULL",
+    ),
+    (
         "idx_node_hex_id",
         "node_info",
         "CREATE INDEX IF NOT EXISTS idx_node_hex_id ON node_info(hex_id)",
@@ -168,7 +188,7 @@ def query_planner_stats_present(cursor: sqlite3.Cursor) -> bool:
     return cursor.fetchone() is not None
 
 
-def ensure_query_planner_stats(cursor: sqlite3.Cursor) -> bool:
+def ensure_query_planner_stats(cursor: sqlite3.Cursor, *, force: bool = False) -> bool:
     """Seed SQLite query-planner statistics if they are missing.
 
     Without ``sqlite_stat1`` the planner guesses index selectivity and can pick
@@ -184,25 +204,32 @@ def ensure_query_planner_stats(cursor: sqlite3.Cursor) -> bool:
 
     Stats are only *seeded* here (when absent). Keeping them fresh as the
     database grows is handled separately by periodic ``PRAGMA optimize`` in the
-    capture daemon.
+    capture daemon. Pass ``force=True`` to refresh stats even when present —
+    needed after adding indexes to an existing database, since stale statistics
+    keep the planner on the old plans.
     """
 
-    if query_planner_stats_present(cursor):
+    if not force and query_planner_stats_present(cursor):
         return False  # stats already present – nothing to do
 
     # analysis_limit bounds the work per index; without it ANALYZE would scan
     # every index in full and could take many minutes on a huge packet_history.
     cursor.execute("PRAGMA analysis_limit=1000")
-    logger.info("Query-planner statistics missing – running bounded ANALYZE")
+    logger.info("Running bounded ANALYZE for query-planner statistics")
     cursor.execute("ANALYZE")
     return True
 
 
 def ensure_startup_schema(
     cursor: sqlite3.Cursor, *, drop_legacy_indexes: bool = False
-) -> None:
-    """Ensure shared schema columns and startup indexes exist."""
+) -> bool:
+    """Ensure shared schema columns and startup indexes exist.
 
+    Returns ``True`` when any index was created (or legacy index dropped), i.e.
+    the query-planner statistics may be stale and should be refreshed.
+    """
+
+    schema_changed = False
     existing_tables = _get_existing_tables(cursor)
     existing_indexes = _get_existing_indexes(cursor)
 
@@ -220,7 +247,11 @@ def ensure_startup_schema(
             continue
         cursor.execute(sql)
         existing_indexes.add(index_name)
+        schema_changed = True
 
     if drop_legacy_indexes and "packet_history" in existing_tables:
         for index_name in LEGACY_INDEX_NAMES:
             cursor.execute(f"DROP INDEX IF EXISTS {index_name}")
+            schema_changed = True
+
+    return schema_changed

--- a/src/malla/mqtt_capture.py
+++ b/src/malla/mqtt_capture.py
@@ -409,7 +409,7 @@ def init_database() -> None:
         )
     """)
 
-    ensure_startup_schema(cursor, drop_legacy_indexes=True)
+    schema_changed = ensure_startup_schema(cursor, drop_legacy_indexes=True)
 
     # Backfill primary_channel only when there are actually missing values.
     try:
@@ -455,8 +455,9 @@ def init_database() -> None:
     # Seed query-planner statistics on first run so the planner picks
     # index-based plans instead of full scans on a large packet_history. Runs in
     # a background thread so a cold ANALYZE (~100s on a multi-GB DB) does not
-    # delay packet ingestion or hold the write lock.
-    seed_query_planner_stats_async(DATABASE_FILE)
+    # delay packet ingestion or hold the write lock. Re-run when startup
+    # created new indexes so the planner learns about them.
+    seed_query_planner_stats_async(DATABASE_FILE, force=schema_changed)
 
     logging.info(
         "Database initialized: %s (%.3fs)",

--- a/src/malla/routes/api_routes.py
+++ b/src/malla/routes/api_routes.py
@@ -1068,6 +1068,7 @@ def api_traceroute_hops_nodes():
                 WHERE portnum_name = 'TRACEROUTE_APP'
                   AND processed_successfully = 1
                   AND raw_payload IS NOT NULL
+                  AND length(raw_payload) > 0
                   AND timestamp >= ? AND timestamp <= ?
                 ORDER BY timestamp DESC
                 LIMIT {DEFAULT_GRAPH_PACKET_LIMIT}
@@ -1221,6 +1222,7 @@ def api_traceroute_link(node1_id, node2_id):
             "start_time": start_time.timestamp(),
             "end_time": end_time.timestamp(),
             "processed_successfully_only": True,
+            "exclude_empty_payload": True,
         }
 
         all_packets = TracerouteRepository.get_traceroute_packets(

--- a/src/malla/routes/api_routes.py
+++ b/src/malla/routes/api_routes.py
@@ -30,7 +30,10 @@ from ..utils.node_utils import (
 )
 from ..utils.serialization_utils import convert_bytes_to_base64, sanitize_floats
 from ..utils.signal_quality import is_plausible_traceroute_snr
-from ..utils.traceroute_utils import parse_traceroute_payload
+from ..utils.traceroute_utils import (
+    get_packet_traceroute_id,
+    parse_traceroute_payload,
+)
 
 logger = logging.getLogger(__name__)
 api_bp = Blueprint("api", __name__, url_prefix="/api")
@@ -1226,7 +1229,7 @@ def api_traceroute_link(node1_id, node2_id):
         }
 
         all_packets = TracerouteRepository.get_traceroute_packets(
-            limit=15000, filters=filters
+            limit=DEFAULT_GRAPH_PACKET_LIMIT, filters=filters
         )
 
         # Don't convert bytes to base64 yet - TraceroutePacket needs raw bytes
@@ -1237,41 +1240,54 @@ def api_traceroute_link(node1_id, node2_id):
 
         # Process each packet to find RF hops between our target nodes
         processed_traceroutes: list[dict[str, Any]] = []
+        seen_traceroute_packets: dict[Any, dict[str, Any]] = {}
+        seen_traceroute_hops: set[tuple[Any, int, int]] = set()
         direction_counts: dict[str, int] = {}
         snr_values: list[float] = []
 
         for packet in all_packets["packets"]:
             try:
+                tr_id = get_packet_traceroute_id(packet)
                 # Create TraceroutePacket for analysis
                 tr_packet = TraceroutePacket(packet, resolve_names=True)
 
                 # Get RF hops (no need to calculate distances for this analysis)
                 rf_hops = tr_packet.get_rf_hops()
 
-                # Find any RF hop between our two target nodes
-                target_hop = None
-                for hop in rf_hops:
+                # Find all RF hops between our two target nodes
+                matching_hops = [
+                    hop
+                    for hop in rf_hops
                     if (
                         hop.from_node_id == node1_id_int
                         and hop.to_node_id == node2_id_int
-                    ) or (
+                    )
+                    or (
                         hop.from_node_id == node2_id_int
                         and hop.to_node_id == node1_id_int
-                    ):
-                        target_hop = hop
-                        break
+                    )
+                ]
 
-                if target_hop:
-                    # Determine direction
-                    if target_hop.from_node_id == node1_id_int:
-                        direction = f"{node_names.get(node1_id_int, f'!{node1_id_int:08x}')} → {node_names.get(node2_id_int, f'!{node2_id_int:08x}')}"
-                    else:
-                        direction = f"{node_names.get(node2_id_int, f'!{node2_id_int:08x}')} → {node_names.get(node1_id_int, f'!{node1_id_int:08x}')}"
+                if matching_hops:
+                    packet_snrs: list[float] = []
+                    for hop in matching_hops:
+                        # Multiple gateways can receive the same traceroute: count
+                        # each RF hop once per transmission (per traceroute id).
+                        hop_tr_key = (tr_id, hop.from_node_id, hop.to_node_id)
+                        if hop_tr_key not in seen_traceroute_hops:
+                            seen_traceroute_hops.add(hop_tr_key)
 
-                    direction_counts[direction] = direction_counts.get(direction, 0) + 1
+                            # Determine direction
+                            if hop.from_node_id == node1_id_int:
+                                direction = f"{node_names.get(node1_id_int, f'!{node1_id_int:08x}')} → {node_names.get(node2_id_int, f'!{node2_id_int:08x}')}"
+                            else:
+                                direction = f"{node_names.get(node2_id_int, f'!{node2_id_int:08x}')} → {node_names.get(node1_id_int, f'!{node1_id_int:08x}')}"
 
-                    if is_plausible_traceroute_snr(target_hop.snr):
-                        snr_values.append(target_hop.snr)
+                            direction_counts[direction] = direction_counts.get(direction, 0) + 1
+
+                            if is_plausible_traceroute_snr(hop.snr):
+                                snr_values.append(hop.snr)
+                                packet_snrs.append(hop.snr)
 
                     # Create route_hops structure for UI - include ALL RF hops (forward and return)
                     route_hops = []
@@ -1323,7 +1339,29 @@ def api_traceroute_link(node1_id, node2_id):
                         except (ValueError, TypeError):
                             pass
 
-                    # Create traceroute entry for UI
+                    # Representative hop SNR for the history entry / chart:
+                    # use the minimum valid SNR among matching hops so the weakest
+                    # direction for this packet is reflected.
+                    entry_hop_snr = (
+                        min(packet_snrs)
+                        if packet_snrs
+                        else (
+                            min(
+                                [
+                                    h.snr
+                                    for h in matching_hops
+                                    if is_plausible_traceroute_snr(h.snr)
+                                ]
+                            )
+                            if any(
+                                is_plausible_traceroute_snr(h.snr)
+                                for h in matching_hops
+                            )
+                            else None
+                        )
+                    )
+
+                    # Create traceroute entry for UI (one per unique traceroute)
                     traceroute_entry = {
                         "id": packet["id"],
                         "timestamp": packet["timestamp"],
@@ -1336,16 +1374,25 @@ def api_traceroute_link(node1_id, node2_id):
                         "gateway_node_name": gateway_node_name,
                         # Null out garbage SNR so the SNR-over-time chart
                         # (which autoscales over hop_snr) can't be flattened.
-                        "hop_snr": target_hop.snr
-                        if is_plausible_traceroute_snr(target_hop.snr)
-                        else None,
+                        "hop_snr": entry_hop_snr,
                         "route_hops": route_hops,
                         "complete_path_display": tr_packet.format_path_display(
                             "display"
                         ),
                     }
 
-                    processed_traceroutes.append(traceroute_entry)
+                    if tr_id not in seen_traceroute_packets:
+                        seen_traceroute_packets[tr_id] = traceroute_entry
+                        processed_traceroutes.append(traceroute_entry)
+                    else:
+                        existing_entry = seen_traceroute_packets[tr_id]
+                        if len(route_hops) > len(existing_entry.get("route_hops", [])):
+                            existing_entry["route_hops"] = route_hops
+                            existing_entry["complete_path_display"] = (
+                                traceroute_entry["complete_path_display"]
+                            )
+                            if entry_hop_snr is not None:
+                                existing_entry["hop_snr"] = entry_hop_snr
 
             except Exception as e:
                 logger.warning(
@@ -1358,6 +1405,7 @@ def api_traceroute_link(node1_id, node2_id):
 
         # Calculate summary statistics
         total_attempts = len(processed_traceroutes)
+        total_observations = sum(direction_counts.values())
         avg_snr = sum(snr_values) / len(snr_values) if snr_values else None
 
         # Ensure direction_counts has the expected format even when empty
@@ -1374,6 +1422,7 @@ def api_traceroute_link(node1_id, node2_id):
             "from_node_name": node_names.get(node1_id_int, f"!{node1_id_int:08x}"),
             "to_node_name": node_names.get(node2_id_int, f"!{node2_id_int:08x}"),
             "total_attempts": total_attempts,
+            "total_observations": total_observations,
             "avg_snr": avg_snr,
             "direction_counts": direction_counts,
             "traceroutes": processed_traceroutes,
@@ -1913,7 +1962,9 @@ def api_traceroute_data():
                 node_ids.add(tr["to_node_id"])
             # Check if gateway is a node ID
             gateway_id = tr.get("gateway_id")
-            if gateway_id and gateway_id.startswith("!"):
+            if not gateway_id and tr.get("gateway_count") == 1 and tr.get("gateway_list"):
+                gateway_id = tr.get("gateway_list").strip()
+            if gateway_id and isinstance(gateway_id, str) and gateway_id.startswith("!"):
                 try:
                     gateway_node_id = int(gateway_id[1:], 16)
                     gateway_node_ids.add(gateway_node_id)
@@ -2081,10 +2132,19 @@ def api_traceroute_data():
             if group_packets:
                 response_data["gateway_list"] = tr.get("gateway_list", "")
                 response_data["gateway_count"] = tr.get("gateway_count", 0)
+                if response_data["gateway_count"] == 1 and response_data["gateway_list"]:
+                    single_gw = response_data["gateway_list"].strip()
+                    if single_gw.startswith("!"):
+                        try:
+                            gateway_node_id = int(single_gw[1:], 16)
+                            response_data["gateway_node_id"] = gateway_node_id
+                            response_data["gateway_name"] = node_names.get(gateway_node_id)
+                        except ValueError:
+                            pass
             else:
                 # For individual packets, add gateway node info for frontend links
                 gateway_id = tr.get("gateway_id")
-                if gateway_id and gateway_id.startswith("!"):
+                if gateway_id and isinstance(gateway_id, str) and gateway_id.startswith("!"):
                     try:
                         gateway_node_id = int(gateway_id[1:], 16)
                         response_data["gateway_node_id"] = gateway_node_id

--- a/src/malla/services/location_service.py
+++ b/src/malla/services/location_service.py
@@ -950,7 +950,7 @@ class LocationService:
                     AVG(CASE WHEN {rssi_valid_sql()} THEN rssi END) AS avg_rssi,
                     AVG(CASE WHEN {snr_valid_sql()} THEN snr END) AS avg_snr,
                     MAX(timestamp)         AS last_seen
-                FROM packet_history
+                FROM packet_history INDEXED BY idx_packet_history_packet_links_cover
                 {where_sql}
                 GROUP BY from_node_id, gateway_id
             """

--- a/src/malla/services/node_service.py
+++ b/src/malla/services/node_service.py
@@ -12,6 +12,7 @@ from ..database import NodeRepository
 from ..services.location_service import LocationService
 from ..services.traceroute_service import TracerouteService
 from ..utils.node_utils import convert_node_id
+from ..utils.traceroute_utils import get_packet_traceroute_id
 
 logger = logging.getLogger(__name__)
 
@@ -187,7 +188,8 @@ class NodeService:
                 gateway_id,
                 hop_start,
                 hop_limit,
-                raw_payload
+                raw_payload,
+                mesh_packet_id
             FROM packet_history
             WHERE portnum_name = 'TRACEROUTE_APP'
             AND processed_successfully = 1
@@ -202,6 +204,7 @@ class NodeService:
 
         # Track nodes with direct RF hops and their connection counts
         related_nodes = {}
+        seen_traceroute_hops: set[tuple[Any, int, int]] = set()
 
         for packet in packets:
             (
@@ -213,6 +216,7 @@ class NodeService:
                 hop_start,
                 hop_limit,
                 raw_payload,
+                mesh_packet_id,
             ) = packet
 
             try:
@@ -226,15 +230,22 @@ class NodeService:
                     "hop_start": hop_start,
                     "hop_limit": hop_limit,
                     "raw_payload": raw_payload,
+                    "mesh_packet_id": mesh_packet_id,
                 }
 
                 tr_packet = TraceroutePacket(packet_data, resolve_names=False)
+                tr_id = get_packet_traceroute_id(packet_data)
 
                 # Get all RF hops (both forward and return)
                 rf_hops = tr_packet.get_rf_hops()
 
                 # Check if any RF hop involves our target node
                 for hop in rf_hops:
+                    hop_tr_key = (tr_id, hop.from_node_id, hop.to_node_id)
+                    if hop_tr_key in seen_traceroute_hops:
+                        continue
+                    seen_traceroute_hops.add(hop_tr_key)
+
                     if hop.from_node_id == node_id_int:
                         # Target node is the sender in this RF hop
                         other_node = hop.to_node_id

--- a/src/malla/services/node_service.py
+++ b/src/malla/services/node_service.py
@@ -192,6 +192,7 @@ class NodeService:
             WHERE portnum_name = 'TRACEROUTE_APP'
             AND processed_successfully = 1
             AND raw_payload IS NOT NULL
+            AND length(raw_payload) > 0
             AND timestamp >= ?
             AND timestamp <= ?
         """

--- a/src/malla/services/traceroute_service.py
+++ b/src/malla/services/traceroute_service.py
@@ -24,7 +24,10 @@ from ..models.traceroute import (
 )
 from ..utils.node_utils import get_bulk_node_names
 from ..utils.signal_quality import is_plausible_traceroute_snr
-from ..utils.traceroute_utils import parse_traceroute_payload
+from ..utils.traceroute_utils import (
+    get_packet_traceroute_id,
+    parse_traceroute_payload,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -658,6 +661,7 @@ class TracerouteService:
                 cache_hits = 0
                 cache_misses = 0
                 early_filtered = 0
+                seen_traceroute_hops: set[tuple[Any, int, int]] = set()
 
                 for packet in result["packets"]:
                     packet_start = time.time()
@@ -674,6 +678,8 @@ class TracerouteService:
                             packet_data=packet,
                             resolve_names=True,
                         )
+
+                        tr_id = get_packet_traceroute_id(packet)
 
                         # Track cache performance before distance calculation
                         cache_size_before = len(location_cache)
@@ -706,6 +712,11 @@ class TracerouteService:
                                 or 4294967295 in [hop.from_node_id, hop.to_node_id]
                             ):
                                 continue
+
+                            hop_tr_key = (tr_id, hop.from_node_id, hop.to_node_id)
+                            if hop_tr_key in seen_traceroute_hops:
+                                continue
+                            seen_traceroute_hops.add(hop_tr_key)
 
                             # Use a bidirectional key so A<->B == B<->A
                             key = tuple(sorted([hop.from_node_id, hop.to_node_id]))
@@ -1091,6 +1102,8 @@ class TracerouteService:
             nodes = {}  # node_id -> node_data
             direct_links = {}  # (node1, node2) -> link_data
             indirect_connections = {}  # (node1, node2) -> connection_data
+            seen_traceroute_hops: set[tuple[Any, int, int]] = set()
+            seen_traceroute_indirect: set[tuple[Any, tuple[int, int]]] = set()
 
             # Statistics
             stats = {
@@ -1118,6 +1131,8 @@ class TracerouteService:
                     if not rf_hops:
                         continue
 
+                    tr_id = get_packet_traceroute_id(tr_data)
+
                     stats["packets_with_rf_hops"] += 1
                     stats["total_rf_hops"] += len(rf_hops)
 
@@ -1135,6 +1150,20 @@ class TracerouteService:
                             continue
                         if 4294967295 in [hop.from_node_id, hop.to_node_id]:
                             continue
+
+                        link_key = tuple(sorted([hop.from_node_id, hop.to_node_id]))
+                        hop_tr_key = (tr_id, hop.from_node_id, hop.to_node_id)
+                        if hop_tr_key in seen_traceroute_hops:
+                            # Keep recency updated even if this hop was already counted for this traceroute
+                            if (
+                                link_key in direct_links
+                                and tr_data["timestamp"] > direct_links[link_key]["last_seen"]
+                            ):
+                                direct_links[link_key]["last_seen"] = tr_data["timestamp"]
+                                direct_links[link_key]["last_packet_id"] = tr_data["id"]
+                            continue
+                        seen_traceroute_hops.add(hop_tr_key)
+
                         # Add nodes to the graph
                         for node_id, node_name in [
                             (hop.from_node_id, hop.from_node_name),
@@ -1155,9 +1184,6 @@ class TracerouteService:
                             nodes[node_id]["packet_count"] += 1
                             if tr_data["timestamp"] > nodes[node_id]["last_seen"]:
                                 nodes[node_id]["last_seen"] = tr_data["timestamp"]
-
-                        # Create bidirectional link key (sorted to ensure consistency)
-                        link_key = tuple(sorted([hop.from_node_id, hop.to_node_id]))
 
                         # Add/update direct link
                         if link_key not in direct_links:
@@ -1194,32 +1220,42 @@ class TracerouteService:
                         indirect_key = tuple(
                             sorted([first_hop.from_node_id, last_hop.to_node_id])
                         )
+                        indirect_tr_key = (tr_id, indirect_key)
 
                         # Only add if it's not already a direct link
                         if indirect_key not in direct_links:
-                            if indirect_key not in indirect_connections:
-                                path_snrs = [
-                                    h.snr
-                                    for h in rf_hops
-                                    if h.snr and is_plausible_traceroute_snr(h.snr)
-                                ]
-                                indirect_connections[indirect_key] = {
-                                    "source": indirect_key[0],
-                                    "target": indirect_key[1],
-                                    "hop_count": len(rf_hops),
-                                    "path_count": 1,
-                                    "avg_snr": (sum(path_snrs) / len(path_snrs))
-                                    if path_snrs
-                                    else None,
-                                    "last_seen": tr_data["timestamp"],
-                                    "last_packet_id": tr_data["id"],
-                                }
+                            if indirect_tr_key in seen_traceroute_indirect:
+                                if (
+                                    indirect_key in indirect_connections
+                                    and tr_data["timestamp"] > indirect_connections[indirect_key]["last_seen"]
+                                ):
+                                    indirect_connections[indirect_key]["last_seen"] = tr_data["timestamp"]
+                                    indirect_connections[indirect_key]["last_packet_id"] = tr_data["id"]
                             else:
-                                conn = indirect_connections[indirect_key]
-                                conn["path_count"] += 1
-                                if tr_data["timestamp"] > conn["last_seen"]:
-                                    conn["last_seen"] = tr_data["timestamp"]
-                                    conn["last_packet_id"] = tr_data["id"]
+                                seen_traceroute_indirect.add(indirect_tr_key)
+                                if indirect_key not in indirect_connections:
+                                    path_snrs = [
+                                        h.snr
+                                        for h in rf_hops
+                                        if h.snr and is_plausible_traceroute_snr(h.snr)
+                                    ]
+                                    indirect_connections[indirect_key] = {
+                                        "source": indirect_key[0],
+                                        "target": indirect_key[1],
+                                        "hop_count": len(rf_hops),
+                                        "path_count": 1,
+                                        "avg_snr": (sum(path_snrs) / len(path_snrs))
+                                        if path_snrs
+                                        else None,
+                                        "last_seen": tr_data["timestamp"],
+                                        "last_packet_id": tr_data["id"],
+                                    }
+                                else:
+                                    conn = indirect_connections[indirect_key]
+                                    conn["path_count"] += 1
+                                    if tr_data["timestamp"] > conn["last_seen"]:
+                                        conn["last_seen"] = tr_data["timestamp"]
+                                        conn["last_packet_id"] = tr_data["id"]
 
                 except Exception as e:
                     logger.warning(

--- a/src/malla/services/traceroute_service.py
+++ b/src/malla/services/traceroute_service.py
@@ -301,7 +301,10 @@ class TracerouteService:
 
         try:
             # Get recent successful traceroutes
-            filters = {"processed_successfully_only": True}
+            filters = {
+                "processed_successfully_only": True,
+                "exclude_empty_payload": True,
+            }
             result = TracerouteRepository.get_traceroute_packets(
                 limit=1000,  # Analyze more data
                 filters=filters,
@@ -502,6 +505,7 @@ class TracerouteService:
                 "start_time": start_time_filter.timestamp(),
                 "end_time": end_time.timestamp(),
                 "processed_successfully_only": True,
+                "exclude_empty_payload": True,
             }
 
             result = TracerouteRepository.get_traceroute_packets(

--- a/src/malla/services/traceroute_service.py
+++ b/src/malla/services/traceroute_service.py
@@ -1217,9 +1217,10 @@ class TracerouteService:
                         last_hop = rf_hops[-1]
 
                         # Create indirect connection key
-                        indirect_key = tuple(
-                            sorted([first_hop.from_node_id, last_hop.to_node_id])
+                        key_lo, key_hi = sorted(
+                            [first_hop.from_node_id, last_hop.to_node_id]
                         )
+                        indirect_key = (key_lo, key_hi)
                         indirect_tr_key = (tr_id, indirect_key)
 
                         # Only add if it's not already a direct link

--- a/src/malla/templates/packets.html
+++ b/src/malla/templates/packets.html
@@ -359,15 +359,15 @@ document.addEventListener('DOMContentLoaded', function() {
                         const gatewayName = row.gateway_name;
                         const gatewayNodeId = row.gateway_node_id;
 
-                        if (value && value.startsWith('!') && gatewayNodeId) {
+                        if (value && typeof value === 'string' && value.startsWith('!') && gatewayNodeId) {
                             const shortName = value.substring(value.length - 4).toUpperCase();
                             return nodeLink(gatewayNodeId, shortName);
                         } else if (gatewayName && gatewayNodeId) {
-                            const parenMatch = gatewayName.match(/\(([^)]+)\)$/);
-                            const shortName = parenMatch ? parenMatch[1] : gatewayName.substring(0, 4).toUpperCase();
+                            const parenMatch = typeof gatewayName === 'string' ? gatewayName.match(/\(([^)]+)\)$/) : null;
+                            const shortName = parenMatch ? parenMatch[1] : (typeof gatewayName === 'string' ? gatewayName.substring(0, 4).toUpperCase() : 'N/A');
                             return nodeLink(gatewayNodeId, shortName);
                         }
-                        return textNode(value || 'N/A');
+                        return textNode((typeof value === 'string' ? value : (value != null ? String(value) : '')) || 'N/A');
                     }
                 }
             },

--- a/src/malla/templates/traceroute.html
+++ b/src/malla/templates/traceroute.html
@@ -266,7 +266,18 @@ document.addEventListener('DOMContentLoaded', function() {
                                 title: `Multiple gateways: ${row.gateway_list}`
                             }, `${count} gateways`);
                         } else if (count === 1) {
-                            return badge('1 gateway', 'bg-info');
+                            const gw = (typeof value === 'string' && value.startsWith('!')) ? value : (row.gateway_list || '');
+                            const gatewayName = row.gateway_name;
+                            const gatewayNodeId = row.gateway_node_id;
+                            if (gw && typeof gw === 'string' && gw.startsWith('!') && gatewayNodeId) {
+                                const shortName = gw.substring(gw.length - 4).toUpperCase();
+                                return nodeLink(gatewayNodeId, shortName);
+                            } else if (gatewayName && gatewayNodeId) {
+                                const parenMatch = typeof gatewayName === 'string' ? gatewayName.match(/\(([^)]+)\)$/) : null;
+                                const shortName = parenMatch ? parenMatch[1] : (typeof gatewayName === 'string' ? gatewayName.substring(0, 4).toUpperCase() : 'N/A');
+                                return nodeLink(gatewayNodeId, shortName);
+                            }
+                            return textNode((typeof gw === 'string' && gw) ? gw : (gatewayName || (typeof value === 'string' ? value : '1 Gateway')));
                         } else {
                             return el('span', { className: 'text-muted' }, 'N/A');
                         }
@@ -274,15 +285,15 @@ document.addEventListener('DOMContentLoaded', function() {
                         const gatewayName = row.gateway_name;
                         const gatewayNodeId = row.gateway_node_id;
 
-                        if (value && value.startsWith('!') && gatewayNodeId) {
+                        if (value && typeof value === 'string' && value.startsWith('!') && gatewayNodeId) {
                             const shortName = value.substring(value.length - 4).toUpperCase();
                             return nodeLink(gatewayNodeId, shortName);
                         } else if (gatewayName && gatewayNodeId) {
-                            const parenMatch = gatewayName.match(/\(([^)]+)\)$/);
-                            const shortName = parenMatch ? parenMatch[1] : gatewayName.substring(0, 4).toUpperCase();
+                            const parenMatch = typeof gatewayName === 'string' ? gatewayName.match(/\(([^)]+)\)$/) : null;
+                            const shortName = parenMatch ? parenMatch[1] : (typeof gatewayName === 'string' ? gatewayName.substring(0, 4).toUpperCase() : 'N/A');
                             return nodeLink(gatewayNodeId, shortName);
                         }
-                        return textNode(value || 'N/A');
+                        return textNode((typeof value === 'string' ? value : (value != null ? String(value) : '')) || 'N/A');
                     }
                 }
             },

--- a/src/malla/utils/traceroute_utils.py
+++ b/src/malla/utils/traceroute_utils.py
@@ -19,6 +19,35 @@ class RouteData(TypedDict):
     snr_back: list[float]
 
 
+def get_packet_traceroute_id(packet: Any) -> tuple:
+    """
+    Get a unique identifier for the traceroute that this packet belongs to.
+
+    Multiple gateway receptions of the same mesh packet share the same
+    mesh_packet_id, from_node_id, and to_node_id.
+    If mesh_packet_id is not available or 0, fallback to the packet's unique ID.
+    """
+    if hasattr(packet, "packet_data"):
+        data = packet.packet_data
+    elif isinstance(packet, dict):
+        data = packet
+    else:
+        return ("unknown", id(packet))
+
+    mp_id = data.get("mesh_packet_id")
+    from_node = data.get("from_node_id")
+    to_node = data.get("to_node_id")
+    if mp_id and mp_id != 0:
+        return (mp_id, from_node, to_node)
+
+    pkt_id = data.get("id")
+    if pkt_id is not None:
+        return ("packet", pkt_id)
+
+    ts = data.get("timestamp") or 0.0
+    return ("cluster", from_node, to_node, ts)
+
+
 def parse_traceroute_payload(raw_payload: bytes) -> RouteData:
     """
     Parse traceroute payload from raw bytes using protobuf parsing.

--- a/tests/e2e/test_tables.py
+++ b/tests/e2e/test_tables.py
@@ -824,10 +824,8 @@ class TestTables:
         """Test that grouped traceroute table shows at least 1 gateway when grouping is enabled."""
         page.goto(f"{test_server_url}/traceroute")
 
-        # Wait for traceroute data to load by looking for gateway count
-        page.wait_for_selector(
-            ".modern-table tbody tr:has-text('gateway')", timeout=15000
-        )
+        # Wait for traceroute data to load
+        page.wait_for_selector(".modern-table tbody tr", timeout=15000)
 
         # Ensure grouping is enabled
         grouping_checkbox = page.locator("#group_packets")
@@ -835,21 +833,22 @@ class TestTables:
             grouping_checkbox.check()
             apply_button = page.locator("#applyFilters")
             apply_button.click()
-            # Wait for the grouped data to reload with gateway counts
-            page.wait_for_selector(
-                ".modern-table tbody tr:has-text('gateway')", timeout=10000
-            )
+            # Wait for the grouped data to reload
+            page.wait_for_timeout(1500)
+            page.wait_for_selector(".modern-table tbody tr", timeout=10000)
 
-        # Check that gateway counts show at least 1 gateway (not N/A)
+        # Check that gateway cells are populated (not N/A). Grouped rows show
+        # either an "N gateways" badge (multi-gateway group) or the resolved
+        # single gateway as a node link / raw id.
         gateway_cells = page.locator(
             ".modern-table tbody tr td:nth-child(5)"
         )  # Gateway column
 
         valid_gateway_count_found = False
         for i in range(min(5, gateway_cells.count())):
-            gateway_text = gateway_cells.nth(i).inner_text()
-            # Should show "1 gateway", "2 gateways", etc., not "N/A"
-            if gateway_text and "gateway" in gateway_text and gateway_text != "N/A":
+            gateway_text = gateway_cells.nth(i).inner_text().strip()
+            # Should show a gateway (badge, link or raw id), not "N/A" or empty
+            if gateway_text and gateway_text != "N/A":
                 valid_gateway_count_found = True
                 break
 
@@ -1106,8 +1105,8 @@ class TestTables:
         """Test that route data is displayed correctly in both grouped and ungrouped modes."""
         # Test grouped mode (default)
         page.goto(f"{test_server_url}/traceroute")
-        # Wait for traceroute data to load by looking for gateway count
-        page.wait_for_selector("table tbody tr:has-text('gateway')", timeout=15000)
+        # Wait for traceroute data to load
+        page.wait_for_selector("table tbody tr", timeout=15000)
 
         # Verify grouping is enabled
         group_checkbox = page.locator("#group_packets")

--- a/tests/e2e/test_tables.py
+++ b/tests/e2e/test_tables.py
@@ -824,18 +824,24 @@ class TestTables:
         """Test that grouped traceroute table shows at least 1 gateway when grouping is enabled."""
         page.goto(f"{test_server_url}/traceroute")
 
-        # Wait for traceroute data to load
-        page.wait_for_selector(".modern-table tbody tr", timeout=15000)
-
         # Ensure grouping is enabled
         grouping_checkbox = page.locator("#group_packets")
         if not grouping_checkbox.is_checked():
             grouping_checkbox.check()
             apply_button = page.locator("#applyFilters")
             apply_button.click()
-            # Wait for the grouped data to reload
-            page.wait_for_timeout(1500)
-            page.wait_for_selector(".modern-table tbody tr", timeout=10000)
+
+        # Wait for traceroute data to load with valid gateway cells (not the loading spinner row)
+        page.wait_for_function(
+            """() => {
+                const gatewayCells = document.querySelectorAll('.modern-table tbody tr td:nth-child(5)');
+                return Array.from(gatewayCells).some(cell => {
+                    const text = (cell.textContent || '').trim();
+                    return text && text !== 'N/A' && text.length > 0;
+                });
+            }""",
+            timeout=15000,
+        )
 
         # Check that gateway cells are populated (not N/A). Grouped rows show
         # either an "N gateways" badge (multi-gateway group) or the resolved
@@ -1105,12 +1111,22 @@ class TestTables:
         """Test that route data is displayed correctly in both grouped and ungrouped modes."""
         # Test grouped mode (default)
         page.goto(f"{test_server_url}/traceroute")
-        # Wait for traceroute data to load
-        page.wait_for_selector("table tbody tr", timeout=15000)
 
         # Verify grouping is enabled
         group_checkbox = page.locator("#group_packets")
         assert group_checkbox.is_checked(), "Grouping should be enabled by default"
+
+        # Wait for route data to be present in grouped mode (not the loading spinner row)
+        page.wait_for_function(
+            """() => {
+                const routeCells = document.querySelectorAll('table tbody tr td:nth-child(4)');
+                return Array.from(routeCells).some(cell => {
+                    const text = (cell.textContent || '').trim();
+                    return text && text !== 'No route data' && text.length > 0;
+                });
+            }""",
+            timeout=15000,
+        )
 
         # Count route data entries in grouped mode
         route_cells_grouped = page.locator("table tbody tr td:nth-child(4)")
@@ -1172,7 +1188,7 @@ class TestTables:
     ):
         """Test that gateway and route data are properly formatted without HTML escaping."""
         page.goto(f"{test_server_url}/traceroute")
-        page.wait_for_selector("table tbody tr", timeout=10000)
+        page.wait_for_selector("table tbody tr td:nth-child(5)", timeout=15000)
 
         # Find all rows
         rows = page.locator("table tbody tr")

--- a/tests/e2e/test_timezone_toggle.py
+++ b/tests/e2e/test_timezone_toggle.py
@@ -51,7 +51,8 @@ class TestTimezoneToggleE2E:
         )
 
         # Click timezone toggle button
-        page.click("#timezone-toggle")
+        with page.expect_navigation():
+            page.click("#timezone-toggle")
 
         # Wait for page to reload (the toggle should trigger a reload)
         page.wait_for_load_state("load")
@@ -79,7 +80,8 @@ class TestTimezoneToggleE2E:
         )
 
         # Click timezone toggle
-        page.click("#timezone-toggle")
+        with page.expect_navigation():
+            page.click("#timezone-toggle")
 
         # Wait for page reload
         page.wait_for_load_state("load")
@@ -254,7 +256,8 @@ class TestTimezoneToggleE2E:
         assert value == "2025-01-01T12:00", "Datetime input should work correctly"
 
         # Toggle timezone
-        page.click("#timezone-toggle")
+        with page.expect_navigation():
+            page.click("#timezone-toggle")
         page.wait_for_load_state("load")
 
         # Reopen filters and check input still works

--- a/tests/e2e/test_traceroute_filters_e2e.py
+++ b/tests/e2e/test_traceroute_filters_e2e.py
@@ -1543,12 +1543,22 @@ class TestTracerouteFilters:
             api_data = response.json()
             assert "data" in api_data, "API response should contain data field"
 
-            # Verify API results contain the route node
+            # Verify API results contain the route node anywhere in the path
             for item in api_data["data"]:
                 route_nodes = item.get("route_nodes", [])
-                assert int(route_node_id) in route_nodes, (
-                    f"API result should contain route_node {route_node_id}, got {route_nodes}"
+                from_node = item.get("from_node_id")
+                to_node = item.get("to_node_id")
+                assert (
+                    int(route_node_id) in route_nodes
+                    or int(route_node_id) == from_node
+                    or int(route_node_id) == to_node
+                ), (
+                    f"API result should contain route_node {route_node_id}, got route_nodes={route_nodes}, from={from_node}, to={to_node}"
                 )
+
+            # Verify frontend table shows filtered results
+            filtered_rows = page.locator("#tracerouteTable tbody tr").count()
+            assert filtered_rows > 0, "Should have filtered results"
 
     def test_traceroute_gateway_filter_e2e(self, page: Page, test_server_url: str):
         """Test that the gateway filter works end-to-end."""

--- a/tests/integration/test_traceroute_empty_payload_filter.py
+++ b/tests/integration/test_traceroute_empty_payload_filter.py
@@ -1,0 +1,163 @@
+"""
+Test that empty-payload TRACEROUTE_APP packets (requests / flood-loop junk)
+are excluded from hop/link analysis queries but kept for raw listings.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+JUNK_MESH_PACKET_ID = 2118652877
+NODE_A = 0x7A110001
+NODE_B = 0x7A110002
+NODE_C = 0x7A110003
+
+
+def _make_route_payload() -> bytes:
+    from meshtastic import mesh_pb2
+
+    route = mesh_pb2.RouteDiscovery()
+    route.route.extend([NODE_C])
+    route.snr_towards.extend([int(-5.0 * 4)])
+    return route.SerializeToString()
+
+
+def _insert_traceroute_rows(cursor, base_time: float) -> None:
+    payload = _make_route_payload()
+
+    for i, mesh_packet_id in enumerate((1001, 1002)):
+        cursor.execute(
+            """
+            INSERT INTO packet_history
+            (mesh_packet_id, from_node_id, to_node_id, gateway_id, rssi, snr,
+             timestamp, hop_limit, hop_start, portnum, portnum_name, topic,
+             payload_length, raw_payload, processed_successfully)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+            (
+                mesh_packet_id,
+                NODE_A,
+                NODE_B,
+                f"!gw{i:08x}",
+                -90,
+                -5.0,
+                base_time - i,
+                3,
+                3,
+                70,
+                "TRACEROUTE_APP",
+                "msh/2/c/LongFast/!gw",
+                len(payload),
+                payload,
+                True,
+            ),
+        )
+
+    # Flood-loop junk: same mesh_packet_id redelivered by one gateway,
+    # empty payload, hop budget expired.
+    for i in range(5):
+        cursor.execute(
+            """
+            INSERT INTO packet_history
+            (mesh_packet_id, from_node_id, to_node_id, gateway_id, rssi, snr,
+             timestamp, hop_limit, hop_start, portnum, portnum_name, topic,
+             payload_length, raw_payload, processed_successfully)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+            (
+                JUNK_MESH_PACKET_ID,
+                NODE_A,
+                NODE_B,
+                "!9e765708",
+                None,
+                0.0,
+                base_time - 100 - i * 60,
+                0,
+                3,
+                70,
+                "TRACEROUTE_APP",
+                "msh/2/c/LongFast/!9e765708",
+                0,
+                b"",
+                True,
+            ),
+        )
+
+
+class TestTracerouteEmptyPayloadFilter:
+    """Test exclusion of empty-payload traceroute packets from analysis paths."""
+
+    @pytest.fixture(autouse=True)
+    def _seed_rows(self, app):
+        from src.malla.database.connection import get_db_connection
+
+        with app.app_context():
+            conn = get_db_connection()
+            cursor = conn.cursor()
+            base_time = datetime.now().timestamp()
+            _insert_traceroute_rows(cursor, base_time)
+            cursor.connection.commit()
+            conn.close()
+            yield
+
+    @staticmethod
+    def _filters() -> dict:
+        end = datetime.now()
+        start = end - timedelta(days=7)
+        return {
+            "start_time": start.timestamp(),
+            "end_time": end.timestamp(),
+            "processed_successfully_only": True,
+            "from_node": NODE_A,
+        }
+
+    @pytest.mark.integration
+    def test_repository_excludes_empty_payload_when_requested(self):
+        from src.malla.database.repositories import TracerouteRepository
+
+        result = TracerouteRepository.get_traceroute_packets(
+            limit=100, filters=self._filters() | {"exclude_empty_payload": True}
+        )
+        mesh_ids = {p["mesh_packet_id"] for p in result["packets"]}
+        assert 1001 in mesh_ids
+        assert 1002 in mesh_ids
+        assert JUNK_MESH_PACKET_ID not in mesh_ids
+
+    @pytest.mark.integration
+    def test_repository_keeps_empty_payload_without_flag(self):
+        from src.malla.database.repositories import TracerouteRepository
+
+        result = TracerouteRepository.get_traceroute_packets(
+            limit=100, filters=self._filters()
+        )
+        mesh_ids = {p["mesh_packet_id"] for p in result["packets"]}
+        assert JUNK_MESH_PACKET_ID in mesh_ids
+
+    @pytest.mark.integration
+    def test_graph_query_excludes_empty_payload_unconditionally(self):
+        from src.malla.database.repositories import TracerouteRepository
+
+        rows = TracerouteRepository.get_traceroute_packets_for_graph(
+            limit=100, filters=self._filters()
+        )
+        rows_from_a = [r for r in rows if r["from_node_id"] == NODE_A]
+        assert len(rows_from_a) == 2
+        assert all(r["raw_payload"] for r in rows_from_a)
+
+    @pytest.mark.integration
+    def test_link_endpoint_ignores_junk_rows(self, app):
+        with app.test_client() as client:
+            response = client.get(f"/api/traceroute/link/{NODE_A}/{NODE_C}")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["total_attempts"] == 2
+        assert len(data["traceroutes"]) == 2
+
+    @pytest.mark.integration
+    def test_related_nodes_ignores_junk_rows(self, app):
+        with app.test_client() as client:
+            response = client.get(f"/api/traceroute/related-nodes/{NODE_A}")
+        assert response.status_code == 200
+        data = response.get_json()
+        related_ids = {n["node_id"] for n in data.get("related_nodes", [])}
+        assert NODE_C in related_ids

--- a/tests/integration/test_traceroute_grouping_pagination.py
+++ b/tests/integration/test_traceroute_grouping_pagination.py
@@ -251,3 +251,247 @@ class TestTracerouteGroupingPagination:
         assert result["total_count"] == self.NUM_PACKETS
         assert len(result["packets"]) == 5
         assert all(p["is_grouped"] for p in result["packets"])
+
+    def test_stage_two_does_not_leak_filtered_out_gateways(self):
+        """Verify Stage 2 reapplies gateway_id filter and does not leak other gateways."""
+        filters = self._filters()
+        target_gw = "!gw00000001"
+        filters["gateway_id"] = target_gw
+
+        result = TracerouteRepository.get_traceroute_packets(
+            limit=5,
+            offset=0,
+            group_packets=True,
+            filters=filters,
+        )
+
+        assert result["total_count"] == self.NUM_PACKETS
+        assert len(result["packets"]) == 5
+        for pkt in result["packets"]:
+            # Gateway count must be 1 (only target_gw, not all 4 gateways)
+            assert pkt["gateway_count"] == 1
+            assert pkt["gateway_list"] == target_gw
+            assert pkt["gateway_id"] == target_gw
+            # Signal aggregates must match target_gw (gw_idx=1: rssi=-85, snr=3.0)
+            assert pkt["min_rssi"] == -85.0
+            assert pkt["max_rssi"] == -85.0
+            assert pkt["min_snr"] == 3.0
+            assert pkt["max_snr"] == 3.0
+
+
+@pytest.mark.integration
+class TestTraceroutePredicateReapplication:
+    """Test that all original predicates and composite keys are reapplied in Stage 2."""
+
+    COLLISION_ID = 888888
+    NODE_A = 0x11111111
+    NODE_B = 0x22222222
+    NODE_C = 0x33333333
+    NODE_D = 0x44444444
+
+    @pytest.fixture(autouse=True)
+    def _seed_predicates_data(self, app):
+        with app.app_context():
+            conn = get_db_connection()
+            cursor = conn.cursor()
+            base_time = datetime.now().timestamp()
+
+            # 1. Composite key collision: two different node pairs sharing mesh_packet_id
+            cursor.execute(
+                """
+                INSERT INTO packet_history
+                (mesh_packet_id, from_node_id, to_node_id, gateway_id, rssi, snr,
+                 timestamp, hop_limit, hop_start, portnum, portnum_name, topic,
+                 payload_length, raw_payload, processed_successfully, channel_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    self.COLLISION_ID,
+                    self.NODE_A,
+                    self.NODE_B,
+                    "!gw_a",
+                    -70.0,
+                    10.0,
+                    base_time - 10,
+                    3,
+                    3,
+                    70,
+                    "TRACEROUTE_APP",
+                    "msh/2/c/LongFast/!gw_a",
+                    16,
+                    b"payload_pair_ab",
+                    1,
+                    0,
+                ),
+            )
+            cursor.execute(
+                """
+                INSERT INTO packet_history
+                (mesh_packet_id, from_node_id, to_node_id, gateway_id, rssi, snr,
+                 timestamp, hop_limit, hop_start, portnum, portnum_name, topic,
+                 payload_length, raw_payload, processed_successfully, channel_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    self.COLLISION_ID,
+                    self.NODE_C,
+                    self.NODE_D,
+                    "!gw_c",
+                    -90.0,
+                    0.0,
+                    base_time - 15,
+                    3,
+                    3,
+                    70,
+                    "TRACEROUTE_APP",
+                    "msh/2/c/LongFast/!gw_c",
+                    16,
+                    b"payload_pair_cd",
+                    1,
+                    0,
+                ),
+            )
+
+            # 2. Multi-reception packet with different channels, processing statuses, payloads, and times
+            # mesh_packet_id: 777777
+            # Reception 1: valid, channel 0, processed 1, payload b"good_payload", recent time
+            cursor.execute(
+                """
+                INSERT INTO packet_history
+                (mesh_packet_id, from_node_id, to_node_id, gateway_id, rssi, snr,
+                 timestamp, hop_limit, hop_start, portnum, portnum_name, topic,
+                 payload_length, raw_payload, processed_successfully, channel_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    777777,
+                    self.NODE_A,
+                    self.NODE_B,
+                    "!gw_primary",
+                    -65.0,
+                    12.0,
+                    base_time - 20,
+                    3,
+                    3,
+                    70,
+                    "TRACEROUTE_APP",
+                    "msh/2/c/LongFast/!gw_primary",
+                    12,
+                    b"good_payload",
+                    1,
+                    0,
+                ),
+            )
+            # Reception 2: channel 1, processed 0, empty payload, older time (10 days ago)
+            cursor.execute(
+                """
+                INSERT INTO packet_history
+                (mesh_packet_id, from_node_id, to_node_id, gateway_id, rssi, snr,
+                 timestamp, hop_limit, hop_start, portnum, portnum_name, topic,
+                 payload_length, raw_payload, processed_successfully, channel_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    777777,
+                    self.NODE_A,
+                    self.NODE_B,
+                    "!gw_secondary",
+                    -95.0,
+                    -5.0,
+                    base_time - (10 * 86400),
+                    3,
+                    3,
+                    70,
+                    "TRACEROUTE_APP",
+                    "msh/2/c/LongFast/!gw_secondary",
+                    0,
+                    b"",
+                    0,
+                    1,
+                ),
+            )
+
+            conn.commit()
+            conn.close()
+            yield
+
+    def test_composite_key_does_not_mix_colliding_mesh_packet_ids(self):
+        """Receptions from colliding mesh_packet_id on different node pairs must remain separate."""
+        res = TracerouteRepository.get_traceroute_packets(
+            limit=10,
+            offset=0,
+            group_packets=True,
+            filters={"from_node": self.NODE_A, "to_node": self.NODE_B},
+        )
+        assert res["total_count"] == 2  # COLLISION_ID and 777777
+        ab_packet = next(p for p in res["packets"] if p["mesh_packet_id"] == self.COLLISION_ID)
+        assert ab_packet["from_node_id"] == self.NODE_A
+        assert ab_packet["to_node_id"] == self.NODE_B
+        assert ab_packet["gateway_list"] == "!gw_a"
+        assert ab_packet["raw_payload"] == b"payload_pair_ab"
+
+    def test_stage_two_reapplies_primary_channel_filter(self):
+        """When filtered by primary_channel, stage 2 only fetches matching receptions."""
+        res_ch0 = TracerouteRepository.get_traceroute_packets(
+            limit=10,
+            offset=0,
+            group_packets=True,
+            filters={"from_node": self.NODE_A, "primary_channel": "0"},
+        )
+        pkt_ch0 = next(p for p in res_ch0["packets"] if p["mesh_packet_id"] == 777777)
+        assert pkt_ch0["gateway_count"] == 1
+        assert pkt_ch0["gateway_list"] == "!gw_primary"
+        assert str(pkt_ch0["channel_id"]) == "0"
+
+    def test_stage_two_reapplies_processed_successfully_filter(self):
+        """When filtered by processed_successfully_only, failed receptions are excluded from stage 2."""
+        res = TracerouteRepository.get_traceroute_packets(
+            limit=10,
+            offset=0,
+            group_packets=True,
+            filters={"from_node": self.NODE_A, "processed_successfully_only": True},
+        )
+        pkt = next(p for p in res["packets"] if p["mesh_packet_id"] == 777777)
+        assert pkt["gateway_count"] == 1
+        assert pkt["gateway_list"] == "!gw_primary"
+        assert pkt["gateway_id"] == "!gw_primary"
+
+    def test_stage_two_reapplies_exclude_empty_payload(self):
+        """Receptions with empty payload are excluded from stage 2."""
+        res = TracerouteRepository.get_traceroute_packets(
+            limit=10,
+            offset=0,
+            group_packets=True,
+            filters={"from_node": self.NODE_A, "exclude_empty_payload": True},
+        )
+        pkt = next(p for p in res["packets"] if p["mesh_packet_id"] == 777777)
+        assert pkt["gateway_count"] == 1
+        assert pkt["gateway_list"] == "!gw_primary"
+        assert pkt["raw_payload"] == b"good_payload"
+
+    def test_stage_two_reapplies_time_window(self):
+        """Default 7-day time window excludes receptions older than 7 days from stage 2."""
+        res = TracerouteRepository.get_traceroute_packets(
+            limit=10,
+            offset=0,
+            group_packets=True,
+            filters={"from_node": self.NODE_A},
+        )
+        pkt = next(p for p in res["packets"] if p["mesh_packet_id"] == 777777)
+        # The reception from 10 days ago (!gw_secondary) is outside the 7-day window
+        assert pkt["gateway_count"] == 1
+        assert pkt["gateway_list"] == "!gw_primary"
+
+    def test_stage_two_reapplies_search_filter(self):
+        """Search predicate is reapplied in stage 2."""
+        res = TracerouteRepository.get_traceroute_packets(
+            limit=10,
+            offset=0,
+            group_packets=True,
+            filters={"from_node": self.NODE_A},
+            search="!gw_primary",
+        )
+        assert res["total_count"] == 1
+        pkt = res["packets"][0]
+        assert pkt["mesh_packet_id"] == 777777
+        assert pkt["gateway_list"] == "!gw_primary"

--- a/tests/integration/test_traceroute_grouping_pagination.py
+++ b/tests/integration/test_traceroute_grouping_pagination.py
@@ -1,0 +1,253 @@
+"""
+Integration tests for traceroute packet grouping and two-stage SQL pagination.
+
+Validates that:
+1. Multi-gateway receptions for the same packet are correctly grouped.
+2. Pagination returns the exact requested limit across multiple pages without early truncation.
+3. total_count reflects the total number of unique packet groups across the entire time window.
+4. Ordering by timestamp, gateway_count, etc., operates correctly across groups.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from src.malla.database.connection import get_db_connection
+from src.malla.database.repositories import TracerouteRepository
+
+NODE_SRC = 0x7A111001
+NODE_DST = 0x7A111002
+
+
+def _insert_grouped_test_data(
+    cursor, base_time: float, num_packets: int = 15, gateways_per_packet: int = 4
+):
+    """Insert multiple packets, each received by multiple gateways."""
+    for p_idx in range(num_packets):
+        mesh_packet_id = 900000 + p_idx
+        pkt_time = base_time - (p_idx * 60)  # Each packet 1 minute apart
+
+        for gw_idx in range(gateways_per_packet):
+            cursor.execute(
+                """
+                INSERT INTO packet_history
+                (mesh_packet_id, from_node_id, to_node_id, gateway_id, rssi, snr,
+                 timestamp, hop_limit, hop_start, portnum, portnum_name, topic,
+                 payload_length, raw_payload, processed_successfully)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    mesh_packet_id,
+                    NODE_SRC,
+                    NODE_DST,
+                    f"!gw{gw_idx:08x}",
+                    -80 - (gw_idx * 5),
+                    5.0 - (gw_idx * 2.0),
+                    pkt_time - gw_idx,  # Slightly different reception time per gateway
+                    3,
+                    3,
+                    70,
+                    "TRACEROUTE_APP",
+                    f"msh/2/c/LongFast/!gw{gw_idx:08x}",
+                    16,
+                    b"test_payload_123",
+                    True,
+                ),
+            )
+
+
+@pytest.mark.integration
+class TestTracerouteGroupingPagination:
+    """Test two-stage SQL grouping and pagination."""
+
+    NUM_PACKETS = 15
+    GATEWAYS_PER_PACKET = 4
+
+    @pytest.fixture(autouse=True)
+    def _seed_packets(self, app):
+        with app.app_context():
+            conn = get_db_connection()
+            cursor = conn.cursor()
+            base_time = datetime.now().timestamp()
+            _insert_grouped_test_data(
+                cursor,
+                base_time,
+                num_packets=self.NUM_PACKETS,
+                gateways_per_packet=self.GATEWAYS_PER_PACKET,
+            )
+            conn.commit()
+            conn.close()
+            yield
+
+    def _filters(self) -> dict:
+        end = datetime.now()
+        start = end - timedelta(days=7)
+        return {
+            "start_time": start.timestamp(),
+            "end_time": end.timestamp(),
+            "from_node": NODE_SRC,
+            "to_node": NODE_DST,
+        }
+
+    def test_grouped_packets_pagination_page_slices(self):
+        """Verify that offset 0, 5, 10 return correct slices without premature truncation."""
+        filters = self._filters()
+
+        # Page 1: limit=5, offset=0
+        page1 = TracerouteRepository.get_traceroute_packets(
+            limit=5,
+            offset=0,
+            group_packets=True,
+            filters=filters,
+            order_by="timestamp",
+            order_dir="desc",
+        )
+        assert page1["total_count"] == self.NUM_PACKETS
+        assert len(page1["packets"]) == 5
+
+        page1_ids = [p["mesh_packet_id"] for p in page1["packets"]]
+        assert len(set(page1_ids)) == 5
+
+        # Page 2: limit=5, offset=5
+        page2 = TracerouteRepository.get_traceroute_packets(
+            limit=5,
+            offset=5,
+            group_packets=True,
+            filters=filters,
+            order_by="timestamp",
+            order_dir="desc",
+        )
+        assert page2["total_count"] == self.NUM_PACKETS
+        assert len(page2["packets"]) == 5
+
+        page2_ids = [p["mesh_packet_id"] for p in page2["packets"]]
+        assert len(set(page2_ids)) == 5
+        # Ensure disjoint pages
+        assert set(page1_ids).isdisjoint(set(page2_ids))
+
+        # Page 3: limit=5, offset=10
+        page3 = TracerouteRepository.get_traceroute_packets(
+            limit=5,
+            offset=10,
+            group_packets=True,
+            filters=filters,
+            order_by="timestamp",
+            order_dir="desc",
+        )
+        assert page3["total_count"] == self.NUM_PACKETS
+        assert len(page3["packets"]) == 5
+
+        page3_ids = [p["mesh_packet_id"] for p in page3["packets"]]
+        assert set(page3_ids).isdisjoint(set(page1_ids))
+        assert set(page3_ids).isdisjoint(set(page2_ids))
+
+        # Page 4: offset beyond total (offset=15)
+        page4 = TracerouteRepository.get_traceroute_packets(
+            limit=5,
+            offset=15,
+            group_packets=True,
+            filters=filters,
+            order_by="timestamp",
+            order_dir="desc",
+        )
+        assert page4["total_count"] == self.NUM_PACKETS
+        assert len(page4["packets"]) == 0
+
+    def test_grouped_packet_aggregation_details(self):
+        """Verify that aggregated packet contains gateway counts and reception stats."""
+        filters = self._filters()
+
+        result = TracerouteRepository.get_traceroute_packets(
+            limit=1, offset=0, group_packets=True, filters=filters
+        )
+        assert len(result["packets"]) == 1
+        pkt = result["packets"][0]
+
+        assert pkt["is_grouped"] is True
+        assert pkt["gateway_count"] == self.GATEWAYS_PER_PACKET
+        assert len(pkt["gateway_list"].split(",")) == self.GATEWAYS_PER_PACKET
+        assert pkt["from_node_id"] == NODE_SRC
+        assert pkt["to_node_id"] == NODE_DST
+        assert "min_rssi" in pkt
+        assert "max_rssi" in pkt
+        assert "min_snr" in pkt
+        assert "max_snr" in pkt
+
+    def test_api_endpoint_grouped_pagination(self, client):
+        """Test that /api/traceroute/data correctly serves paginated grouped results."""
+        resp = client.get(
+            f"/api/traceroute/data?page=1&limit=5&group_packets=true&from_node={NODE_SRC}&to_node={NODE_DST}"
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+
+        assert data["total_count"] == self.NUM_PACKETS
+        assert data["page"] == 1
+        assert data["limit"] == 5
+        assert len(data["data"]) == 5
+        assert all(p.get("is_grouped") is True for p in data["data"])
+
+        # Request page 2
+        resp2 = client.get(
+            f"/api/traceroute/data?page=2&limit=5&group_packets=true&from_node={NODE_SRC}&to_node={NODE_DST}"
+        )
+        assert resp2.status_code == 200
+        data2 = resp2.get_json()
+        assert data2["total_count"] == self.NUM_PACKETS
+        assert data2["page"] == 2
+        assert len(data2["data"]) == 5
+
+        page1_ids = {p["id"] for p in data["data"]}
+        page2_ids = {p["id"] for p in data2["data"]}
+        assert page1_ids.isdisjoint(page2_ids)
+
+    def test_empty_results(self):
+        """Verify that when no packets match, total_count is 0 and packets is empty list."""
+        result = TracerouteRepository.get_traceroute_packets(
+            limit=10,
+            offset=0,
+            group_packets=True,
+            filters={"from_node": 0x99999999},  # Non-existent node
+        )
+        assert result["total_count"] == 0
+        assert result["packets"] == []
+
+    def test_sorting_by_timestamp(self):
+        """Verify that timestamp ordering is respected in Stage 1 group selection."""
+        filters = self._filters()
+
+        # Descending
+        desc_res = TracerouteRepository.get_traceroute_packets(
+            limit=self.NUM_PACKETS,
+            offset=0,
+            group_packets=True,
+            filters=filters,
+            order_by="timestamp",
+            order_dir="desc",
+        )
+        timestamps_desc = [p["timestamp"] for p in desc_res["packets"]]
+        assert timestamps_desc == sorted(timestamps_desc, reverse=True)
+
+        # Ascending
+        asc_res = TracerouteRepository.get_traceroute_packets(
+            limit=self.NUM_PACKETS,
+            offset=0,
+            group_packets=True,
+            filters=filters,
+            order_by="timestamp",
+            order_dir="asc",
+        )
+        timestamps_asc = [p["timestamp"] for p in asc_res["packets"]]
+        assert timestamps_asc == sorted(timestamps_asc)
+
+    def test_route_node_fallback_filtering(self):
+        """Verify route_node filter path still returns correctly grouped and paginated items."""
+        result = TracerouteRepository.get_traceroute_packets(
+            limit=5,
+            offset=0,
+            group_packets=True,
+            filters={"route_node": NODE_SRC},  # Matches from_node_id
+        )
+        assert result["total_count"] == self.NUM_PACKETS
+        assert len(result["packets"]) == 5
+        assert all(p["is_grouped"] for p in result["packets"])

--- a/tests/unit/test_gateway_sorting.py
+++ b/tests/unit/test_gateway_sorting.py
@@ -344,65 +344,79 @@ class TestGatewaySortingAPI:
         mock_conn.cursor.return_value = mock_cursor
 
         # Mock the database query results
-        # First call: total count query (returns count as tuple/row)
-        # Second call: no longer used (removed sample count estimation)
+        # Count query returns the total unique groups (2)
         mock_cursor.fetchone.side_effect = [
             (2,),  # Total count query result
         ]
 
-        # Mock the main query results - individual packets that will be grouped in memory
-        # These represent individual packet records, not pre-grouped results
-        mock_cursor.fetchall.return_value = [
-            # First group: mesh_packet_id="trace123" with 1 gateway
-            {
-                "id": 1,
-                "timestamp": 1000,
-                "from_node_id": 123,
-                "to_node_id": 456,
-                "mesh_packet_id": "trace123",
-                "gateway_id": "!433d0c24",
-                "hop_start": 3,
-                "hop_limit": 1,
-                "rssi": -80,
-                "snr": 5,
-                "payload_length": 50,
-                "processed_successfully": 1,
-                "timestamp_str": "2024-01-01 12:00:00",
-                "raw_payload": b"test",
-            },
-            # Second group: mesh_packet_id="trace456" with 2 gateways (2 individual records)
-            {
-                "id": 2,
-                "timestamp": 2000,
-                "from_node_id": 789,
-                "to_node_id": 456,
-                "mesh_packet_id": "trace456",
-                "gateway_id": "!433d0c24",
-                "hop_start": 4,
-                "hop_limit": 3,
-                "rssi": -75,
-                "snr": 8,
-                "payload_length": 75,
-                "processed_successfully": 1,
-                "timestamp_str": "2024-01-01 12:01:00",
-                "raw_payload": b"test2",
-            },
-            {
-                "id": 3,
-                "timestamp": 2001,
-                "from_node_id": 789,
-                "to_node_id": 456,
-                "mesh_packet_id": "trace456",  # Same mesh_packet_id as above
-                "gateway_id": "!da73e9cc",  # Different gateway
-                "hop_start": 2,
-                "hop_limit": 1,
-                "rssi": -70,
-                "snr": 10,
-                "payload_length": 75,
-                "processed_successfully": 1,
-                "timestamp_str": "2024-01-01 12:01:01",
-                "raw_payload": b"test2_longer",  # Longer payload to test best selection
-            },
+        # In two-stage grouping:
+        # Stage 1: Group slice query returns unique (mesh_packet_id, from_node_id, to_node_id) rows
+        # Stage 2: Receptions query returns individual packet records for the current page
+        mock_cursor.fetchall.side_effect = [
+            [
+                {
+                    "mesh_packet_id": "trace123",
+                    "from_node_id": 123,
+                    "to_node_id": 456,
+                },
+                {
+                    "mesh_packet_id": "trace456",
+                    "from_node_id": 789,
+                    "to_node_id": 456,
+                },
+            ],
+            [
+                # First group: mesh_packet_id="trace123" with 1 gateway
+                {
+                    "id": 1,
+                    "timestamp": 1000,
+                    "from_node_id": 123,
+                    "to_node_id": 456,
+                    "mesh_packet_id": "trace123",
+                    "gateway_id": "!433d0c24",
+                    "hop_start": 3,
+                    "hop_limit": 1,
+                    "rssi": -80,
+                    "snr": 5,
+                    "payload_length": 50,
+                    "processed_successfully": 1,
+                    "timestamp_str": "2024-01-01 12:00:00",
+                    "raw_payload": b"test",
+                },
+                # Second group: mesh_packet_id="trace456" with 2 gateways (2 individual records)
+                {
+                    "id": 2,
+                    "timestamp": 2000,
+                    "from_node_id": 789,
+                    "to_node_id": 456,
+                    "mesh_packet_id": "trace456",
+                    "gateway_id": "!433d0c24",
+                    "hop_start": 4,
+                    "hop_limit": 3,
+                    "rssi": -75,
+                    "snr": 8,
+                    "payload_length": 75,
+                    "processed_successfully": 1,
+                    "timestamp_str": "2024-01-01 12:01:00",
+                    "raw_payload": b"test2",
+                },
+                {
+                    "id": 3,
+                    "timestamp": 2001,
+                    "from_node_id": 789,
+                    "to_node_id": 456,
+                    "mesh_packet_id": "trace456",  # Same mesh_packet_id as above
+                    "gateway_id": "!da73e9cc",  # Different gateway
+                    "hop_start": 2,
+                    "hop_limit": 1,
+                    "rssi": -70,
+                    "snr": 10,
+                    "payload_length": 75,
+                    "processed_successfully": 1,
+                    "timestamp_str": "2024-01-01 12:01:01",
+                    "raw_payload": b"test2_longer",  # Longer payload to test best selection
+                },
+            ],
         ]
 
         with patch(

--- a/tests/unit/test_traceroute_hop_deduplication.py
+++ b/tests/unit/test_traceroute_hop_deduplication.py
@@ -1,0 +1,565 @@
+"""
+Unit tests verifying that hops belonging to the same traceroute are only counted once.
+"""
+
+from unittest.mock import MagicMock, Mock, patch
+
+from src.malla.models.traceroute import TracerouteHop
+from src.malla.services.node_service import NodeService
+from src.malla.services.traceroute_service import (
+    _NETWORK_GRAPH_CACHE,
+    TracerouteService,
+)
+from src.malla.utils.traceroute_utils import get_packet_traceroute_id
+
+
+class TestTracerouteHopDeduplication:
+    """Tests for deduplicating hops across multiple receptions of the same traceroute."""
+
+    def test_get_packet_traceroute_id(self):
+        """Test traceroute ID generation with various packet structures."""
+        # 1. Mesh packet ID present and non-zero
+        pkt_with_mesh_id = {
+            "id": 100,
+            "mesh_packet_id": 99999,
+            "from_node_id": 10,
+            "to_node_id": 20,
+        }
+        assert get_packet_traceroute_id(pkt_with_mesh_id) == (99999, 10, 20)
+
+        # 2. Mesh packet ID is 0 or None -> fallback to packet id
+        pkt_zero_mesh_id = {
+            "id": 100,
+            "mesh_packet_id": 0,
+            "from_node_id": 10,
+            "to_node_id": 20,
+        }
+        assert get_packet_traceroute_id(pkt_zero_mesh_id) == ("packet", 100)
+
+        pkt_no_mesh_id = {
+            "id": 101,
+            "from_node_id": 10,
+            "to_node_id": 20,
+        }
+        assert get_packet_traceroute_id(pkt_no_mesh_id) == ("packet", 101)
+
+        # 3. Object with packet_data attribute
+        obj = Mock()
+        obj.packet_data = {
+            "id": 102,
+            "mesh_packet_id": 88888,
+            "from_node_id": 30,
+            "to_node_id": 40,
+        }
+        assert get_packet_traceroute_id(obj) == (88888, 30, 40)
+
+        # 4. Neither mesh_packet_id nor id
+        bare_pkt = {"from_node_id": 10, "to_node_id": 20, "timestamp": 12345.0}
+        assert get_packet_traceroute_id(bare_pkt) == ("cluster", 10, 20, 12345.0)
+
+    @patch("src.malla.services.traceroute_service.get_bulk_node_names")
+    @patch("src.malla.services.traceroute_service.LocationRepository")
+    @patch("src.malla.services.traceroute_service.TraceroutePacket")
+    @patch("src.malla.services.traceroute_service.TracerouteRepository")
+    def test_network_graph_deduplicates_hops_from_same_traceroute(
+        self, mock_repo, mock_packet_cls, mock_loc_repo, mock_names
+    ):
+        """
+        Verify that multiple receptions of the same traceroute (same mesh_packet_id)
+        only increment hop counts once, but update the last_seen timestamp to the latest.
+        """
+        _NETWORK_GRAPH_CACHE.clear()
+        mock_names.return_value = {10: "Node10", 15: "Node15", 20: "Node20", 18: "Node18"}
+        mock_loc_repo.get_node_locations.return_value = []
+
+        # 3 gateway receptions of the same traceroute (mesh_packet_id = 12345)
+        packets = [
+            {
+                "id": 1,
+                "mesh_packet_id": 12345,
+                "from_node_id": 10,
+                "to_node_id": 20,
+                "timestamp": 1000.0,
+                "raw_payload": b"pkt1",
+            },
+            {
+                "id": 2,
+                "mesh_packet_id": 12345,
+                "from_node_id": 10,
+                "to_node_id": 20,
+                "timestamp": 1005.0,
+                "raw_payload": b"pkt2",
+            },
+            {
+                "id": 3,
+                "mesh_packet_id": 12345,
+                "from_node_id": 10,
+                "to_node_id": 20,
+                "timestamp": 1010.0,
+                "raw_payload": b"pkt3",
+            },
+        ]
+        mock_repo.get_traceroute_packets_for_graph.return_value = packets
+
+        # Packet 1 has hops: 10 -> 15, 15 -> 20
+        hop10_15_a = TracerouteHop(
+            hop_number=1, from_node_id=10, to_node_id=15,
+            from_node_name="Node10", to_node_name="Node15", snr=5.0
+        )
+        hop15_20_a = TracerouteHop(
+            hop_number=2, from_node_id=15, to_node_id=20,
+            from_node_name="Node15", to_node_name="Node20", snr=4.0
+        )
+        p1 = Mock()
+        p1.get_rf_hops.return_value = [hop10_15_a, hop15_20_a]
+
+        # Packet 2 (duplicate route heard by another gateway) has hops: 10 -> 15, 15 -> 20
+        hop10_15_b = TracerouteHop(
+            hop_number=1, from_node_id=10, to_node_id=15,
+            from_node_name="Node10", to_node_name="Node15", snr=5.0
+        )
+        hop15_20_b = TracerouteHop(
+            hop_number=2, from_node_id=15, to_node_id=20,
+            from_node_name="Node15", to_node_name="Node20", snr=4.0
+        )
+        p2 = Mock()
+        p2.get_rf_hops.return_value = [hop10_15_b, hop15_20_b]
+
+        # Packet 3 (different branch of same traceroute) has hops: 10 -> 15, 15 -> 18, 18 -> 20
+        hop10_15_c = TracerouteHop(
+            hop_number=1, from_node_id=10, to_node_id=15,
+            from_node_name="Node10", to_node_name="Node15", snr=5.0
+        )
+        hop15_18 = TracerouteHop(
+            hop_number=2, from_node_id=15, to_node_id=18,
+            from_node_name="Node15", to_node_name="Node18", snr=3.0
+        )
+        hop18_20 = TracerouteHop(
+            hop_number=3, from_node_id=18, to_node_id=20,
+            from_node_name="Node18", to_node_name="Node20", snr=2.0
+        )
+        p3 = Mock()
+        p3.get_rf_hops.return_value = [hop10_15_c, hop15_18, hop18_20]
+
+        mock_packet_cls.side_effect = [p1, p2, p3]
+
+        graph = TracerouteService.get_network_graph_data(hours=1, min_snr=-200.0, include_indirect=False)
+
+        link_map = {(link["source"], link["target"]): link for link in graph["links"]}
+
+        # Hop 10 <-> 15 appeared in all 3 receptions, but should only have packet_count == 1
+        link_10_15 = link_map[(10, 15)]
+        assert link_10_15["packet_count"] == 1
+        # last_seen should be updated to packet 3's timestamp (1010.0)
+        assert link_10_15["last_seen"] == 1010.0
+        assert link_10_15["last_packet_id"] == 3
+
+        # Hop 15 <-> 20 appeared in packets 1 and 2 -> packet_count should be 1
+        link_15_20 = link_map[(15, 20)]
+        assert link_15_20["packet_count"] == 1
+        assert link_15_20["last_seen"] == 1005.0
+
+        # Hop 15 <-> 18 and 18 <-> 20 appeared only in packet 3 -> packet_count should be 1
+        assert link_map[(15, 18)]["packet_count"] == 1
+        assert link_map[(18, 20)]["packet_count"] == 1
+
+    @patch("src.malla.services.traceroute_service.get_bulk_node_names")
+    @patch("src.malla.services.traceroute_service.LocationRepository")
+    @patch("src.malla.services.traceroute_service.TraceroutePacket")
+    @patch("src.malla.services.traceroute_service.TracerouteRepository")
+    def test_network_graph_counts_round_trip_hops_once_each(
+        self, mock_repo, mock_packet_cls, mock_loc_repo, mock_names
+    ):
+        """
+        Verify that a round-trip traceroute with forward 10 -> 20 and return 20 -> 10
+        counts both directional hops once (packet_count = 2, forward = 1, return = 1),
+        even if duplicate receptions are processed.
+        """
+        _NETWORK_GRAPH_CACHE.clear()
+        mock_names.return_value = {10: "Node10", 20: "Node20"}
+        mock_loc_repo.get_node_locations.return_value = []
+
+        packets = [
+            {
+                "id": 1,
+                "mesh_packet_id": 7777,
+                "from_node_id": 10,
+                "to_node_id": 20,
+                "timestamp": 1000.0,
+                "raw_payload": b"pkt1",
+            },
+            {
+                "id": 2,
+                "mesh_packet_id": 7777,
+                "from_node_id": 10,
+                "to_node_id": 20,
+                "timestamp": 1002.0,
+                "raw_payload": b"pkt2",
+            },
+        ]
+        mock_repo.get_traceroute_packets_for_graph.return_value = packets
+
+        hop_fwd_1 = TracerouteHop(
+            hop_number=1, from_node_id=10, to_node_id=20,
+            from_node_name="Node10", to_node_name="Node20", snr=7.0
+        )
+        hop_ret_1 = TracerouteHop(
+            hop_number=2, from_node_id=20, to_node_id=10,
+            from_node_name="Node20", to_node_name="Node10", snr=-2.0
+        )
+        p1 = Mock()
+        p1.get_rf_hops.return_value = [hop_fwd_1, hop_ret_1]
+
+        hop_fwd_2 = TracerouteHop(
+            hop_number=1, from_node_id=10, to_node_id=20,
+            from_node_name="Node10", to_node_name="Node20", snr=7.0
+        )
+        hop_ret_2 = TracerouteHop(
+            hop_number=2, from_node_id=20, to_node_id=10,
+            from_node_name="Node20", to_node_name="Node10", snr=-2.0
+        )
+        p2 = Mock()
+        p2.get_rf_hops.return_value = [hop_fwd_2, hop_ret_2]
+
+        mock_packet_cls.side_effect = [p1, p2]
+
+        graph = TracerouteService.get_network_graph_data(hours=1, min_snr=-200.0, include_indirect=False)
+
+        assert len(graph["links"]) == 1
+        link = graph["links"][0]
+        assert link["source"] == 10
+        assert link["target"] == 20
+        assert link["packet_count"] == 2
+        assert link["last_seen"] == 1002.0
+
+    @patch("src.malla.services.traceroute_service.get_bulk_node_names")
+    @patch("src.malla.services.traceroute_service.LocationRepository")
+    @patch("src.malla.services.traceroute_service.TraceroutePacket")
+    @patch("src.malla.services.traceroute_service.TracerouteRepository")
+    def test_network_graph_counts_distinct_traceroutes_separately(
+        self, mock_repo, mock_packet_cls, mock_loc_repo, mock_names
+    ):
+        """Verify that distinct traceroutes (different mesh_packet_id) both increment counts."""
+        _NETWORK_GRAPH_CACHE.clear()
+        mock_names.return_value = {10: "Node10", 20: "Node20"}
+        mock_loc_repo.get_node_locations.return_value = []
+
+        packets = [
+            {
+                "id": 1,
+                "mesh_packet_id": 1111,
+                "from_node_id": 10,
+                "to_node_id": 20,
+                "timestamp": 1000.0,
+                "raw_payload": b"pkt1",
+            },
+            {
+                "id": 2,
+                "mesh_packet_id": 2222,
+                "from_node_id": 10,
+                "to_node_id": 20,
+                "timestamp": 1050.0,
+                "raw_payload": b"pkt2",
+            },
+        ]
+        mock_repo.get_traceroute_packets_for_graph.return_value = packets
+
+        hop1 = TracerouteHop(
+            hop_number=1, from_node_id=10, to_node_id=20,
+            from_node_name="Node10", to_node_name="Node20", snr=5.0
+        )
+        p1 = Mock()
+        p1.get_rf_hops.return_value = [hop1]
+
+        hop2 = TracerouteHop(
+            hop_number=1, from_node_id=10, to_node_id=20,
+            from_node_name="Node10", to_node_name="Node20", snr=6.0
+        )
+        p2 = Mock()
+        p2.get_rf_hops.return_value = [hop2]
+
+        mock_packet_cls.side_effect = [p1, p2]
+
+        graph = TracerouteService.get_network_graph_data(hours=1, min_snr=-200.0, include_indirect=False)
+
+        assert len(graph["links"]) == 1
+        link = graph["links"][0]
+        assert link["packet_count"] == 2
+        assert link["avg_snr"] == 5.5
+
+    def test_api_traceroute_link_deduplicates_same_traceroute(self, client):
+        """Verify api_traceroute_link deduplicates hops and traceroutes sharing mesh_packet_id."""
+        node1_id = 1000
+        node2_id = 2000
+
+        # Two packets from same traceroute (mesh_packet_id 9999) containing hop 1000 -> 2000
+        packets = [
+            {
+                "id": 10,
+                "mesh_packet_id": 9999,
+                "from_node_id": node1_id,
+                "to_node_id": node2_id,
+                "gateway_id": 3000,
+                "timestamp": 1000.0,
+                "timestamp_str": "2024-01-20 10:00:00",
+                "raw_payload": b"pkt1",
+            },
+            {
+                "id": 11,
+                "mesh_packet_id": 9999,
+                "from_node_id": node1_id,
+                "to_node_id": node2_id,
+                "gateway_id": 3000,
+                "timestamp": 1002.0,
+                "timestamp_str": "2024-01-20 10:02:00",
+                "raw_payload": b"pkt2",
+            },
+        ]
+
+        hop1 = TracerouteHop(
+            hop_number=1, from_node_id=node1_id, to_node_id=node2_id,
+            from_node_name="Node 1000", to_node_name="Node 2000", snr=6.5,
+            direction="forward_rf"
+        )
+        p1 = Mock()
+        p1.get_rf_hops.return_value = [hop1]
+        p1.from_node_name = "Node 1000"
+        p1.to_node_name = "Node 2000"
+        p1.gateway_id = 3000
+        p1.timestamp = 1000.0
+        p1.timestamp_str = "2024-01-20 10:00:00"
+        p1.from_node_id = node1_id
+        p1.to_node_id = node2_id
+        p1.packet_data = packets[0]
+        p1.format_path_display.return_value = "1000 -> 2000"
+
+        hop2 = TracerouteHop(
+            hop_number=1, from_node_id=node1_id, to_node_id=node2_id,
+            from_node_name="Node 1000", to_node_name="Node 2000", snr=6.5,
+            direction="forward_rf"
+        )
+        p2 = Mock()
+        p2.get_rf_hops.return_value = [hop2]
+        p2.from_node_name = "Node 1000"
+        p2.to_node_name = "Node 2000"
+        p2.gateway_id = 3000
+        p2.timestamp = 1002.0
+        p2.timestamp_str = "2024-01-20 10:02:00"
+        p2.from_node_id = node1_id
+        p2.to_node_id = node2_id
+        p2.packet_data = packets[1]
+        p2.format_path_display.return_value = "1000 -> 2000"
+
+        with (
+            patch("src.malla.routes.api_routes.TracerouteRepository") as mock_repo,
+            patch("src.malla.routes.api_routes.NodeRepository") as mock_nodes,
+            patch("src.malla.routes.api_routes.TraceroutePacket") as mock_pkt_cls,
+        ):
+            mock_repo.get_traceroute_packets.return_value = {"packets": packets}
+            mock_nodes.get_bulk_node_names.return_value = {
+                node1_id: "Node 1000",
+                node2_id: "Node 2000",
+                3000: "Gateway Node",
+            }
+            mock_pkt_cls.side_effect = [p1, p2]
+
+            response = client.get(f"/api/traceroute/link/{node1_id}/{node2_id}")
+            assert response.status_code == 200
+            data = response.get_json()
+
+            # Same traceroute seen via two gateway receptions: one direction
+            # counted once and a single merged traceroute entry.
+            assert sum(data["direction_counts"].values()) == 1
+            assert data["total_observations"] == 1
+            assert len(data["traceroutes"]) == 1
+
+    def test_api_traceroute_link_counts_round_trip_hops_once_each(self, client):
+        """Verify api_traceroute_link counts both forward and return hops of a round-trip traceroute."""
+        node1_id = 1000
+        node2_id = 2000
+
+        packets = [
+            {
+                "id": 10,
+                "mesh_packet_id": 8888,
+                "from_node_id": node1_id,
+                "to_node_id": node2_id,
+                "gateway_id": 3000,
+                "timestamp": 1000.0,
+                "timestamp_str": "2024-01-20 10:00:00",
+                "raw_payload": b"pkt1",
+            },
+            {
+                "id": 11,
+                "mesh_packet_id": 8888,
+                "from_node_id": node1_id,
+                "to_node_id": node2_id,
+                "gateway_id": 3001,
+                "timestamp": 1002.0,
+                "timestamp_str": "2024-01-20 10:02:00",
+                "raw_payload": b"pkt2",
+            },
+        ]
+
+        hop_fwd = TracerouteHop(
+            hop_number=1, from_node_id=node1_id, to_node_id=node2_id,
+            from_node_name="Node 1000", to_node_name="Node 2000", snr=8.0,
+            direction="forward_rf"
+        )
+        hop_ret = TracerouteHop(
+            hop_number=2, from_node_id=node2_id, to_node_id=node1_id,
+            from_node_name="Node 2000", to_node_name="Node 1000", snr=4.0,
+            direction="return_rf"
+        )
+
+        def make_mock_packet(pkt_data):
+            p = Mock()
+            p.get_rf_hops.return_value = [hop_fwd, hop_ret]
+            p.from_node_name = "Node 1000"
+            p.to_node_name = "Node 2000"
+            p.gateway_id = pkt_data["gateway_id"]
+            p.timestamp = pkt_data["timestamp"]
+            p.timestamp_str = pkt_data["timestamp_str"]
+            p.from_node_id = node1_id
+            p.to_node_id = node2_id
+            p.packet_data = pkt_data
+            p.format_path_display.return_value = "1000 <-> 2000"
+            return p
+
+        p1 = make_mock_packet(packets[0])
+        p2 = make_mock_packet(packets[1])
+
+        with (
+            patch("src.malla.routes.api_routes.TracerouteRepository") as mock_repo,
+            patch("src.malla.routes.api_routes.NodeRepository") as mock_nodes,
+            patch("src.malla.routes.api_routes.TraceroutePacket") as mock_pkt_cls,
+        ):
+            mock_repo.get_traceroute_packets.return_value = {"packets": packets}
+            mock_nodes.get_bulk_node_names.return_value = {
+                node1_id: "Node 1000",
+                node2_id: "Node 2000",
+                3000: "Gateway Node 1",
+                3001: "Gateway Node 2",
+            }
+            mock_pkt_cls.side_effect = [p1, p2]
+
+            response = client.get(f"/api/traceroute/link/{node1_id}/{node2_id}")
+            assert response.status_code == 200
+            data = response.get_json()
+
+            # Two directions observed once each (forward and return), total observations == 2,
+            # but single merged traceroute entry.
+            assert sum(data["direction_counts"].values()) == 2
+            assert data["total_observations"] == 2
+            assert len(data["traceroutes"]) == 1
+            assert data["traceroutes"][0]["hop_snr"] == 4.0  # Min of plausible matching SNRs (8.0 and 4.0)
+
+    @patch("src.malla.services.traceroute_service.TraceroutePacket")
+    @patch("src.malla.services.traceroute_service.TracerouteRepository")
+    def test_longest_links_analysis_deduplicates_same_traceroute(
+        self, mock_repo, mock_packet_cls
+    ):
+        """Verify get_longest_links_analysis deduplicates hops from the same traceroute."""
+        packets = [
+            {
+                "id": 1,
+                "mesh_packet_id": 4321,
+                "from_node_id": 100,
+                "to_node_id": 200,
+                "timestamp": 1000.0,
+                "raw_payload": b"pkt1",
+                "gateway_id": "!12345678",
+                "processed_successfully": True,
+            },
+            {
+                "id": 2,
+                "mesh_packet_id": 4321,
+                "from_node_id": 100,
+                "to_node_id": 200,
+                "timestamp": 1003.0,
+                "raw_payload": b"pkt2",
+                "gateway_id": "!12345678",
+                "processed_successfully": True,
+            },
+        ]
+        mock_repo.get_traceroute_packets.return_value = {"packets": packets}
+
+        hop1 = Mock()
+        hop1.from_node_id = 100
+        hop1.to_node_id = 200
+        hop1.from_node_name = "Node100"
+        hop1.to_node_name = "Node200"
+        hop1.distance_km = 10.0
+        hop1.snr = 4.0
+
+        p1 = Mock()
+        p1.get_rf_hops.return_value = [hop1]
+        p1.calculate_hop_distances = Mock()
+
+        hop2 = Mock()
+        hop2.from_node_id = 100
+        hop2.to_node_id = 200
+        hop2.from_node_name = "Node100"
+        hop2.to_node_name = "Node200"
+        hop2.distance_km = 10.0
+        hop2.snr = 4.0
+
+        p2 = Mock()
+        p2.get_rf_hops.return_value = [hop2]
+        p2.calculate_hop_distances = Mock()
+
+        mock_packet_cls.side_effect = [p1, p2]
+
+        result = TracerouteService.get_longest_links_analysis(
+            min_distance_km=1.0, min_snr=-10.0, max_results=10
+        )
+        links = result.get("direct_links", [])
+        assert len(links) == 1
+        assert links[0]["traceroute_count"] == 1
+
+    @patch("src.malla.database.get_db_connection")
+    @patch("src.malla.models.traceroute.TraceroutePacket")
+    def test_node_service_related_nodes_deduplicates_same_traceroute(
+        self, mock_packet_cls, mock_conn
+    ):
+        """Verify NodeService.get_traceroute_related_nodes deduplicates shared hops from same traceroute."""
+        mock_db = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.return_value = mock_db
+        mock_db.cursor.return_value = mock_cursor
+
+        # Packets returned by cursor
+        mock_cursor.fetchall.side_effect = [
+            # First query: packet rows
+            [
+                (1, 1000.0, 10, 20, "!gw1", 0, 3, b"p1", 888),
+                (2, 1002.0, 10, 20, "!gw2", 0, 3, b"p2", 888),
+            ],
+            # Second query: node_info rows
+            [
+                (20, "Node Twenty", "N20", "!00000014"),
+            ],
+        ]
+
+        hop1 = TracerouteHop(
+            hop_number=1, from_node_id=10, to_node_id=20,
+            from_node_name="N10", to_node_name="N20", snr=5.0
+        )
+        p1 = Mock()
+        p1.get_rf_hops.return_value = [hop1]
+
+        hop2 = TracerouteHop(
+            hop_number=1, from_node_id=10, to_node_id=20,
+            from_node_name="N10", to_node_name="N20", snr=5.0
+        )
+        p2 = Mock()
+        p2.get_rf_hops.return_value = [hop2]
+
+        mock_packet_cls.side_effect = [p1, p2]
+
+        result = NodeService.get_traceroute_related_nodes(10)
+        related = result["related_nodes"]
+        assert len(related) == 1
+        # Node 20 should have traceroute_count == 1, not 2
+        assert related[0]["node_id"] == 20
+        assert related[0]["traceroute_count"] == 1


### PR DESCRIPTION
Fixes wrong observations/attempts count, lowers the loading time in /traceroute-hops (Traceroute RF Hop Analysis) from 10+ seconds to <1 seconds and shows all the traceroutes in /traceroutes without hurting performance.

The numbers behind hop/link analysis were wrong in three ways
(1) One traceroute crossing the mesh is often heard by several
gateways, each storing a copy — every copy was counted as a separate hop
observation, inflating counts 20x+. 
(2) ~99% of recent rows on busy brokers
were empty route-less traceroute records (requests, flood-loop
re-deliveries) that crowded real data out of fetch limits and put phantom
endpoints in the hops-page node pickers. 
(3) The traceroute listing grabbed a fixed pile of raw rows and grouped them in Python, so "all history"
silently capped at an artificial 30-minute window. 

## What it affects
- Observation counts, SNR aggregates, hops-page node pickers, link
  analysis, longest links, related nodes, route patterns.
- Traceroute listing pagination (exact totals, full time window).

## Changes
**Two-stage SQL grouping & pagination** (`get_traceroute_packets()`)
- Stage 1: exact `total_count` of unique packet groups
  `(mesh_packet_id, from_node_id, to_node_id)` via SQL `GROUP BY`/`ORDER BY`,
  returning only the active page's group keys.
- Stage 2: gateway receptions for those packet IDs via
  `WHERE mesh_packet_id IN (...)`, joining on the full composite key (CTE)
  and reapplying all original predicates (time window, gateway, channel,
  node, processing status, search, empty payload) so filtered-out
  receptions can't leak back in.
- Removes the 1500/3000-row in-memory limit and the 30-minute window while
  keeping sub-15ms query latency.

**Dedup across gateway receptions**
- Hops tracked by `(traceroute_id, from_node_id, to_node_id)` via
  `get_packet_traceroute_id()` in `get_network_graph_data()`,
  `get_longest_links_analysis()`, `get_traceroute_related_nodes()` and
  `/api/traceroute/link/<n1>/<n2>` — each RF hop counted once per
  transmission, `last_seen` recency still updated.
- `get_traceroute_packets_for_graph()` selects `mesh_packet_id` for
  correlation; the link endpoint dedups entries by `traceroute_id`,
  retaining the best route.

**Empty-payload filtering**
- Unconditional in `get_traceroute_packets_for_graph`; opt-in via
  `filters['exclude_empty_payload']` in `get_traceroute_packets` — enabled
  for link analysis, route patterns, longest links, related nodes and
  hops/nodes. Raw listing pages keep all rows.

**Indexes**
- Partial index `idx_packet_history_traceroute_time`: traceroute window
  scans in milliseconds (~300x on a 4.2 GB snapshot; previously 31–80s to
  fetch ~500 rows from a 6.9M-row table).
- Covering index `idx_packet_history_packet_links_cover`: index-only scan
  for the packet-links aggregate (~150x), forced via `INDEXED BY`.
- `ensure_startup_schema` reports created indexes; both processes re-run a
  bounded `ANALYZE` in the background so the planner adopts them on
  existing databases.

## Testing
- `test_traceroute_hop_deduplication.py`, `test_traceroute_empty_payload_filter.py`,
  `tests/integration/test_traceroute_grouping_pagination.py` (multi-gateway
  grouping, pagination, sorting, predicate reapplication, composite-key
  isolation).

- Updated two e2e table tests that waited for the literal "1 gateway" badge: grouped single-gateway rows now render the resolved gateway (node link / raw id) instead. The tests still assert the gateway cell is populated and never N/A.

## Merge notes
No merge order is required — this PR is self-contained against `main`. It
does, however, restructure the same two functions as the directional
link-quality PR (`feat/directional-link-quality`), so whichever of the two
merges second will show conflicts in `src/malla/routes/api_routes.py` and
`src/malla/services/traceroute_service.py`. The intended resolution is the
union of both: the link endpoint's `matching_hops` loop keeps the
`(traceroute_id, from_node_id, to_node_id)` dedup guard, and the graph
builder keeps both the dedup recency check and the per-direction SNR
bucketing. That exact combination has been merged locally and passes the
full test suite — I'm happy to push a rebase onto whichever lands first.

## Commits
- fix(traceroute): two-stage SQL grouping and pagination across full time window
- perf(db): add traceroute/packet-link indexes with planner-stat refresh
- fix(traceroute): exclude empty-payload packets from hop/link analysis
- test(traceroute): update gateway sorting mock for two-stage SQL grouping
- fix(traceroute): reapply filter predicates and composite key in stage two pagination
- fix(traceroute): deduplicate hop observations across multi-gateway receptions
- fix(traceroute): tighten indirect connection key typing for basedpyright

