### PR TITLE
feat(rf): directional, preset-aware link quality in API, map and hops page

### DIFF
--- a/src/malla/config.py
+++ b/src/malla/config.py
@@ -54,6 +54,12 @@ class AppConfig:
     # Supports comma-separated list of base64-encoded keys
     default_channel_key: str = "1PG7OiApB1nwvP+rz05pAQ=="
 
+    # LoRa modem preset and spreading factor settings for RF link quality estimation
+    # Supported presets: LongFast, LongSlow, ShortFast, SFNarrow, etc.
+    # If lora_spreading_factor is set, it overrides the preset's default SF (7-12).
+    lora_preset: str = "LongFast"
+    lora_spreading_factor: int | None = None
+
     # Logging
     log_level: str = "INFO"
 

--- a/src/malla/database/repositories.py
+++ b/src/malla/database/repositories.py
@@ -3375,6 +3375,7 @@ class TracerouteRepository:
                     from_node_id,
                     to_node_id,
                     gateway_id,
+                    channel_id,
                     hop_start,
                     hop_limit,
                     raw_payload

--- a/src/malla/routes/api_routes.py
+++ b/src/malla/routes/api_routes.py
@@ -1237,6 +1237,8 @@ def api_traceroute_link(node1_id, node2_id):
         processed_traceroutes: list[dict[str, Any]] = []
         direction_counts: dict[str, int] = {}
         snr_values: list[float] = []
+        forward_snr_values: list[float] = []
+        return_snr_values: list[float] = []
 
         for packet in all_packets["packets"]:
             try:
@@ -1270,6 +1272,10 @@ def api_traceroute_link(node1_id, node2_id):
 
                     if is_plausible_traceroute_snr(target_hop.snr):
                         snr_values.append(target_hop.snr)
+                        if target_hop.from_node_id == node1_id_int:
+                            forward_snr_values.append(target_hop.snr)
+                        else:
+                            return_snr_values.append(target_hop.snr)
 
                     # Create route_hops structure for UI - include ALL RF hops (forward and return)
                     route_hops = []
@@ -1356,7 +1362,17 @@ def api_traceroute_link(node1_id, node2_id):
 
         # Calculate summary statistics
         total_attempts = len(processed_traceroutes)
-        avg_snr = sum(snr_values) / len(snr_values) if snr_values else None
+        avg_snr = round(sum(snr_values) / len(snr_values), 1) if snr_values else None
+        forward_avg_snr = (
+            round(sum(forward_snr_values) / len(forward_snr_values), 1)
+            if forward_snr_values
+            else None
+        )
+        return_avg_snr = (
+            round(sum(return_snr_values) / len(return_snr_values), 1)
+            if return_snr_values
+            else None
+        )
 
         # Ensure direction_counts has the expected format even when empty
         if not direction_counts:
@@ -1373,6 +1389,10 @@ def api_traceroute_link(node1_id, node2_id):
             "to_node_name": node_names.get(node2_id_int, f"!{node2_id_int:08x}"),
             "total_attempts": total_attempts,
             "avg_snr": avg_snr,
+            "forward_avg_snr": forward_avg_snr,
+            "return_avg_snr": return_avg_snr,
+            "forward_count": len(forward_snr_values),
+            "return_count": len(return_snr_values),
             "direction_counts": direction_counts,
             "traceroutes": processed_traceroutes,
         }

--- a/src/malla/routes/api_routes.py
+++ b/src/malla/routes/api_routes.py
@@ -30,6 +30,7 @@ from ..utils.node_utils import (
 )
 from ..utils.serialization_utils import convert_bytes_to_base64, sanitize_floats
 from ..utils.signal_quality import (
+    TRACEROUTE_UNKNOWN_SNR,
     calculate_estimated_reliability,
     classify_link_balance,
     classify_signal_quality,
@@ -1255,37 +1256,44 @@ def api_traceroute_link(node1_id, node2_id):
                 # Get RF hops (no need to calculate distances for this analysis)
                 rf_hops = tr_packet.get_rf_hops()
 
-                # Find any RF hop between our two target nodes
-                target_hop = None
-                for hop in rf_hops:
+                # Find all RF hops between our two target nodes
+                matching_hops = [
+                    hop
+                    for hop in rf_hops
                     if (
                         hop.from_node_id == node1_id_int
                         and hop.to_node_id == node2_id_int
-                    ) or (
+                    )
+                    or (
                         hop.from_node_id == node2_id_int
                         and hop.to_node_id == node1_id_int
-                    ):
-                        target_hop = hop
-                        break
+                    )
+                ]
 
-                if target_hop:
+                if matching_hops:
                     if not link_channel and packet.get("channel_id"):
                         link_channel = packet.get("channel_id")
 
-                    # Determine direction
-                    if target_hop.from_node_id == node1_id_int:
-                        direction = f"{node_names.get(node1_id_int, f'!{node1_id_int:08x}')} → {node_names.get(node2_id_int, f'!{node2_id_int:08x}')}"
-                    else:
-                        direction = f"{node_names.get(node2_id_int, f'!{node2_id_int:08x}')} → {node_names.get(node1_id_int, f'!{node1_id_int:08x}')}"
-
-                    direction_counts[direction] = direction_counts.get(direction, 0) + 1
-
-                    if is_plausible_traceroute_snr(target_hop.snr):
-                        snr_values.append(target_hop.snr)
-                        if target_hop.from_node_id == node1_id_int:
-                            forward_snr_values.append(target_hop.snr)
+                    packet_snrs: list[float] = []
+                    for hop in matching_hops:
+                        # Determine direction
+                        if hop.from_node_id == node1_id_int:
+                            direction = f"{node_names.get(node1_id_int, f'!{node1_id_int:08x}')} → {node_names.get(node2_id_int, f'!{node2_id_int:08x}')}"
                         else:
-                            return_snr_values.append(target_hop.snr)
+                            direction = f"{node_names.get(node2_id_int, f'!{node2_id_int:08x}')} → {node_names.get(node1_id_int, f'!{node1_id_int:08x}')}"
+
+                        direction_counts[direction] = direction_counts.get(direction, 0) + 1
+
+                        if is_plausible_traceroute_snr(hop.snr):
+                            # The -32.0 sentinel is a real observation with
+                            # unrecorded SNR: keep it out of the directional averages.
+                            if hop.snr != TRACEROUTE_UNKNOWN_SNR:
+                                snr_values.append(hop.snr)
+                                packet_snrs.append(hop.snr)
+                                if hop.from_node_id == node1_id_int:
+                                    forward_snr_values.append(hop.snr)
+                                else:
+                                    return_snr_values.append(hop.snr)
 
                     # Create route_hops structure for UI - include ALL RF hops (forward and return)
                     route_hops = []
@@ -1337,7 +1345,12 @@ def api_traceroute_link(node1_id, node2_id):
                         except (ValueError, TypeError):
                             pass
 
-                    # Create traceroute entry for UI
+                    # Representative hop SNR for the history entry / chart:
+                    # use the minimum valid SNR among matching hops (excluding no-observation),
+                    # so the weakest direction for this packet is reflected.
+                    entry_hop_snr = min(packet_snrs) if packet_snrs else None
+
+                    # Create traceroute entry for UI (one per packet)
                     traceroute_entry = {
                         "id": packet["id"],
                         "timestamp": packet["timestamp"],
@@ -1350,9 +1363,7 @@ def api_traceroute_link(node1_id, node2_id):
                         "gateway_node_name": gateway_node_name,
                         # Null out garbage SNR so the SNR-over-time chart
                         # (which autoscales over hop_snr) can't be flattened.
-                        "hop_snr": target_hop.snr
-                        if is_plausible_traceroute_snr(target_hop.snr)
-                        else None,
+                        "hop_snr": entry_hop_snr,
                         "route_hops": route_hops,
                         "complete_path_display": tr_packet.format_path_display(
                             "display"

--- a/src/malla/routes/api_routes.py
+++ b/src/malla/routes/api_routes.py
@@ -29,7 +29,13 @@ from ..utils.node_utils import (
     get_bulk_node_short_names,
 )
 from ..utils.serialization_utils import convert_bytes_to_base64, sanitize_floats
-from ..utils.signal_quality import is_plausible_traceroute_snr
+from ..utils.signal_quality import (
+    calculate_estimated_reliability,
+    classify_link_balance,
+    classify_signal_quality,
+    is_plausible_snr,
+    is_plausible_traceroute_snr,
+)
 from ..utils.traceroute_utils import parse_traceroute_payload
 
 logger = logging.getLogger(__name__)
@@ -1239,6 +1245,7 @@ def api_traceroute_link(node1_id, node2_id):
         snr_values: list[float] = []
         forward_snr_values: list[float] = []
         return_snr_values: list[float] = []
+        link_channel: str | None = None
 
         for packet in all_packets["packets"]:
             try:
@@ -1262,6 +1269,9 @@ def api_traceroute_link(node1_id, node2_id):
                         break
 
                 if target_hop:
+                    if not link_channel and packet.get("channel_id"):
+                        link_channel = packet.get("channel_id")
+
                     # Determine direction
                     if target_hop.from_node_id == node1_id_int:
                         direction = f"{node_names.get(node1_id_int, f'!{node1_id_int:08x}')} → {node_names.get(node2_id_int, f'!{node2_id_int:08x}')}"
@@ -1374,6 +1384,35 @@ def api_traceroute_link(node1_id, node2_id):
             else None
         )
 
+        valid_snrs = [
+            s
+            for s in (forward_avg_snr, return_avg_snr)
+            if s is not None and is_plausible_snr(s)
+        ]
+        worst_snr = (
+            min(valid_snrs)
+            if valid_snrs
+            else (avg_snr if is_plausible_snr(avg_snr) else None)
+        )
+
+        overall_reliability = calculate_estimated_reliability(
+            worst_snr, sf=link_channel
+        )
+        forward_reliability = calculate_estimated_reliability(
+            forward_avg_snr, sf=link_channel
+        )
+        return_reliability = calculate_estimated_reliability(
+            return_avg_snr, sf=link_channel
+        )
+
+        forward_quality = classify_signal_quality(forward_avg_snr, sf=link_channel)
+        return_quality = classify_signal_quality(return_avg_snr, sf=link_channel)
+        overall_quality = classify_signal_quality(worst_snr, sf=link_channel)
+
+        link_balance = classify_link_balance(
+            forward_avg_snr, return_avg_snr, sf=link_channel
+        )
+
         # Ensure direction_counts has the expected format even when empty
         if not direction_counts:
             # Create default direction labels for the two nodes
@@ -1387,10 +1426,20 @@ def api_traceroute_link(node1_id, node2_id):
             "to_node_id": node2_id_int,
             "from_node_name": node_names.get(node1_id_int, f"!{node1_id_int:08x}"),
             "to_node_name": node_names.get(node2_id_int, f"!{node2_id_int:08x}"),
+            "channel_id": link_channel,
             "total_attempts": total_attempts,
+            "total_observations": len(forward_snr_values) + len(return_snr_values),
             "avg_snr": avg_snr,
             "forward_avg_snr": forward_avg_snr,
             "return_avg_snr": return_avg_snr,
+            "worst_snr": worst_snr,
+            "estimated_reliability": overall_reliability,
+            "forward_reliability": forward_reliability,
+            "return_reliability": return_reliability,
+            "forward_quality": forward_quality,
+            "return_quality": return_quality,
+            "overall_quality": overall_quality,
+            "link_balance": link_balance,
             "forward_count": len(forward_snr_values),
             "return_count": len(return_snr_values),
             "direction_counts": direction_counts,

--- a/src/malla/services/location_service.py
+++ b/src/malla/services/location_service.py
@@ -408,6 +408,10 @@ class LocationService:
                     "to_node_id": link["target"],
                     "success_rate": success_rate,
                     "avg_snr": link.get("avg_snr"),
+                    "forward_avg_snr": link.get("forward_avg_snr"),
+                    "return_avg_snr": link.get("return_avg_snr"),
+                    "forward_count": link.get("forward_count", 0),
+                    "return_count": link.get("return_count", 0),
                     "age_hours": round(age_hours, 2),
                     "last_seen": link[
                         "last_seen"
@@ -1004,12 +1008,26 @@ class LocationService:
                 # Crude success-rate proxy: scale packet count to 10-100 like traceroute_links
                 success_rate = max(10, min(100, row["packet_count"] * 10))
 
+                is_forward = from_node_id == key[0]
+                row_avg_snr = (
+                    round(row["avg_snr"], 1) if row["avg_snr"] is not None else None
+                )
+                row_avg_rssi = (
+                    round(row["avg_rssi"], 1) if row["avg_rssi"] is not None else None
+                )
+
                 link_payload = {
                     "from_node_id": key[0],
                     "to_node_id": key[1],
                     "success_rate": success_rate,
-                    "avg_snr": row["avg_snr"],
-                    "avg_rssi": row["avg_rssi"],
+                    "avg_snr": row_avg_snr,
+                    "forward_avg_snr": row_avg_snr if is_forward else None,
+                    "return_avg_snr": None if is_forward else row_avg_snr,
+                    "avg_rssi": row_avg_rssi,
+                    "forward_avg_rssi": row_avg_rssi if is_forward else None,
+                    "return_avg_rssi": None if is_forward else row_avg_rssi,
+                    "forward_count": row["packet_count"] if is_forward else 0,
+                    "return_count": 0 if is_forward else row["packet_count"],
                     "age_hours": round(age_hours, 2) if age_hours is not None else None,
                     "last_seen_str": last_seen_str,
                     "is_bidirectional": False,  # will be updated below if we see both directions
@@ -1032,21 +1050,31 @@ class LocationService:
                     ):
                         existing["age_hours"] = round(age_hours, 2)
                         existing["last_seen_str"] = last_seen_str
+                    # Track directional averages and counts
+                    if is_forward:
+                        existing["forward_avg_snr"] = row_avg_snr
+                        existing["forward_avg_rssi"] = row_avg_rssi
+                        existing["forward_count"] = row["packet_count"]
+                    else:
+                        existing["return_avg_snr"] = row_avg_snr
+                        existing["return_avg_rssi"] = row_avg_rssi
+                        existing["return_count"] = row["packet_count"]
+
                     # Merge SNR / RSSI averages (simple mean of means)
-                    if row["avg_snr"] is not None:
+                    if row_avg_snr is not None:
                         if existing["avg_snr"] is None:
-                            existing["avg_snr"] = row["avg_snr"]
+                            existing["avg_snr"] = row_avg_snr
                         else:
-                            existing["avg_snr"] = (
-                                existing["avg_snr"] + row["avg_snr"]
-                            ) / 2.0
-                    if row["avg_rssi"] is not None:
+                            existing["avg_snr"] = round(
+                                (existing["avg_snr"] + row_avg_snr) / 2.0, 1
+                            )
+                    if row_avg_rssi is not None:
                         if existing["avg_rssi"] is None:
-                            existing["avg_rssi"] = row["avg_rssi"]
+                            existing["avg_rssi"] = row_avg_rssi
                         else:
-                            existing["avg_rssi"] = (
-                                existing["avg_rssi"] + row["avg_rssi"]
-                            ) / 2.0
+                            existing["avg_rssi"] = round(
+                                (existing["avg_rssi"] + row_avg_rssi) / 2.0, 1
+                            )
                 else:
                     link_map[key] = link_payload
 

--- a/src/malla/services/location_service.py
+++ b/src/malla/services/location_service.py
@@ -9,7 +9,14 @@ from datetime import UTC, datetime
 from typing import Any
 
 from ..database.repositories import LocationRepository
-from ..utils.signal_quality import rssi_valid_sql, snr_valid_sql
+from ..utils.signal_quality import (
+    calculate_estimated_reliability,
+    classify_link_balance,
+    classify_signal_quality,
+    is_plausible_snr,
+    rssi_valid_sql,
+    snr_valid_sql,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -399,26 +406,72 @@ class LocationService:
                 last_seen_dt = datetime.fromtimestamp(link["last_seen"], UTC)
                 last_seen_str = last_seen_dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
-                # Calculate success rate (using packet count as proxy)
-                # Higher packet count suggests more reliable link
-                success_rate = min(100, max(10, link["packet_count"] * 10))
+                f_snr = link.get("forward_avg_snr")
+                r_snr = link.get("return_avg_snr")
+                f_cnt = link.get("forward_count", 0)
+                r_cnt = link.get("return_count", 0)
+                total_obs = f_cnt + r_cnt if (f_cnt or r_cnt) else link["packet_count"]
+
+                valid_snrs = [
+                    s for s in (f_snr, r_snr) if s is not None and is_plausible_snr(s)
+                ]
+                worst_snr = (
+                    min(valid_snrs)
+                    if valid_snrs
+                    else (
+                        link.get("avg_snr")
+                        if is_plausible_snr(link.get("avg_snr"))
+                        else None
+                    )
+                )
+
+                link_sf = link.get("channel_id")
+                overall_reliability = calculate_estimated_reliability(
+                    worst_snr, sf=link_sf
+                )
+                forward_reliability = calculate_estimated_reliability(
+                    f_snr, sf=link_sf
+                )
+                return_reliability = calculate_estimated_reliability(
+                    r_snr, sf=link_sf
+                )
+
+                forward_quality = classify_signal_quality(f_snr, sf=link_sf)
+                return_quality = classify_signal_quality(r_snr, sf=link_sf)
+                overall_quality = classify_signal_quality(worst_snr, sf=link_sf)
+
+                link_balance = classify_link_balance(f_snr, r_snr, sf=link_sf)
+                is_bidirectional = bool(f_cnt > 0 and r_cnt > 0)
 
                 traceroute_link = {
                     "from_node_id": link["source"],
                     "to_node_id": link["target"],
-                    "success_rate": success_rate,
+                    "channel_id": link_sf,
+                    "success_rate": overall_reliability
+                    if overall_reliability is not None
+                    else 50.0,
+                    "estimated_reliability": overall_reliability,
+                    "forward_reliability": forward_reliability,
+                    "return_reliability": return_reliability,
+                    "forward_quality": forward_quality,
+                    "return_quality": return_quality,
+                    "overall_quality": overall_quality,
+                    "link_balance": link_balance,
+                    "worst_snr": worst_snr,
                     "avg_snr": link.get("avg_snr"),
-                    "forward_avg_snr": link.get("forward_avg_snr"),
-                    "return_avg_snr": link.get("return_avg_snr"),
-                    "forward_count": link.get("forward_count", 0),
-                    "return_count": link.get("return_count", 0),
+                    "forward_avg_snr": f_snr,
+                    "return_avg_snr": r_snr,
+                    "forward_count": f_cnt,
+                    "return_count": r_cnt,
                     "age_hours": round(age_hours, 2),
                     "last_seen": link[
                         "last_seen"
                     ],  # Raw Unix timestamp for client-side formatting
                     "last_seen_str": last_seen_str,
-                    "is_bidirectional": True,  # Network graph links are bidirectional by design
-                    "total_hops_seen": link["packet_count"],
+                    "is_bidirectional": is_bidirectional,
+                    "total_hops_seen": total_obs,
+                    "total_observations": total_obs,
+                    "strength": link.get("strength"),
                     "last_packet_id": link.get("last_packet_id"),
                 }
 
@@ -950,6 +1003,7 @@ class LocationService:
                 SELECT
                     from_node_id,
                     gateway_id,
+                    MAX(channel_id)        AS channel_id,
                     COUNT(*)               AS packet_count,
                     AVG(CASE WHEN {rssi_valid_sql()} THEN rssi END) AS avg_rssi,
                     AVG(CASE WHEN {snr_valid_sql()} THEN snr END) AS avg_snr,
@@ -1019,6 +1073,7 @@ class LocationService:
                 link_payload = {
                     "from_node_id": key[0],
                     "to_node_id": key[1],
+                    "channel_id": row.get("channel_id"),
                     "success_rate": success_rate,
                     "avg_snr": row_avg_snr,
                     "forward_avg_snr": row_avg_snr if is_forward else None,
@@ -1077,6 +1132,57 @@ class LocationService:
                             )
                 else:
                     link_map[key] = link_payload
+
+            # Calculate physical link reliability, quality, and balance metrics
+            for link_data in link_map.values():
+                f_snr = link_data.get("forward_avg_snr")
+                r_snr = link_data.get("return_avg_snr")
+                valid_snrs = [
+                    s for s in (f_snr, r_snr) if s is not None and is_plausible_snr(s)
+                ]
+                worst_snr = (
+                    min(valid_snrs)
+                    if valid_snrs
+                    else (
+                        link_data.get("avg_snr")
+                        if is_plausible_snr(link_data.get("avg_snr"))
+                        else None
+                    )
+                )
+
+                link_sf = link_data.get("channel_id")
+                overall_reliability = calculate_estimated_reliability(
+                    worst_snr, sf=link_sf
+                )
+                link_data["estimated_reliability"] = overall_reliability
+                link_data["forward_reliability"] = calculate_estimated_reliability(
+                    f_snr, sf=link_sf
+                )
+                link_data["return_reliability"] = calculate_estimated_reliability(
+                    r_snr, sf=link_sf
+                )
+                link_data["forward_quality"] = classify_signal_quality(
+                    f_snr, sf=link_sf
+                )
+                link_data["return_quality"] = classify_signal_quality(
+                    r_snr, sf=link_sf
+                )
+                link_data["overall_quality"] = classify_signal_quality(
+                    worst_snr, sf=link_sf
+                )
+                link_data["link_balance"] = classify_link_balance(
+                    f_snr, r_snr, sf=link_sf
+                )
+                link_data["worst_snr"] = worst_snr
+                link_data["total_observations"] = link_data.get(
+                    "forward_count", 0
+                ) + link_data.get("return_count", 0)
+                obs = link_data["total_observations"] or link_data.get("packet_count", 1)
+                link_data["strength"] = round(
+                    min(8.0, max(1.5, 1.5 + 2.5 * math.log10(max(1, obs)))), 1
+                )
+                if overall_reliability is not None:
+                    link_data["success_rate"] = overall_reliability
 
             logger.info("Generated %d packet-based RF links", len(link_map))
             result = list(link_map.values())

--- a/src/malla/services/traceroute_service.py
+++ b/src/malla/services/traceroute_service.py
@@ -24,6 +24,7 @@ from ..models.traceroute import (
 )
 from ..utils.node_utils import get_bulk_node_names
 from ..utils.signal_quality import (
+    TRACEROUTE_UNKNOWN_SNR,
     calculate_estimated_reliability,
     classify_link_balance,
     classify_signal_quality,
@@ -1161,6 +1162,11 @@ class TracerouteService:
                         # Create bidirectional link key (sorted to ensure consistency)
                         link_key = tuple(sorted([hop.from_node_id, hop.to_node_id]))
                         is_forward = hop.from_node_id == link_key[0]
+                        # The -32.0 sentinel is a real hop with unrecorded SNR:
+                        # keep it out of the directional averages.
+                        directional_snr = (
+                            None if hop.snr == TRACEROUTE_UNKNOWN_SNR else hop.snr
+                        )
 
                         # Add/update direct link
                         if link_key not in direct_links:
@@ -1169,8 +1175,12 @@ class TracerouteService:
                                 "target": link_key[1],
                                 "channel_id": tr_data.get("channel_id"),
                                 "snr_values": [hop.snr],
-                                "forward_snr_values": [hop.snr] if is_forward else [],
-                                "return_snr_values": [] if is_forward else [hop.snr],
+                                "forward_snr_values": [directional_snr]
+                                if is_forward and directional_snr is not None
+                                else [],
+                                "return_snr_values": [directional_snr]
+                                if not is_forward and directional_snr is not None
+                                else [],
                                 "packet_count": 1,
                                 "last_seen": tr_data["timestamp"],
                                 "last_packet_id": tr_data["id"],
@@ -1181,10 +1191,11 @@ class TracerouteService:
                             if not link.get("channel_id") and tr_data.get("channel_id"):
                                 link["channel_id"] = tr_data.get("channel_id")
                             link["snr_values"].append(hop.snr)
-                            if is_forward:
-                                link["forward_snr_values"].append(hop.snr)
-                            else:
-                                link["return_snr_values"].append(hop.snr)
+                            if directional_snr is not None:
+                                if is_forward:
+                                    link["forward_snr_values"].append(directional_snr)
+                                else:
+                                    link["return_snr_values"].append(directional_snr)
                             link["packet_count"] += 1
                             if tr_data["timestamp"] > link["last_seen"]:
                                 link["last_seen"] = tr_data["timestamp"]

--- a/src/malla/services/traceroute_service.py
+++ b/src/malla/services/traceroute_service.py
@@ -23,7 +23,13 @@ from ..models.traceroute import (
     TraceroutePacket,  # Use the correct TraceroutePacket class
 )
 from ..utils.node_utils import get_bulk_node_names
-from ..utils.signal_quality import is_plausible_traceroute_snr
+from ..utils.signal_quality import (
+    calculate_estimated_reliability,
+    classify_link_balance,
+    classify_signal_quality,
+    is_plausible_snr,
+    is_plausible_traceroute_snr,
+)
 from ..utils.traceroute_utils import parse_traceroute_payload
 
 logger = logging.getLogger(__name__)
@@ -1161,6 +1167,7 @@ class TracerouteService:
                             direct_links[link_key] = {
                                 "source": link_key[0],
                                 "target": link_key[1],
+                                "channel_id": tr_data.get("channel_id"),
                                 "snr_values": [hop.snr],
                                 "forward_snr_values": [hop.snr] if is_forward else [],
                                 "return_snr_values": [] if is_forward else [hop.snr],
@@ -1171,6 +1178,8 @@ class TracerouteService:
                             stats["links_found"] += 1
                         else:
                             link = direct_links[link_key]
+                            if not link.get("channel_id") and tr_data.get("channel_id"):
+                                link["channel_id"] = tr_data.get("channel_id")
                             link["snr_values"].append(hop.snr)
                             if is_forward:
                                 link["forward_snr_values"].append(hop.snr)
@@ -1180,6 +1189,8 @@ class TracerouteService:
                             if tr_data["timestamp"] > link["last_seen"]:
                                 link["last_seen"] = tr_data["timestamp"]
                                 link["last_packet_id"] = tr_data["id"]
+                                if tr_data.get("channel_id"):
+                                    link["channel_id"] = tr_data.get("channel_id")
 
                         # Track connections for nodes
                         nodes[hop.from_node_id]["connections"].add(hop.to_node_id)
@@ -1252,7 +1263,7 @@ class TracerouteService:
                 logger.warning(f"Error fetching location data: {e}")
                 location_map = {}
 
-            # Process direct links - calculate average SNR and strength
+            # Process direct links - calculate average SNR, quality, and observation strength
             processed_links = []
             for link_data in direct_links.values():
                 avg_snr = sum(link_data["snr_values"]) / len(link_data["snr_values"])
@@ -1263,21 +1274,50 @@ class TracerouteService:
                 )
                 return_avg_snr = round(sum(r_snrs) / len(r_snrs), 1) if r_snrs else None
 
-                # Calculate link strength based on SNR and packet count
-                # Higher SNR and more packets = stronger link
+                valid_snrs = [
+                    s
+                    for s in (forward_avg_snr, return_avg_snr)
+                    if s is not None and is_plausible_snr(s)
+                ]
+                worst_snr = (
+                    min(valid_snrs)
+                    if valid_snrs
+                    else (round(avg_snr, 1) if is_plausible_snr(avg_snr) else None)
+                )
+
+                link_sf = link_data.get("channel_id")
+                forward_quality = classify_signal_quality(forward_avg_snr, sf=link_sf)
+                return_quality = classify_signal_quality(return_avg_snr, sf=link_sf)
+                overall_quality = classify_signal_quality(worst_snr, sf=link_sf)
+                link_balance = classify_link_balance(
+                    forward_avg_snr, return_avg_snr, sf=link_sf
+                )
+                estimated_reliability = calculate_estimated_reliability(
+                    worst_snr, sf=link_sf
+                )
+
+                # Decoupled strength: strictly reflects observation volume (packet count)
+                # Maps 1 packet -> 1.5px, 10 packets -> 4.0px, 100 packets -> 6.5px, max 8.0px
                 strength = min(
-                    10,
-                    max(1, (avg_snr + 20) / 5 + math.log10(link_data["packet_count"])),
+                    8.0,
+                    max(1.5, 1.5 + 2.5 * math.log10(max(1, link_data["packet_count"]))),
                 )
 
                 processed_links.append(
                     {
                         "source": link_data["source"],
                         "target": link_data["target"],
+                        "channel_id": link_sf,
                         "type": "direct",
                         "avg_snr": round(avg_snr, 1),
                         "forward_avg_snr": forward_avg_snr,
                         "return_avg_snr": return_avg_snr,
+                        "worst_snr": worst_snr,
+                        "forward_quality": forward_quality,
+                        "return_quality": return_quality,
+                        "overall_quality": overall_quality,
+                        "link_balance": link_balance,
+                        "estimated_reliability": estimated_reliability,
                         "forward_count": len(f_snrs),
                         "return_count": len(r_snrs),
                         "packet_count": link_data["packet_count"],
@@ -1324,6 +1364,8 @@ class TracerouteService:
                 if node_data["snr_count"] > 0:
                     avg_snr = round(node_data["total_snr"] / node_data["snr_count"], 1)
 
+                node_quality = classify_signal_quality(avg_snr)
+
                 # Get location data for this node
                 location = location_map.get(node_data["id"])
 
@@ -1333,6 +1375,7 @@ class TracerouteService:
                     "packet_count": node_data["packet_count"],
                     "connections": node_data["connections"],
                     "avg_snr": avg_snr,
+                    "quality": node_quality,
                     "last_seen": node_data["last_seen"],
                     "size": min(
                         20, max(5, math.log10(node_data["packet_count"] + 1) * 3)

--- a/src/malla/services/traceroute_service.py
+++ b/src/malla/services/traceroute_service.py
@@ -1154,6 +1154,7 @@ class TracerouteService:
 
                         # Create bidirectional link key (sorted to ensure consistency)
                         link_key = tuple(sorted([hop.from_node_id, hop.to_node_id]))
+                        is_forward = hop.from_node_id == link_key[0]
 
                         # Add/update direct link
                         if link_key not in direct_links:
@@ -1161,6 +1162,8 @@ class TracerouteService:
                                 "source": link_key[0],
                                 "target": link_key[1],
                                 "snr_values": [hop.snr],
+                                "forward_snr_values": [hop.snr] if is_forward else [],
+                                "return_snr_values": [] if is_forward else [hop.snr],
                                 "packet_count": 1,
                                 "last_seen": tr_data["timestamp"],
                                 "last_packet_id": tr_data["id"],
@@ -1169,6 +1172,10 @@ class TracerouteService:
                         else:
                             link = direct_links[link_key]
                             link["snr_values"].append(hop.snr)
+                            if is_forward:
+                                link["forward_snr_values"].append(hop.snr)
+                            else:
+                                link["return_snr_values"].append(hop.snr)
                             link["packet_count"] += 1
                             if tr_data["timestamp"] > link["last_seen"]:
                                 link["last_seen"] = tr_data["timestamp"]
@@ -1249,6 +1256,12 @@ class TracerouteService:
             processed_links = []
             for link_data in direct_links.values():
                 avg_snr = sum(link_data["snr_values"]) / len(link_data["snr_values"])
+                f_snrs = link_data.get("forward_snr_values", [])
+                r_snrs = link_data.get("return_snr_values", [])
+                forward_avg_snr = (
+                    round(sum(f_snrs) / len(f_snrs), 1) if f_snrs else None
+                )
+                return_avg_snr = round(sum(r_snrs) / len(r_snrs), 1) if r_snrs else None
 
                 # Calculate link strength based on SNR and packet count
                 # Higher SNR and more packets = stronger link
@@ -1263,6 +1276,10 @@ class TracerouteService:
                         "target": link_data["target"],
                         "type": "direct",
                         "avg_snr": round(avg_snr, 1),
+                        "forward_avg_snr": forward_avg_snr,
+                        "return_avg_snr": return_avg_snr,
+                        "forward_count": len(f_snrs),
+                        "return_count": len(r_snrs),
                         "packet_count": link_data["packet_count"],
                         "strength": round(strength, 1),
                         "last_seen": link_data["last_seen"],

--- a/src/malla/templates/map.html
+++ b/src/malla/templates/map.html
@@ -1429,8 +1429,10 @@ function drawTracerouteLinksFiltered(filterNodeId = null) {
 
         // Half closest to fromNode = reception at fromNode (Return: toNode -> fromNode)
         // Half closest to toNode = reception at toNode (Forward: fromNode -> toNode)
-        let colorA = link.return_quality ? getQualityColor(link.return_quality) : (hasReturn ? '#28a745' : '#888888');
-        let colorB = link.forward_quality ? getQualityColor(link.forward_quality) : (hasForward ? '#28a745' : '#888888');
+        // 'unknown' quality (or a missing classification) renders grey via
+        // getQualityColor's default, never green.
+        let colorA = link.return_quality ? getQualityColor(link.return_quality) : '#888888';
+        let colorB = link.forward_quality ? getQualityColor(link.forward_quality) : '#888888';
 
         if (!hasForward && !hasReturn && link.overall_quality) {
             colorA = getQualityColor(link.overall_quality);

--- a/src/malla/templates/map.html
+++ b/src/malla/templates/map.html
@@ -1572,6 +1572,90 @@ function createLinkPopupContent(link) {
         losButton.addEventListener('click', () => showLineOfSight(link.from_node_id, link.to_node_id));
     }
 
+    // Build directional / average SNR elements
+    const snrElements = [];
+    const hasForwardSnr = link.forward_avg_snr !== null && link.forward_avg_snr !== undefined;
+    const hasReturnSnr = link.return_avg_snr !== null && link.return_avg_snr !== undefined;
+
+    if (hasForwardSnr && hasReturnSnr) {
+        snrElements.push(
+            el('div', null,
+                el('strong', null, 'Forward SNR:'),
+                textNode(` ${link.forward_avg_snr.toFixed(1)} dB `),
+                el('span', { className: 'text-muted small' }, `(${fromName} → ${toName})`)
+            ),
+            el('div', null,
+                el('strong', null, 'Return SNR:'),
+                textNode(` ${link.return_avg_snr.toFixed(1)} dB `),
+                el('span', { className: 'text-muted small' }, `(${toName} → ${fromName})`)
+            ),
+            link.avg_snr !== null && link.avg_snr !== undefined ? el('div', { className: 'text-muted small' },
+                el('strong', null, 'Combined Avg SNR:'),
+                textNode(` ${link.avg_snr.toFixed(1)} dB`)
+            ) : null
+        );
+    } else if (hasForwardSnr) {
+        snrElements.push(
+            el('div', null,
+                el('strong', null, 'Forward SNR:'),
+                textNode(` ${link.forward_avg_snr.toFixed(1)} dB `),
+                el('span', { className: 'text-muted small' }, `(${fromName} → ${toName})`)
+            )
+        );
+    } else if (hasReturnSnr) {
+        snrElements.push(
+            el('div', null,
+                el('strong', null, 'Return SNR:'),
+                textNode(` ${link.return_avg_snr.toFixed(1)} dB `),
+                el('span', { className: 'text-muted small' }, `(${toName} → ${fromName})`)
+            )
+        );
+    } else if (link.avg_snr !== null && link.avg_snr !== undefined) {
+        snrElements.push(
+            el('div', null, el('strong', null, 'Avg SNR:'), textNode(` ${link.avg_snr.toFixed(1)} dB`))
+        );
+    }
+
+    // Build directional / average RSSI elements
+    const rssiElements = [];
+    const hasForwardRssi = link.forward_avg_rssi !== null && link.forward_avg_rssi !== undefined;
+    const hasReturnRssi = link.return_avg_rssi !== null && link.return_avg_rssi !== undefined;
+
+    if (hasForwardRssi && hasReturnRssi) {
+        rssiElements.push(
+            el('div', null,
+                el('strong', null, 'Forward RSSI:'),
+                textNode(` ${link.forward_avg_rssi.toFixed(0)} dBm `),
+                el('span', { className: 'text-muted small' }, `(${fromName} → ${toName})`)
+            ),
+            el('div', null,
+                el('strong', null, 'Return RSSI:'),
+                textNode(` ${link.return_avg_rssi.toFixed(0)} dBm `),
+                el('span', { className: 'text-muted small' }, `(${toName} → ${fromName})`)
+            )
+        );
+    } else if (hasForwardRssi) {
+        rssiElements.push(
+            el('div', null,
+                el('strong', null, 'Forward RSSI:'),
+                textNode(` ${link.forward_avg_rssi.toFixed(0)} dBm `),
+                el('span', { className: 'text-muted small' }, `(${fromName} → ${toName})`)
+            )
+        );
+    } else if (hasReturnRssi) {
+        rssiElements.push(
+            el('div', null,
+                el('strong', null, 'Return RSSI:'),
+                textNode(` ${link.return_avg_rssi.toFixed(0)} dBm `),
+                el('span', { className: 'text-muted small' }, `(${toName} → ${fromName})`)
+            )
+        );
+    } else if (link.avg_rssi !== null && link.avg_rssi !== undefined) {
+        rssiElements.push(
+            el('div', null, el('strong', null, 'Avg RSSI:'), textNode(` ${link.avg_rssi.toFixed(0)} dBm`))
+        );
+    }
+
     return el('div', { className: 'traceroute-link-info' },
         el('div', { className: 'fw-bold mb-2' }, link.link_type === 'packet' ? 'Direct Packet Link' : 'Traceroute RF Hop'),
         el('div', null, el('strong', null, 'From:'), textNode(` ${fromName}`)),
@@ -1579,8 +1663,8 @@ function createLinkPopupContent(link) {
         el('div', null, el('strong', null, 'Success Rate:'), textNode(' '), el('span', { className: qualityClass }, `${link.success_rate.toFixed(1)}%`)),
         el('div', null, el('strong', null, 'Attempts:'), textNode(` ${link.total_hops_seen}`)),
         el('div', null, el('strong', null, 'Last Seen:'), textNode(` ${formattedTime}`)),
-        link.avg_snr ? el('div', null, el('strong', null, 'Avg SNR:'), textNode(` ${link.avg_snr.toFixed(1)} dB`)) : null,
-        link.avg_rssi ? el('div', null, el('strong', null, 'Avg RSSI:'), textNode(` ${link.avg_rssi.toFixed(0)} dBm`)) : null,
+        ...snrElements,
+        ...rssiElements,
         el('div', { className: 'mt-2 d-flex gap-1' }, historyButton, losButton)
     );
 }

--- a/src/malla/templates/map.html
+++ b/src/malla/templates/map.html
@@ -1421,39 +1421,56 @@ function drawTracerouteLinksFiltered(filterNodeId = null) {
             return; // Skip if either node doesn't have position
         }
 
-        // Determine link color and style based on success rate and SNR
-        let linkColor = '#999999';
-        let linkWeight = 2;
-        let linkOpacity = 0.6;
+        // Calculate midpoint between fromPos and toPos for split two-half line
+        const midPos = [(fromPos[0] + toPos[0]) / 2, (fromPos[1] + toPos[1]) / 2];
 
-        // If filtering by node, highlight the selected node's links
+        const hasForward = link.forward_avg_snr !== null && link.forward_avg_snr !== undefined;
+        const hasReturn = link.return_avg_snr !== null && link.return_avg_snr !== undefined;
+
+        // Half closest to fromNode = reception at fromNode (Return: toNode -> fromNode)
+        // Half closest to toNode = reception at toNode (Forward: fromNode -> toNode)
+        let colorA = link.return_quality ? getQualityColor(link.return_quality) : (hasReturn ? '#28a745' : '#888888');
+        let colorB = link.forward_quality ? getQualityColor(link.forward_quality) : (hasForward ? '#28a745' : '#888888');
+
+        if (!hasForward && !hasReturn && link.overall_quality) {
+            colorA = getQualityColor(link.overall_quality);
+            colorB = colorA;
+        }
+
+        const dashA = hasReturn ? null : '3, 5';
+        const dashB = hasForward ? null : '3, 5';
+
+        const totalObs = link.total_observations || link.total_hops_seen || ((link.forward_count || 0) + (link.return_count || 0)) || 1;
+        const baseWeight = (link.strength !== undefined && link.strength !== null)
+            ? link.strength
+            : Math.min(8.0, Math.max(1.5, 1.5 + 2.5 * Math.log10(Math.max(1, totalObs))));
+        let linkWeight = baseWeight;
+        let linkOpacity = 0.75;
         if (filterNodeId !== null) {
-            linkWeight = 3; // Make filtered links thicker
-            linkOpacity = 0.9; // Make them more opaque
+            linkWeight = baseWeight + 1.0;
+            linkOpacity = 0.95;
         }
 
-        if (link.success_rate >= 80) {
-            linkColor = '#28a745'; // Green for high success
-        } else if (link.success_rate >= 50) {
-            linkColor = '#ffc107'; // Yellow for medium success
-        } else {
-            linkColor = '#dc3545'; // Red for low success
-        }
-
-        // Create the line
-        const line = L.polyline([fromPos, toPos], {
-            color: linkColor,
+        const segA = L.polyline([fromPos, midPos], {
+            color: colorA,
             weight: linkWeight,
-            opacity: linkOpacity,
-            dashArray: link.success_rate < 50 ? '5, 5' : null // Dashed for unreliable links
+            opacity: hasReturn ? linkOpacity : 0.45,
+            dashArray: dashA
         });
 
-        // Add popup with link information
-        const popupContent = createLinkPopupContent(link);
-        line.bindPopup(popupContent);
+        const segB = L.polyline([midPos, toPos], {
+            color: colorB,
+            weight: linkWeight,
+            opacity: hasForward ? linkOpacity : 0.45,
+            dashArray: dashB
+        });
 
-        line.addTo(map);
-        tracerouteLinks.push(line);
+        const linkGroup = L.featureGroup([segA, segB]);
+        const popupContent = createLinkPopupContent(link);
+        linkGroup.bindPopup(popupContent);
+
+        linkGroup.addTo(map);
+        tracerouteLinks.push(linkGroup);
     });
 }
 
@@ -1497,47 +1514,80 @@ function drawPacketLinksFiltered(filterNodeId = null) {
             return; // Skip if either node doesn't have position
         }
 
-        // Determine link color and style based on success rate and SNR
-        let linkColor = '#999999';
-        let linkWeight = 2;
-        let linkOpacity = 0.6;
+        const midPos = [(fromPos[0] + toPos[0]) / 2, (fromPos[1] + toPos[1]) / 2];
 
-        // If filtering by node, highlight the selected node's links
+        const hasForward = link.forward_avg_snr !== null && link.forward_avg_snr !== undefined;
+        const hasReturn = link.return_avg_snr !== null && link.return_avg_snr !== undefined;
+
+        let colorA = link.return_quality ? getQualityColor(link.return_quality) : (hasReturn ? '#28a745' : '#888888');
+        let colorB = link.forward_quality ? getQualityColor(link.forward_quality) : (hasForward ? '#28a745' : '#888888');
+
+        if (!hasForward && !hasReturn && link.overall_quality) {
+            colorA = getQualityColor(link.overall_quality);
+            colorB = colorA;
+        }
+
+        // Direct packet links get distinctive dash pattern
+        const dashA = hasReturn ? '6, 4' : '2, 5';
+        const dashB = hasForward ? '6, 4' : '2, 5';
+
+        const totalObs = link.total_observations || link.packet_count || 1;
+        const baseWeight = (link.strength !== undefined && link.strength !== null)
+            ? link.strength
+            : Math.min(8.0, Math.max(1.5, 1.5 + 2.5 * Math.log10(Math.max(1, totalObs))));
+        let linkWeight = baseWeight;
+        let linkOpacity = 0.75;
         if (filterNodeId !== null) {
-            linkWeight = 3; // Make filtered links thicker
-            linkOpacity = 0.9; // Make them more opaque
+            linkWeight = baseWeight + 1.0;
+            linkOpacity = 0.95;
         }
 
-        if (link.success_rate >= 80) {
-            linkColor = '#28a745'; // Green for high success
-        } else if (link.success_rate >= 50) {
-            linkColor = '#ffc107'; // Yellow for medium success
-        } else {
-            linkColor = '#dc3545'; // Red for low success
-        }
-
-        // Packet links get dashed style to visually distinguish
-        const isPacket = link.link_type === 'packet';
-
-        const line = L.polyline([fromPos, toPos], {
-            color: linkColor,
+        const segA = L.polyline([fromPos, midPos], {
+            color: colorA,
             weight: linkWeight,
-            opacity: linkOpacity,
-            dashArray: isPacket ? '3, 6' : (link.success_rate < 50 ? '5, 5' : null)
+            opacity: hasReturn ? linkOpacity : 0.45,
+            dashArray: dashA
         });
 
-        // Add popup with link information
-        const popupContent = createLinkPopupContent(link);
-        line.bindPopup(popupContent);
+        const segB = L.polyline([midPos, toPos], {
+            color: colorB,
+            weight: linkWeight,
+            opacity: hasForward ? linkOpacity : 0.45,
+            dashArray: dashB
+        });
 
-        line.addTo(map);
-        packetLinks.push(line);
+        const linkGroup = L.featureGroup([segA, segB]);
+        const popupContent = createLinkPopupContent(link);
+        linkGroup.bindPopup(popupContent);
+
+        linkGroup.addTo(map);
+        packetLinks.push(linkGroup);
     });
 }
 
 // Draw only links connected to a specific node
 function drawFilteredPacketLinks(nodeId) {
     drawPacketLinksFiltered(nodeId);
+}
+
+// Signal quality color lookup
+function getQualityColor(quality) {
+    switch (quality) {
+        case 'good': return '#28a745';
+        case 'fair': return '#ffc107';
+        case 'marginal': return '#dc3545';
+        default: return '#888888';
+    }
+}
+
+// Signal quality Bootstrap badge class lookup
+function getQualityBadgeClass(quality) {
+    switch (quality) {
+        case 'good': return 'bg-success';
+        case 'fair': return 'bg-warning text-dark';
+        case 'marginal': return 'bg-danger';
+        default: return 'bg-secondary';
+    }
 }
 
 // Create popup content for traceroute links
@@ -1547,10 +1597,6 @@ function createLinkPopupContent(link) {
 
     const fromName = fromNode ? fromNode.display_name : `!${link.from_node_id.toString(16).padStart(8, '0')}`;
     const toName = toNode ? toNode.display_name : `!${link.to_node_id.toString(16).padStart(8, '0')}`;
-
-    let qualityClass = 'text-success';
-    if (link.success_rate < 50) qualityClass = 'text-danger';
-    else if (link.success_rate < 80) qualityClass = 'text-warning';
 
     // Format timestamp using timezone preference
     const formattedTime = (typeof formatTimestamp === 'function' && link.last_seen)
@@ -1572,6 +1618,50 @@ function createLinkPopupContent(link) {
         losButton.addEventListener('click', () => showLineOfSight(link.from_node_id, link.to_node_id));
     }
 
+    // Reliability & Link Quality Badge
+    let reliabilityBadge = null;
+    if (link.estimated_reliability !== null && link.estimated_reliability !== undefined) {
+        const qualityName = link.overall_quality ? (link.overall_quality.charAt(0).toUpperCase() + link.overall_quality.slice(1)) : 'Estimated';
+        const badgeClass = getQualityBadgeClass(link.overall_quality || 'unknown');
+        reliabilityBadge = el('span', { className: `badge ${badgeClass} ms-1` }, `${link.estimated_reliability.toFixed(0)}% (${qualityName})`);
+    } else if (link.success_rate !== null && link.success_rate !== undefined) {
+        reliabilityBadge = el('span', { className: 'badge bg-secondary ms-1' }, `${link.success_rate.toFixed(0)}%`);
+    }
+
+    // Practical Asymmetry Alert
+    let balanceAlert = null;
+    if (link.link_balance === 'asymmetric_marginal') {
+        const marginalDir = link.forward_quality === 'marginal'
+            ? `${fromName} → ${toName} marginal`
+            : `${toName} → ${fromName} marginal`;
+        balanceAlert = el('div', { className: 'alert alert-warning py-1 px-2 my-2 small d-flex align-items-center gap-1' },
+            el('strong', null, '⚠️ Asymmetric:'),
+            textNode(` ${marginalDir}`)
+        );
+    } else if (link.link_balance === 'marginal_both') {
+        balanceAlert = el('div', { className: 'alert alert-danger py-1 px-2 my-2 small' },
+            el('strong', null, '⚠️ Fragile:'),
+            textNode(' Both directions marginal')
+        );
+    } else if (link.link_balance === 'unidirectional') {
+        balanceAlert = el('div', { className: 'text-muted small my-1' },
+            el('em', null, 'Single direction observed')
+        );
+    }
+
+    // Observations display
+    const fCount = link.forward_count || 0;
+    const rCount = link.return_count || 0;
+    const totalObs = link.total_observations || link.total_hops_seen || (fCount + rCount);
+    let obsText = `${totalObs}`;
+    if (fCount > 0 && rCount > 0) {
+        obsText = `${totalObs} (${fCount} forward, ${rCount} return)`;
+    } else if (fCount > 0) {
+        obsText = `${totalObs} (${fCount} forward)`;
+    } else if (rCount > 0) {
+        obsText = `${totalObs} (${rCount} return)`;
+    }
+
     // Build directional / average SNR elements
     const snrElements = [];
     const hasForwardSnr = link.forward_avg_snr !== null && link.forward_avg_snr !== undefined;
@@ -1582,11 +1672,13 @@ function createLinkPopupContent(link) {
             el('div', null,
                 el('strong', null, 'Forward SNR:'),
                 textNode(` ${link.forward_avg_snr.toFixed(1)} dB `),
+                link.forward_quality ? el('span', { className: `badge ${getQualityBadgeClass(link.forward_quality)} me-1` }, link.forward_quality) : null,
                 el('span', { className: 'text-muted small' }, `(${fromName} → ${toName})`)
             ),
             el('div', null,
                 el('strong', null, 'Return SNR:'),
                 textNode(` ${link.return_avg_snr.toFixed(1)} dB `),
+                link.return_quality ? el('span', { className: `badge ${getQualityBadgeClass(link.return_quality)} me-1` }, link.return_quality) : null,
                 el('span', { className: 'text-muted small' }, `(${toName} → ${fromName})`)
             ),
             link.avg_snr !== null && link.avg_snr !== undefined ? el('div', { className: 'text-muted small' },
@@ -1599,6 +1691,7 @@ function createLinkPopupContent(link) {
             el('div', null,
                 el('strong', null, 'Forward SNR:'),
                 textNode(` ${link.forward_avg_snr.toFixed(1)} dB `),
+                link.forward_quality ? el('span', { className: `badge ${getQualityBadgeClass(link.forward_quality)} me-1` }, link.forward_quality) : null,
                 el('span', { className: 'text-muted small' }, `(${fromName} → ${toName})`)
             )
         );
@@ -1607,6 +1700,7 @@ function createLinkPopupContent(link) {
             el('div', null,
                 el('strong', null, 'Return SNR:'),
                 textNode(` ${link.return_avg_snr.toFixed(1)} dB `),
+                link.return_quality ? el('span', { className: `badge ${getQualityBadgeClass(link.return_quality)} me-1` }, link.return_quality) : null,
                 el('span', { className: 'text-muted small' }, `(${toName} → ${fromName})`)
             )
         );
@@ -1657,11 +1751,12 @@ function createLinkPopupContent(link) {
     }
 
     return el('div', { className: 'traceroute-link-info' },
-        el('div', { className: 'fw-bold mb-2' }, link.link_type === 'packet' ? 'Direct Packet Link' : 'Traceroute RF Hop'),
+        el('div', { className: 'fw-bold mb-1' }, link.link_type === 'packet' ? 'Direct Packet Link' : 'Traceroute RF Hop'),
+        balanceAlert,
         el('div', null, el('strong', null, 'From:'), textNode(` ${fromName}`)),
         el('div', null, el('strong', null, 'To:'), textNode(` ${toName}`)),
-        el('div', null, el('strong', null, 'Success Rate:'), textNode(' '), el('span', { className: qualityClass }, `${link.success_rate.toFixed(1)}%`)),
-        el('div', null, el('strong', null, 'Attempts:'), textNode(` ${link.total_hops_seen}`)),
+        reliabilityBadge ? el('div', { className: 'mb-1' }, el('strong', null, 'Estimated Reliability:'), reliabilityBadge) : null,
+        el('div', null, el('strong', null, 'Observations:'), textNode(` ${obsText}`)),
         el('div', null, el('strong', null, 'Last Seen:'), textNode(` ${formattedTime}`)),
         ...snrElements,
         ...rssiElements,

--- a/src/malla/templates/traceroute_hops.html
+++ b/src/malla/templates/traceroute_hops.html
@@ -109,7 +109,7 @@
                         <div class="col-md-3">
                             <div class="text-center">
                                 <h3 id="total-hops" class="text-primary">-</h3>
-                                <small class="text-muted">Total Hops Seen</small>
+                                <small class="text-muted">Total Observations</small>
                             </div>
                         </div>
                         <div class="col-md-3">
@@ -552,7 +552,7 @@
         document.getElementById('results-section').style.display = 'block';
 
         // Update summary
-        document.getElementById('total-hops').textContent = data.total_attempts;
+        document.getElementById('total-hops').textContent = data.total_observations || data.total_attempts;
         document.getElementById('avg-snr').textContent = data.avg_snr ? `${data.avg_snr.toFixed(1)}` : 'N/A';
         const dirSnrDiv = document.getElementById('directional-snr');
         if (dirSnrDiv) {
@@ -561,10 +561,12 @@
             const n1Display = formatNodeIdForDisplay(data.from_node_id);
             const n2Display = formatNodeIdForDisplay(data.to_node_id);
             if (data.forward_avg_snr !== null && data.forward_avg_snr !== undefined) {
-                parts.push(el('div', null, `${n1Display} → ${n2Display}: `, el('strong', null, `${data.forward_avg_snr.toFixed(1)} dB`)));
+                const fQual = data.forward_quality ? ` [${data.forward_quality.toUpperCase()}]` : '';
+                parts.push(el('div', null, `${n1Display} → ${n2Display}: `, el('strong', null, `${data.forward_avg_snr.toFixed(1)} dB`), el('span', { className: 'text-muted small ms-1' }, fQual)));
             }
             if (data.return_avg_snr !== null && data.return_avg_snr !== undefined) {
-                parts.push(el('div', null, `${n2Display} → ${n1Display}: `, el('strong', null, `${data.return_avg_snr.toFixed(1)} dB`)));
+                const rQual = data.return_quality ? ` [${data.return_quality.toUpperCase()}]` : '';
+                parts.push(el('div', null, `${n2Display} → ${n1Display}: `, el('strong', null, `${data.return_avg_snr.toFixed(1)} dB`), el('span', { className: 'text-muted small ms-1' }, rQual)));
             }
             if (parts.length > 0) {
                 appendChildren(dirSnrDiv, ...parts);
@@ -577,7 +579,7 @@
         document.getElementById('geo-distance').textContent = geoDistance;
 
         // Display direction information with proper node formatting
-        displayDirectionInfo(data.direction_counts, data.from_node_id, data.to_node_id);
+        displayDirectionInfo(data, data.from_node_id, data.to_node_id);
 
         // Update charts
         updateSNRChart(data.traceroutes);
@@ -618,9 +620,9 @@
         }
     }
 
-    function displayDirectionInfo(directionCounts, fromNodeId, toNodeId) {
+    function displayDirectionInfo(data, fromNodeId, toNodeId) {
         const directionDiv = document.getElementById('direction-info');
-
+        const directionCounts = (data && data.direction_counts) ? data.direction_counts : {};
         const directions = Object.keys(directionCounts);
         const content = fragment(
             el('strong', 'Link Analysis:'),
@@ -631,12 +633,23 @@
             el('br')
         );
 
-        if (directions.length > 1) {
-            appendChildren(content, badge('Bidirectional Link', 'bg-success signal-badge'));
+        if (data && data.link_balance === 'asymmetric_marginal') {
+            appendChildren(content, badge('⚠️ Asymmetric Link (Marginal Direction)', 'bg-warning text-dark signal-badge me-2'));
+        } else if (data && data.link_balance === 'marginal_both') {
+            appendChildren(content, badge('⚠️ Fragile Link (Both Sides Marginal)', 'bg-danger signal-badge me-2'));
+        } else if (data && data.link_balance === 'balanced') {
+            appendChildren(content, badge('Balanced Two-Way Link', 'bg-success signal-badge me-2'));
+        } else if (directions.length > 1) {
+            appendChildren(content, badge('Bidirectional Link', 'bg-success signal-badge me-2'));
         } else if (directions.length === 1) {
-            appendChildren(content, badge('Unidirectional Link', 'bg-warning signal-badge'));
+            appendChildren(content, badge('Unidirectional Link', 'bg-warning signal-badge me-2'));
         } else {
-            appendChildren(content, badge('No Data', 'bg-secondary signal-badge'));
+            appendChildren(content, badge('No Data', 'bg-secondary signal-badge me-2'));
+        }
+
+        if (data && data.estimated_reliability !== null && data.estimated_reliability !== undefined) {
+            const relBadgeClass = data.overall_quality === 'good' ? 'bg-success' : (data.overall_quality === 'fair' ? 'bg-warning text-dark' : 'bg-danger');
+            appendChildren(content, badge(`Estimated Reliability: ${data.estimated_reliability.toFixed(0)}%`, `${relBadgeClass} signal-badge`));
         }
 
         if (directions.length > 1) {

--- a/src/malla/templates/traceroute_hops.html
+++ b/src/malla/templates/traceroute_hops.html
@@ -116,6 +116,7 @@
                             <div class="text-center">
                                 <h3 id="avg-snr" class="text-success">-</h3>
                                 <small class="text-muted">Average SNR (dB)</small>
+                                <div id="directional-snr" class="small text-muted mt-1" style="font-size: 0.75rem;"></div>
                             </div>
                         </div>
                         <div class="col-md-3">
@@ -553,6 +554,22 @@
         // Update summary
         document.getElementById('total-hops').textContent = data.total_attempts;
         document.getElementById('avg-snr').textContent = data.avg_snr ? `${data.avg_snr.toFixed(1)}` : 'N/A';
+        const dirSnrDiv = document.getElementById('directional-snr');
+        if (dirSnrDiv) {
+            dirSnrDiv.replaceChildren();
+            const parts = [];
+            const n1Display = formatNodeIdForDisplay(data.from_node_id);
+            const n2Display = formatNodeIdForDisplay(data.to_node_id);
+            if (data.forward_avg_snr !== null && data.forward_avg_snr !== undefined) {
+                parts.push(el('div', null, `${n1Display} → ${n2Display}: `, el('strong', null, `${data.forward_avg_snr.toFixed(1)} dB`)));
+            }
+            if (data.return_avg_snr !== null && data.return_avg_snr !== undefined) {
+                parts.push(el('div', null, `${n2Display} → ${n1Display}: `, el('strong', null, `${data.return_avg_snr.toFixed(1)} dB`)));
+            }
+            if (parts.length > 0) {
+                appendChildren(dirSnrDiv, ...parts);
+            }
+        }
         document.getElementById('last-seen').textContent = getRelativeTime(data.traceroutes[0]?.timestamp);
 
         // Calculate and display geographic distance

--- a/src/malla/utils/signal_quality.py
+++ b/src/malla/utils/signal_quality.py
@@ -16,7 +16,7 @@ Conventions shared with Meshtastic firmware:
 """
 
 import math
-from typing import TypeGuard
+from typing import Any, TypeGuard
 
 RSSI_PLAUSIBLE_MIN = -150  # dBm; below any LoRa sensitivity floor (~-137)
 RSSI_PLAUSIBLE_MAX = -1  # dBm; 0 is the "not provided" sentinel, positive is garbage
@@ -74,3 +74,194 @@ def is_plausible_traceroute_snr(value: float | int | None) -> TypeGuard[float]:
     return value is not None and (
         value == TRACEROUTE_UNKNOWN_SNR or is_plausible_snr(value)
     )
+
+
+# ---------------------------------------------------------------------------
+# LoRa Modem Presets, Spreading Factors, & Hardware Demodulation Limits
+# ---------------------------------------------------------------------------
+
+# Standard Meshtastic presets and known custom/regional presets (e.g. SFNarrow in Spain)
+LORA_PRESET_DEFINITIONS: dict[str, dict[str, Any]] = {
+    # Standard Meshtastic presets
+    "shortfast": {"sf": 7, "bw_khz": 250, "name": "ShortFast"},
+    "shortturbo": {"sf": 7, "bw_khz": 500, "name": "ShortTurbo"},
+    "shortslow": {"sf": 8, "bw_khz": 250, "name": "ShortSlow"},
+    "mediumfast": {"sf": 9, "bw_khz": 250, "name": "MediumFast"},
+    "mediumslow": {"sf": 10, "bw_khz": 250, "name": "MediumSlow"},
+    "longfast": {"sf": 11, "bw_khz": 250, "name": "LongFast"},
+    "longmoderate": {"sf": 11, "bw_khz": 125, "name": "LongModerate"},
+    "longslow": {"sf": 12, "bw_khz": 125, "name": "LongSlow"},
+    "verylongslow": {"sf": 12, "bw_khz": 62.5, "name": "VeryLongSlow"},
+    # Known regional & custom configurations
+    "sfnarrow": {"sf": 7, "bw_khz": 62.5, "name": "SFNarrow (Spain)"},
+    "sfnarrow8": {"sf": 8, "bw_khz": 62.5, "name": "SFNarrow SF8"},
+    "eunarrow": {"sf": 8, "bw_khz": 62.5, "name": "EU Narrow"},
+}
+
+DEFAULT_SPREADING_FACTOR = 11  # LongFast default
+
+
+def resolve_spreading_factor(
+    preset_or_sf: str | int | None = None,
+) -> int:
+    """Resolve a modem preset name, custom config name, or spreading factor integer to an SF (7-12).
+
+    If not provided or unresolvable, falls back to application config (``lora_spreading_factor``
+    or ``lora_preset``), defaulting to 11 (LongFast).
+    """
+    if isinstance(preset_or_sf, int):
+        if 7 <= preset_or_sf <= 12:
+            return preset_or_sf
+
+    if isinstance(preset_or_sf, str) and preset_or_sf.strip():
+        cleaned = preset_or_sf.strip().lower().replace("-", "").replace("_", "")
+        # Check known dictionary
+        if cleaned in LORA_PRESET_DEFINITIONS:
+            return int(LORA_PRESET_DEFINITIONS[cleaned]["sf"])
+
+        # Check for direct SF designation e.g. "sf7", "sf8", "sf11"
+        for sf in range(7, 13):
+            if f"sf{sf}" in cleaned:
+                return sf
+
+        # Check if single or double digit matches SF
+        if cleaned.isdigit():
+            val = int(cleaned)
+            if 7 <= val <= 12:
+                return val
+
+    # Fallback to AppConfig
+    try:
+        from ..config import get_config
+
+        config = get_config()
+        if config.lora_spreading_factor is not None:
+            if 7 <= config.lora_spreading_factor <= 12:
+                return config.lora_spreading_factor
+
+        if config.lora_preset:
+            cleaned_cfg = (
+                config.lora_preset.strip().lower().replace("-", "").replace("_", "")
+            )
+            if cleaned_cfg in LORA_PRESET_DEFINITIONS:
+                return int(LORA_PRESET_DEFINITIONS[cleaned_cfg]["sf"])
+            for sf in range(7, 13):
+                if f"sf{sf}" in cleaned_cfg:
+                    return sf
+    except Exception:
+        pass
+
+    return DEFAULT_SPREADING_FACTOR
+
+
+def get_demodulation_snr_limit(sf: int) -> float:
+    """Theoretical LoRa hardware demodulation limit (Semtech SX1262/SX1276) for a given Spreading Factor.
+
+    Formula: ``-2.5 * (SF - 4)`` dB.
+    SF7: -7.5 dB, SF8: -10.0 dB, SF9: -12.5 dB, SF10: -15.0 dB, SF11: -17.5 dB, SF12: -20.0 dB.
+    """
+    clamped_sf = max(7, min(12, sf))
+    return -2.5 * (clamped_sf - 4)
+
+
+def calculate_fade_margin(
+    snr: float | None, sf: int | str | None = None
+) -> float | None:
+    """Calculate the fade margin (dB above hardware demodulation limit) for a given SNR.
+
+    Returns None if SNR is None or invalid.
+    """
+    if snr is None or not is_plausible_snr(snr):
+        return None
+    effective_sf = resolve_spreading_factor(sf)
+    snr_limit = get_demodulation_snr_limit(effective_sf)
+    return round(snr - snr_limit, 1)
+
+
+def classify_signal_quality(snr: float | None, sf: int | str | None = None) -> str:
+    """Classify SNR into quality tiers relative to the modem preset's demodulation limit:
+
+    - 'good': Margin >= +10.0 dB (robust link margin)
+    - 'fair': +4.0 dB <= Margin < +10.0 dB (usable, moderate fade margin)
+    - 'marginal': Margin < +4.0 dB (fragile, high packet drop probability)
+    - 'unknown': Missing or invalid SNR
+    """
+    margin = calculate_fade_margin(snr, sf)
+    if margin is None:
+        return "unknown"
+    if margin >= 10.0:
+        return "good"
+    if margin >= 4.0:
+        return "fair"
+    return "marginal"
+
+
+def calculate_estimated_reliability(
+    snr: float | None, sf: int | str | None = None
+) -> float | None:
+    """Estimate packet delivery reliability (0.0 to 100.0%) from SNR fade margin using LoRa sigmoid model.
+
+    Returns None if SNR is None or invalid.
+    """
+    margin = calculate_fade_margin(snr, sf)
+    if margin is None:
+        return None
+
+    # Sigmoid function centered around Margin = 2.5 dB with steepness k = 0.6
+    # Margin >= 10 dB -> ~99%
+    # Margin = 6 dB -> ~89%
+    # Margin = 4 dB -> ~71%
+    # Margin = 2 dB -> ~43%
+    # Margin = 0 dB (at cliff) -> ~18%
+    # Margin < 0 dB (below cliff) -> < 10%
+    exponent = -0.6 * (margin - 2.5)
+    # Clamp exponent to prevent overflow
+    exponent = max(-20.0, min(20.0, exponent))
+    reliability = 100.0 / (1.0 + math.exp(exponent))
+    return round(max(0.0, min(100.0, reliability)), 1)
+
+
+def classify_link_balance(
+    forward_snr: float | None,
+    return_snr: float | None,
+    sf: int | str | None = None,
+) -> str:
+    """Classify the practical operational balance between forward and return links:
+
+    - 'balanced': Both directions observed and neither is marginal.
+    - 'asymmetric_marginal': Both directions observed, but exactly one is marginal while the other is viable.
+    - 'marginal_both': Both directions observed and both are marginal.
+    - 'unidirectional': Only one direction has observed SNR.
+    - 'unknown': Neither direction has valid SNR.
+    """
+    has_f = forward_snr is not None and is_plausible_snr(forward_snr)
+    has_r = return_snr is not None and is_plausible_snr(return_snr)
+
+    if not has_f and not has_r:
+        return "unknown"
+    if has_f and not has_r:
+        return "unidirectional"
+    if has_r and not has_f:
+        return "unidirectional"
+
+    q_f = classify_signal_quality(forward_snr, sf)
+    q_r = classify_signal_quality(return_snr, sf)
+
+    if q_f == "marginal" and q_r == "marginal":
+        return "marginal_both"
+    if (q_f == "marginal" and q_r != "marginal") or (
+        q_r == "marginal" and q_f != "marginal"
+    ):
+        return "asymmetric_marginal"
+    return "balanced"
+
+
+def get_quality_color(quality: str) -> str:
+    """Return standard hex color for a given quality tier."""
+    colors = {
+        "good": "#28a745",  # Green
+        "fair": "#ffc107",  # Yellow/Amber
+        "marginal": "#dc3545",  # Red
+        "unknown": "#888888",  # Muted grey
+    }
+    return colors.get(quality, "#888888")

--- a/tests/unit/test_rf_hop_directional_snr.py
+++ b/tests/unit/test_rf_hop_directional_snr.py
@@ -1,0 +1,258 @@
+"""
+Unit tests for directional RF hop average SNR analysis.
+"""
+
+import time
+from unittest.mock import MagicMock, Mock, patch
+
+from src.malla.models.traceroute import TracerouteHop, TraceroutePacket
+from src.malla.services.location_service import LocationService
+from src.malla.services.traceroute_service import TracerouteService
+
+
+class TestRFHopDirectionalSNR:
+    """Test directional SNR separation in network graph, location service, and API."""
+
+    @patch("src.malla.services.traceroute_service.get_bulk_node_names")
+    @patch("src.malla.services.traceroute_service.LocationRepository")
+    @patch("src.malla.services.traceroute_service.TraceroutePacket")
+    @patch("src.malla.services.traceroute_service.TracerouteRepository")
+    def test_network_graph_separates_forward_and_return_snr(
+        self, mock_repo, mock_packet_cls, mock_loc_repo, mock_names
+    ):
+        """Test that get_network_graph_data separates forward vs return SNR."""
+        mock_names.return_value = {10: "Node10", 20: "Node20"}
+        mock_loc_repo.get_node_locations.return_value = []
+
+        # Two packets: packet 1 has hop 10 -> 20 (SNR = 5.0), packet 2 has hop 20 -> 10 (SNR = -3.0)
+        packets = [
+            {
+                "id": 1,
+                "from_node_id": 10,
+                "to_node_id": 20,
+                "timestamp": 1000.0,
+                "raw_payload": b"dummy1",
+            },
+            {
+                "id": 2,
+                "from_node_id": 20,
+                "to_node_id": 10,
+                "timestamp": 1010.0,
+                "raw_payload": b"dummy2",
+            },
+        ]
+        mock_repo.get_traceroute_packets_for_graph.return_value = packets
+
+        hop1 = Mock()
+        hop1.from_node_id = 10
+        hop1.to_node_id = 20
+        hop1.from_node_name = "Node10"
+        hop1.to_node_name = "Node20"
+        hop1.snr = 5.0
+
+        hop2 = Mock()
+        hop2.from_node_id = 20
+        hop2.to_node_id = 10
+        hop2.from_node_name = "Node20"
+        hop2.to_node_name = "Node10"
+        hop2.snr = -3.0
+
+        p1 = Mock()
+        p1.get_rf_hops.return_value = [hop1]
+        p2 = Mock()
+        p2.get_rf_hops.return_value = [hop2]
+
+        mock_packet_cls.side_effect = [p1, p2]
+
+        # Use unique hours or clear cache
+        graph = TracerouteService.get_network_graph_data(
+            hours=99, min_snr=-200.0, include_indirect=False
+        )
+
+        assert len(graph["links"]) == 1
+        link = graph["links"][0]
+        assert link["source"] == 10
+        assert link["target"] == 20
+        # Combined avg SNR = (5.0 + -3.0) / 2 = 1.0
+        assert link["avg_snr"] == 1.0
+        # Forward: 10 -> 20: 5.0
+        assert link["forward_avg_snr"] == 5.0
+        assert link["forward_count"] == 1
+        # Return: 20 -> 10: -3.0
+        assert link["return_avg_snr"] == -3.0
+        assert link["return_count"] == 1
+
+    def test_location_service_get_traceroute_links_exposes_directional_snr(self):
+        """Test that get_traceroute_links includes forward_avg_snr and return_avg_snr."""
+        network_data = {
+            "links": [
+                {
+                    "source": 10,
+                    "target": 20,
+                    "packet_count": 4,
+                    "last_seen": 1000.0,
+                    "avg_snr": 1.0,
+                    "forward_avg_snr": 5.0,
+                    "return_avg_snr": -3.0,
+                    "forward_count": 2,
+                    "return_count": 2,
+                    "last_packet_id": 42,
+                }
+            ]
+        }
+        links = LocationService.get_traceroute_links(network_data=network_data)
+        assert len(links) == 1
+        link = links[0]
+        assert link["from_node_id"] == 10
+        assert link["to_node_id"] == 20
+        assert link["avg_snr"] == 1.0
+        assert link["forward_avg_snr"] == 5.0
+        assert link["return_avg_snr"] == -3.0
+        assert link["forward_count"] == 2
+        assert link["return_count"] == 2
+
+    @patch("src.malla.database.connection.get_db_connection")
+    def test_location_service_get_packet_links_directional_snr(self, mock_db_conn):
+        """Test that get_packet_links computes forward and return SNR for bidirectional packet links."""
+        from src.malla.services.location_service import _PACKET_LINKS_CACHE
+
+        _PACKET_LINKS_CACHE.clear()
+
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        # Two rows: node 10 -> gateway 20, and node 20 -> gateway 10
+        mock_cursor.fetchall.return_value = [
+            {
+                "from_node_id": 10,
+                "gateway_id": "!00000014",  # 20 in hex
+                "packet_count": 5,
+                "avg_rssi": -90.0,
+                "avg_snr": 6.0,
+                "last_seen": 1000.0,
+            },
+            {
+                "from_node_id": 20,
+                "gateway_id": "!0000000a",  # 10 in hex
+                "packet_count": 3,
+                "avg_rssi": -100.0,
+                "avg_snr": -2.0,
+                "last_seen": 1020.0,
+            },
+        ]
+        mock_db_conn.return_value = mock_conn
+
+        links = LocationService.get_packet_links()
+        assert len(links) == 1
+        link = links[0]
+        assert link["from_node_id"] == 10
+        assert link["to_node_id"] == 20
+        assert link["is_bidirectional"] is True
+        assert link["forward_avg_snr"] == 6.0
+        assert link["return_avg_snr"] == -2.0
+        assert link["forward_count"] == 5
+        assert link["return_count"] == 3
+        assert link["forward_avg_rssi"] == -90.0
+        assert link["return_avg_rssi"] == -100.0
+
+    def test_api_traceroute_link_directional_snr(self, client):
+        """Test that /api/traceroute/link returns separated forward and return SNRs."""
+        node1_id = 1000
+        node2_id = 2000
+
+        mock_packets = [
+            {
+                "id": 101,
+                "timestamp": time.time(),
+                "timestamp_str": "2024-01-20 10:30:00",
+                "from_node_id": node1_id,
+                "to_node_id": node2_id,
+                "gateway_id": 3000,
+                "raw_payload": b"fake1",
+            },
+            {
+                "id": 102,
+                "timestamp": time.time(),
+                "timestamp_str": "2024-01-20 10:32:00",
+                "from_node_id": node1_id,
+                "to_node_id": node2_id,
+                "gateway_id": 3000,
+                "raw_payload": b"fake2",
+            },
+            {
+                "id": 103,
+                "timestamp": time.time(),
+                "timestamp_str": "2024-01-20 10:35:00",
+                "from_node_id": node2_id,
+                "to_node_id": node1_id,
+                "gateway_id": 3000,
+                "raw_payload": b"fake3",
+            },
+        ]
+
+        p1 = MagicMock(spec=TraceroutePacket)
+        p1.from_node_name = "Node 1000"
+        p1.to_node_name = "Node 2000"
+        p1.gateway_id = 3000
+        p1.format_path_display.return_value = "1000 -> 2000"
+        hop1 = MagicMock(spec=TracerouteHop)
+        hop1.from_node_id = node1_id
+        hop1.to_node_id = node2_id
+        hop1.from_node_name = "Node 1000"
+        hop1.to_node_name = "Node 2000"
+        hop1.snr = 8.0
+        hop1.direction = "forward_rf"
+        p1.get_rf_hops.return_value = [hop1]
+
+        p2 = MagicMock(spec=TraceroutePacket)
+        p2.from_node_name = "Node 1000"
+        p2.to_node_name = "Node 2000"
+        p2.gateway_id = 3000
+        p2.format_path_display.return_value = "1000 -> 2000"
+        hop2 = MagicMock(spec=TracerouteHop)
+        hop2.from_node_id = node1_id
+        hop2.to_node_id = node2_id
+        hop2.from_node_name = "Node 1000"
+        hop2.to_node_name = "Node 2000"
+        hop2.snr = 5.0
+        hop2.direction = "forward_rf"
+        p2.get_rf_hops.return_value = [hop2]
+
+        p3 = MagicMock(spec=TraceroutePacket)
+        p3.from_node_name = "Node 2000"
+        p3.to_node_name = "Node 1000"
+        p3.gateway_id = 3000
+        p3.format_path_display.return_value = "2000 -> 1000"
+        hop3 = MagicMock(spec=TracerouteHop)
+        hop3.from_node_id = node2_id
+        hop3.to_node_id = node1_id
+        hop3.from_node_name = "Node 2000"
+        hop3.to_node_name = "Node 1000"
+        hop3.snr = 1.0
+        hop3.direction = "return_rf"
+        p3.get_rf_hops.return_value = [hop3]
+
+        with (
+            patch("src.malla.routes.api_routes.TracerouteRepository") as mock_repo,
+            patch("src.malla.routes.api_routes.NodeRepository") as mock_nodes,
+            patch("src.malla.routes.api_routes.TraceroutePacket") as mock_pkt_cls,
+        ):
+            mock_repo.get_traceroute_packets.return_value = {"packets": mock_packets}
+            mock_nodes.get_bulk_node_names.return_value = {
+                node1_id: "Node 1000",
+                node2_id: "Node 2000",
+                3000: "Gateway Node",
+            }
+            mock_pkt_cls.side_effect = [p1, p2, p3]
+
+            response = client.get(f"/api/traceroute/link/{node1_id}/{node2_id}")
+            assert response.status_code == 200
+            data = response.get_json()
+
+            assert data["forward_avg_snr"] == 6.5
+            assert data["return_avg_snr"] == 1.0
+            assert data["forward_count"] == 2
+            assert data["return_count"] == 1
+            # (8.0 + 5.0 + 1.0) / 3 = 4.6666... rounded to 1 decimal is 4.7
+            assert data["avg_snr"] == 4.7

--- a/tests/unit/test_rf_hop_directional_snr.py
+++ b/tests/unit/test_rf_hop_directional_snr.py
@@ -7,7 +7,11 @@ from unittest.mock import MagicMock, Mock, patch
 
 from src.malla.models.traceroute import TracerouteHop, TraceroutePacket
 from src.malla.services.location_service import LocationService
-from src.malla.services.traceroute_service import TracerouteService
+from src.malla.services.traceroute_service import (
+    _NETWORK_GRAPH_CACHE,
+    TracerouteService,
+)
+from src.malla.utils.signal_quality import TRACEROUTE_UNKNOWN_SNR
 
 
 class TestRFHopDirectionalSNR:
@@ -87,6 +91,127 @@ class TestRFHopDirectionalSNR:
         assert link["estimated_reliability"] is not None
         # Strength is decoupled: packet_count=2 -> 1.5 + 2.5 * log10(2) ~= 2.3
         assert 1.5 <= link["strength"] <= 8.0
+
+    @patch("src.malla.services.traceroute_service.get_bulk_node_names")
+    @patch("src.malla.services.traceroute_service.LocationRepository")
+    @patch("src.malla.services.traceroute_service.TraceroutePacket")
+    @patch("src.malla.services.traceroute_service.TracerouteRepository")
+    def test_network_graph_excludes_unknown_snr_sentinel_from_directional_avg(
+        self, mock_repo, mock_packet_cls, mock_loc_repo, mock_names
+    ):
+        """A -32.0 sentinel must not drag directional averages down.
+
+        Firmware encodes "SNR unknown" as -32.0; it passes
+        is_plausible_traceroute_snr so the hop stays visible. Forward
+        readings of [8.0, -32.0] must average 8.0, not -12.0.
+        """
+        _NETWORK_GRAPH_CACHE.clear()
+        mock_names.return_value = {10: "Node10", 20: "Node20"}
+        mock_loc_repo.get_node_locations.return_value = []
+
+        packets = [
+            {
+                "id": 1,
+                "from_node_id": 10,
+                "to_node_id": 20,
+                "timestamp": 1000.0,
+                "raw_payload": b"dummy1",
+            },
+            {
+                "id": 2,
+                "from_node_id": 10,
+                "to_node_id": 20,
+                "timestamp": 1010.0,
+                "raw_payload": b"dummy2",
+            },
+        ]
+        mock_repo.get_traceroute_packets_for_graph.return_value = packets
+
+        hop1 = Mock()
+        hop1.from_node_id = 10
+        hop1.to_node_id = 20
+        hop1.from_node_name = "Node10"
+        hop1.to_node_name = "Node20"
+        hop1.snr = 8.0
+
+        hop2 = Mock()
+        hop2.from_node_id = 10
+        hop2.to_node_id = 20
+        hop2.from_node_name = "Node10"
+        hop2.to_node_name = "Node20"
+        hop2.snr = TRACEROUTE_UNKNOWN_SNR
+
+        p1 = Mock()
+        p1.get_rf_hops.return_value = [hop1]
+        p2 = Mock()
+        p2.get_rf_hops.return_value = [hop2]
+
+        mock_packet_cls.side_effect = [p1, p2]
+
+        graph = TracerouteService.get_network_graph_data(
+            hours=98, min_snr=-200.0, include_indirect=False
+        )
+
+        assert len(graph["links"]) == 1
+        link = graph["links"][0]
+        assert link["forward_avg_snr"] == 8.0
+        assert link["forward_count"] == 1
+        assert link["return_avg_snr"] is None
+        assert link["return_count"] == 0
+        # The sentinel hop is still an observation of the link
+        assert link["packet_count"] == 2
+        assert link["worst_snr"] == 8.0
+        assert link["overall_quality"] != "unknown"
+        assert link["link_balance"] == "unidirectional"
+
+    @patch("src.malla.services.traceroute_service.get_bulk_node_names")
+    @patch("src.malla.services.traceroute_service.LocationRepository")
+    @patch("src.malla.services.traceroute_service.TraceroutePacket")
+    @patch("src.malla.services.traceroute_service.TracerouteRepository")
+    def test_network_graph_sentinel_only_direction_has_no_directional_avg(
+        self, mock_repo, mock_packet_cls, mock_loc_repo, mock_names
+    ):
+        """A direction observed only via the -32.0 sentinel reports no SNR, not -32.0."""
+        _NETWORK_GRAPH_CACHE.clear()
+        mock_names.return_value = {10: "Node10", 20: "Node20"}
+        mock_loc_repo.get_node_locations.return_value = []
+
+        packets = [
+            {
+                "id": 1,
+                "from_node_id": 10,
+                "to_node_id": 20,
+                "timestamp": 1000.0,
+                "raw_payload": b"dummy1",
+            }
+        ]
+        mock_repo.get_traceroute_packets_for_graph.return_value = packets
+
+        hop1 = Mock()
+        hop1.from_node_id = 10
+        hop1.to_node_id = 20
+        hop1.from_node_name = "Node10"
+        hop1.to_node_name = "Node20"
+        hop1.snr = TRACEROUTE_UNKNOWN_SNR
+
+        p1 = Mock()
+        p1.get_rf_hops.return_value = [hop1]
+
+        mock_packet_cls.side_effect = [p1]
+
+        graph = TracerouteService.get_network_graph_data(
+            hours=97, min_snr=-200.0, include_indirect=False
+        )
+
+        assert len(graph["links"]) == 1
+        link = graph["links"][0]
+        assert link["forward_avg_snr"] is None
+        assert link["forward_count"] == 0
+        assert link["return_avg_snr"] is None
+        assert link["worst_snr"] is None
+        assert link["packet_count"] == 1
+        assert link["overall_quality"] == "unknown"
+        assert link["estimated_reliability"] is None
 
     def test_location_service_get_traceroute_links_exposes_directional_snr(self):
         """Test that get_traceroute_links includes forward_avg_snr and return_avg_snr."""
@@ -270,6 +395,245 @@ class TestRFHopDirectionalSNR:
             assert data["return_count"] == 1
             # (8.0 + 5.0 + 1.0) / 3 = 4.6666... rounded to 1 decimal is 4.7
             assert data["avg_snr"] == 4.7
+
+    def test_api_traceroute_link_excludes_unknown_snr_sentinel_from_directional_avg(
+        self, client
+    ):
+        """A -32.0 sentinel must not skew /api/traceroute/link directional averages."""
+        node1_id = 1000
+        node2_id = 2000
+
+        mock_packets = [
+            {
+                "id": 201,
+                "timestamp": time.time(),
+                "timestamp_str": "2024-01-20 11:30:00",
+                "from_node_id": node1_id,
+                "to_node_id": node2_id,
+                "gateway_id": 3000,
+                "raw_payload": b"fake1",
+            },
+            {
+                "id": 202,
+                "timestamp": time.time(),
+                "timestamp_str": "2024-01-20 11:32:00",
+                "from_node_id": node1_id,
+                "to_node_id": node2_id,
+                "gateway_id": 3000,
+                "raw_payload": b"fake2",
+            },
+        ]
+
+        p1 = MagicMock(spec=TraceroutePacket)
+        p1.from_node_name = "Node 1000"
+        p1.to_node_name = "Node 2000"
+        p1.gateway_id = 3000
+        p1.format_path_display.return_value = "1000 -> 2000"
+        hop1 = MagicMock(spec=TracerouteHop)
+        hop1.from_node_id = node1_id
+        hop1.to_node_id = node2_id
+        hop1.from_node_name = "Node 1000"
+        hop1.to_node_name = "Node 2000"
+        hop1.snr = 8.0
+        hop1.direction = "forward_rf"
+        p1.get_rf_hops.return_value = [hop1]
+
+        p2 = MagicMock(spec=TraceroutePacket)
+        p2.from_node_name = "Node 1000"
+        p2.to_node_name = "Node 2000"
+        p2.gateway_id = 3000
+        p2.format_path_display.return_value = "1000 -> 2000"
+        hop2 = MagicMock(spec=TracerouteHop)
+        hop2.from_node_id = node1_id
+        hop2.to_node_id = node2_id
+        hop2.from_node_name = "Node 1000"
+        hop2.to_node_name = "Node 2000"
+        hop2.snr = TRACEROUTE_UNKNOWN_SNR
+        hop2.direction = "forward_rf"
+        p2.get_rf_hops.return_value = [hop2]
+
+        with (
+            patch("src.malla.routes.api_routes.TracerouteRepository") as mock_repo,
+            patch("src.malla.routes.api_routes.NodeRepository") as mock_nodes,
+            patch("src.malla.routes.api_routes.TraceroutePacket") as mock_pkt_cls,
+        ):
+            mock_repo.get_traceroute_packets.return_value = {"packets": mock_packets}
+            mock_nodes.get_bulk_node_names.return_value = {
+                node1_id: "Node 1000",
+                node2_id: "Node 2000",
+                3000: "Gateway Node",
+            }
+            mock_pkt_cls.side_effect = [p1, p2]
+
+            response = client.get(f"/api/traceroute/link/{node1_id}/{node2_id}")
+            assert response.status_code == 200
+            data = response.get_json()
+
+            assert data["forward_avg_snr"] == 8.0
+            assert data["forward_count"] == 1
+            assert data["return_avg_snr"] is None
+            assert data["return_count"] == 0
+            assert data["total_observations"] == 1
+            assert data["worst_snr"] == 8.0
+            assert data["link_balance"] == "unidirectional"
+
+    def test_api_traceroute_link_aggregates_both_hops_in_single_packet(
+        self, client
+    ):
+        """A single traceroute packet containing both forward (8 dB) and return (-16 dB) hops
+        must aggregate both directional metrics while keeping one history entry per packet.
+        """
+        node1_id = 1000
+        node2_id = 2000
+
+        mock_packets = [
+            {
+                "id": 301,
+                "timestamp": time.time(),
+                "timestamp_str": "2024-01-20 12:30:00",
+                "from_node_id": node1_id,
+                "to_node_id": node2_id,
+                "gateway_id": 3000,
+                "raw_payload": b"fake_bidirectional",
+            }
+        ]
+
+        p = MagicMock(spec=TraceroutePacket)
+        p.from_node_name = "Node 1000"
+        p.to_node_name = "Node 2000"
+        p.gateway_id = 3000
+        p.format_path_display.return_value = "1000 <-> 2000"
+
+        hop_fwd = MagicMock(spec=TracerouteHop)
+        hop_fwd.from_node_id = node1_id
+        hop_fwd.to_node_id = node2_id
+        hop_fwd.from_node_name = "Node 1000"
+        hop_fwd.to_node_name = "Node 2000"
+        hop_fwd.snr = 8.0
+        hop_fwd.direction = "forward_rf"
+
+        hop_ret = MagicMock(spec=TracerouteHop)
+        hop_ret.from_node_id = node2_id
+        hop_ret.to_node_id = node1_id
+        hop_ret.from_node_name = "Node 2000"
+        hop_ret.to_node_name = "Node 1000"
+        hop_ret.snr = -16.0
+        hop_ret.direction = "return_rf"
+
+        p.get_rf_hops.return_value = [hop_fwd, hop_ret]
+
+        with (
+            patch("src.malla.routes.api_routes.TracerouteRepository") as mock_repo,
+            patch("src.malla.routes.api_routes.NodeRepository") as mock_nodes,
+            patch("src.malla.routes.api_routes.TraceroutePacket") as mock_pkt_cls,
+        ):
+            mock_repo.get_traceroute_packets.return_value = {"packets": mock_packets}
+            mock_nodes.get_bulk_node_names.return_value = {
+                node1_id: "Node 1000",
+                node2_id: "Node 2000",
+                3000: "Gateway Node",
+            }
+            mock_pkt_cls.side_effect = [p]
+
+            response = client.get(f"/api/traceroute/link/{node1_id}/{node2_id}")
+            assert response.status_code == 200
+            data = response.get_json()
+
+            # Directional metrics must capture both hops
+            assert data["forward_avg_snr"] == 8.0
+            assert data["forward_count"] == 1
+            assert data["return_avg_snr"] == -16.0
+            assert data["return_count"] == 1
+            assert data["total_observations"] == 2
+
+            # Reliability calculated from the minimum value (-16.0 dB), not the first value (8.0 dB)
+            assert data["worst_snr"] == -16.0
+            assert data["estimated_reliability"] < 50.0
+            assert data["forward_reliability"] > 99.0
+            assert data["return_reliability"] < 50.0
+            assert data["link_balance"] == "asymmetric_marginal"
+
+            # Exactly one history entry per packet, with hop_snr reflecting the bottleneck (-16.0 dB)
+            assert data["total_attempts"] == 1
+            assert len(data["traceroutes"]) == 1
+            assert data["traceroutes"][0]["hop_snr"] == -16.0
+
+            # Direction counts record both observed directions
+            assert data["direction_counts"]["Node 1000 → Node 2000"] == 1
+            assert data["direction_counts"]["Node 2000 → Node 1000"] == 1
+
+    def test_api_traceroute_link_single_packet_with_sentinel_and_real_hop(
+        self, client
+    ):
+        """When a packet has one real hop and one -32.0 sentinel hop, the sentinel
+        must be excluded from directional SNR, avg_snr, and hop_snr."""
+        node1_id = 1000
+        node2_id = 2000
+
+        mock_packets = [
+            {
+                "id": 302,
+                "timestamp": time.time(),
+                "timestamp_str": "2024-01-20 12:35:00",
+                "from_node_id": node1_id,
+                "to_node_id": node2_id,
+                "gateway_id": 3000,
+                "raw_payload": b"fake_sentinel",
+            }
+        ]
+
+        p = MagicMock(spec=TraceroutePacket)
+        p.from_node_name = "Node 1000"
+        p.to_node_name = "Node 2000"
+        p.gateway_id = 3000
+        p.format_path_display.return_value = "1000 <-> 2000"
+
+        hop_fwd = MagicMock(spec=TracerouteHop)
+        hop_fwd.from_node_id = node1_id
+        hop_fwd.to_node_id = node2_id
+        hop_fwd.from_node_name = "Node 1000"
+        hop_fwd.to_node_name = "Node 2000"
+        hop_fwd.snr = 8.0
+        hop_fwd.direction = "forward_rf"
+
+        hop_ret = MagicMock(spec=TracerouteHop)
+        hop_ret.from_node_id = node2_id
+        hop_ret.to_node_id = node1_id
+        hop_ret.from_node_name = "Node 2000"
+        hop_ret.to_node_name = "Node 1000"
+        hop_ret.snr = TRACEROUTE_UNKNOWN_SNR
+        hop_ret.direction = "return_rf"
+
+        p.get_rf_hops.return_value = [hop_fwd, hop_ret]
+
+        with (
+            patch("src.malla.routes.api_routes.TracerouteRepository") as mock_repo,
+            patch("src.malla.routes.api_routes.NodeRepository") as mock_nodes,
+            patch("src.malla.routes.api_routes.TraceroutePacket") as mock_pkt_cls,
+        ):
+            mock_repo.get_traceroute_packets.return_value = {"packets": mock_packets}
+            mock_nodes.get_bulk_node_names.return_value = {
+                node1_id: "Node 1000",
+                node2_id: "Node 2000",
+                3000: "Gateway Node",
+            }
+            mock_pkt_cls.side_effect = [p]
+
+            response = client.get(f"/api/traceroute/link/{node1_id}/{node2_id}")
+            assert response.status_code == 200
+            data = response.get_json()
+
+            assert data["forward_avg_snr"] == 8.0
+            assert data["forward_count"] == 1
+            assert data["return_avg_snr"] is None
+            assert data["return_count"] == 0
+            assert data["total_observations"] == 1
+            assert data["worst_snr"] == 8.0
+            assert data["avg_snr"] == 8.0
+            assert data["traceroutes"][0]["hop_snr"] == 8.0
+            assert data["total_attempts"] == 1
+            assert data["direction_counts"]["Node 1000 → Node 2000"] == 1
+            assert data["direction_counts"]["Node 2000 → Node 1000"] == 1
 
     def test_dynamic_per_link_spreading_factor_resolution(self):
         """Test that get_traceroute_links uses the link's channel_id to determine SF thresholds."""

--- a/tests/unit/test_rf_hop_directional_snr.py
+++ b/tests/unit/test_rf_hop_directional_snr.py
@@ -81,6 +81,12 @@ class TestRFHopDirectionalSNR:
         # Return: 20 -> 10: -3.0
         assert link["return_avg_snr"] == -3.0
         assert link["return_count"] == 1
+        assert link["worst_snr"] == -3.0
+        assert link["overall_quality"] in ("good", "fair", "marginal")
+        assert link["link_balance"] in ("balanced", "asymmetric_marginal")
+        assert link["estimated_reliability"] is not None
+        # Strength is decoupled: packet_count=2 -> 1.5 + 2.5 * log10(2) ~= 2.3
+        assert 1.5 <= link["strength"] <= 8.0
 
     def test_location_service_get_traceroute_links_exposes_directional_snr(self):
         """Test that get_traceroute_links includes forward_avg_snr and return_avg_snr."""
@@ -110,6 +116,11 @@ class TestRFHopDirectionalSNR:
         assert link["return_avg_snr"] == -3.0
         assert link["forward_count"] == 2
         assert link["return_count"] == 2
+        assert link["worst_snr"] == -3.0
+        assert link["is_bidirectional"] is True
+        assert link["estimated_reliability"] is not None
+        assert link["link_balance"] in ("balanced", "asymmetric_marginal")
+        assert link["total_observations"] == 4
 
     @patch("src.malla.database.connection.get_db_connection")
     def test_location_service_get_packet_links_directional_snr(self, mock_db_conn):
@@ -151,6 +162,9 @@ class TestRFHopDirectionalSNR:
         assert link["is_bidirectional"] is True
         assert link["forward_avg_snr"] == 6.0
         assert link["return_avg_snr"] == -2.0
+        assert link["worst_snr"] == -2.0
+        assert link["estimated_reliability"] is not None
+        assert link["total_observations"] == 8
         assert link["forward_count"] == 5
         assert link["return_count"] == 3
         assert link["forward_avg_rssi"] == -90.0
@@ -256,3 +270,55 @@ class TestRFHopDirectionalSNR:
             assert data["return_count"] == 1
             # (8.0 + 5.0 + 1.0) / 3 = 4.6666... rounded to 1 decimal is 4.7
             assert data["avg_snr"] == 4.7
+
+    def test_dynamic_per_link_spreading_factor_resolution(self):
+        """Test that get_traceroute_links uses the link's channel_id to determine SF thresholds."""
+        # For SNR = -5.0 dB:
+        # On SFNarrow (SF7, demod limit -7.5 dB): margin is +2.5 dB (< 4 dB) -> marginal
+        # On LongFast (SF11, demod limit -17.5 dB): margin is +12.5 dB (>= 10 dB) -> good
+        network_data = {
+            "links": [
+                {
+                    "source": 100,
+                    "target": 200,
+                    "channel_id": "SFNarrow",
+                    "packet_count": 2,
+                    "last_seen": 1000.0,
+                    "avg_snr": -5.0,
+                    "forward_avg_snr": -5.0,
+                    "return_avg_snr": None,
+                    "forward_count": 2,
+                    "return_count": 0,
+                    "last_packet_id": 1,
+                },
+                {
+                    "source": 300,
+                    "target": 400,
+                    "channel_id": "LongFast",
+                    "packet_count": 2,
+                    "last_seen": 1000.0,
+                    "avg_snr": -5.0,
+                    "forward_avg_snr": -5.0,
+                    "return_avg_snr": None,
+                    "forward_count": 2,
+                    "return_count": 0,
+                    "last_packet_id": 2,
+                },
+            ]
+        }
+
+        tr_links = LocationService.get_traceroute_links(network_data=network_data)
+        assert len(tr_links) == 2
+
+        sfnarrow_link = next(lnk for lnk in tr_links if lnk["channel_id"] == "SFNarrow")
+        longfast_link = next(lnk for lnk in tr_links if lnk["channel_id"] == "LongFast")
+
+        # Under SFNarrow (SF7), -5.0 dB is marginal
+        assert sfnarrow_link["forward_quality"] == "marginal"
+        assert sfnarrow_link["overall_quality"] == "marginal"
+        assert sfnarrow_link["estimated_reliability"] == 50.0
+
+        # Under LongFast (SF11), -5.0 dB is good
+        assert longfast_link["forward_quality"] == "good"
+        assert longfast_link["overall_quality"] == "good"
+        assert longfast_link["estimated_reliability"] > 95.0

--- a/tests/unit/test_rf_signal_quality.py
+++ b/tests/unit/test_rf_signal_quality.py
@@ -1,0 +1,116 @@
+"""Unit tests for LoRa presets, demodulation thresholds, and link quality metrics."""
+
+from src.malla.utils.signal_quality import (
+    calculate_estimated_reliability,
+    calculate_fade_margin,
+    classify_link_balance,
+    classify_signal_quality,
+    get_demodulation_snr_limit,
+    get_quality_color,
+    resolve_spreading_factor,
+)
+
+
+class TestSignalQualityModels:
+    """Test preset resolution and demodulation thresholds."""
+
+    def test_resolve_spreading_factor_standard_presets(self):
+        assert resolve_spreading_factor("ShortFast") == 7
+        assert resolve_spreading_factor("shortturbo") == 7
+        assert resolve_spreading_factor("ShortSlow") == 8
+        assert resolve_spreading_factor("MediumFast") == 9
+        assert resolve_spreading_factor("MediumSlow") == 10
+        assert resolve_spreading_factor("LongFast") == 11
+        assert resolve_spreading_factor("LongSlow") == 12
+
+    def test_resolve_spreading_factor_custom_presets(self):
+        # Spain SFNarrow is SF7
+        assert resolve_spreading_factor("SFNarrow") == 7
+        assert resolve_spreading_factor("sfnarrow") == 7
+        assert resolve_spreading_factor("sfnarrow8") == 8
+        assert resolve_spreading_factor("eunarrow") == 8
+
+    def test_resolve_spreading_factor_numeric_and_substring(self):
+        assert resolve_spreading_factor(7) == 7
+        assert resolve_spreading_factor(12) == 12
+        assert resolve_spreading_factor("my-custom-sf8-network") == 8
+        assert resolve_spreading_factor("SF9") == 9
+
+    def test_get_demodulation_snr_limit(self):
+        # -2.5 * (SF - 4)
+        assert get_demodulation_snr_limit(7) == -7.5
+        assert get_demodulation_snr_limit(8) == -10.0
+        assert get_demodulation_snr_limit(9) == -12.5
+        assert get_demodulation_snr_limit(10) == -15.0
+        assert get_demodulation_snr_limit(11) == -17.5
+        assert get_demodulation_snr_limit(12) == -20.0
+
+    def test_calculate_fade_margin(self):
+        # On LongFast (SF11, limit = -17.5)
+        # SNR = -7.5 -> margin = -7.5 - (-17.5) = +10.0 dB
+        assert calculate_fade_margin(-7.5, sf=11) == 10.0
+        # On ShortFast / SFNarrow (SF7, limit = -7.5)
+        # SNR = -7.0 -> margin = -7.0 - (-7.5) = +0.5 dB (marginal!)
+        assert calculate_fade_margin(-7.0, sf="SFNarrow") == 0.5
+        # Invalid SNR
+        assert calculate_fade_margin(None) is None
+        assert calculate_fade_margin(100.0) is None  # Above plausible range
+
+    def test_classify_signal_quality_presets(self):
+        # On SFNarrow (SF7, limit -7.5):
+        # SNR +4.0 -> margin = 11.5 dB -> good
+        assert classify_signal_quality(4.0, sf="sfnarrow") == "good"
+        # SNR -1.0 -> margin = 6.5 dB -> fair
+        assert classify_signal_quality(-1.0, sf="sfnarrow") == "fair"
+        # SNR -7.0 -> margin = 0.5 dB -> marginal
+        assert classify_signal_quality(-7.0, sf="sfnarrow") == "marginal"
+
+        # On LongFast (SF11, limit -17.5):
+        # SNR -7.0 -> margin = 10.5 dB -> good on LongFast!
+        assert classify_signal_quality(-7.0, sf="LongFast") == "good"
+        # SNR -12.0 -> margin = 5.5 dB -> fair
+        assert classify_signal_quality(-12.0, sf="LongFast") == "fair"
+        # SNR -15.0 -> margin = 2.5 dB -> marginal
+        assert classify_signal_quality(-15.0, sf="LongFast") == "marginal"
+
+    def test_calculate_estimated_reliability(self):
+        # Strong margin (margin >= 10 dB) -> > 98%
+        rel_strong = calculate_estimated_reliability(4.0, sf="sfnarrow")
+        assert rel_strong is not None and rel_strong >= 98.0
+
+        # Fair margin (margin ~ 6.5 dB) -> ~ 90%
+        rel_fair = calculate_estimated_reliability(-1.0, sf="sfnarrow")
+        assert rel_fair is not None and 80.0 <= rel_fair <= 95.0
+
+        # Fragile margin (margin = 0.5 dB) -> < 30%
+        rel_fragile = calculate_estimated_reliability(-7.0, sf="sfnarrow")
+        assert rel_fragile is not None and rel_fragile < 30.0
+
+        # None on invalid
+        assert calculate_estimated_reliability(None) is None
+
+    def test_classify_link_balance_practical(self):
+        # On SFNarrow (SF7): +4 dB (good) and -7 dB (marginal)
+        # Exactly one is marginal -> asymmetric_marginal!
+        assert classify_link_balance(4.0, -7.0, sf="sfnarrow") == "asymmetric_marginal"
+        assert classify_link_balance(-7.0, 4.0, sf="sfnarrow") == "asymmetric_marginal"
+
+        # Both good -> balanced
+        assert classify_link_balance(4.0, 2.8, sf="sfnarrow") == "balanced"
+
+        # Both fair -> balanced
+        assert classify_link_balance(-1.0, -2.0, sf="sfnarrow") == "balanced"
+
+        # Both marginal -> marginal_both
+        assert classify_link_balance(-6.5, -7.0, sf="sfnarrow") == "marginal_both"
+
+        # One-way
+        assert classify_link_balance(4.0, None, sf="sfnarrow") == "unidirectional"
+        assert classify_link_balance(None, 4.0, sf="sfnarrow") == "unidirectional"
+        assert classify_link_balance(None, None, sf="sfnarrow") == "unknown"
+
+    def test_get_quality_color(self):
+        assert get_quality_color("good") == "#28a745"
+        assert get_quality_color("fair") == "#ffc107"
+        assert get_quality_color("marginal") == "#dc3545"
+        assert get_quality_color("unknown") == "#888888"


### PR DESCRIPTION
This PR adds link quality judgement per direction, per preset, and shows it in the map.

A radio link is only as good as its weakest direction — one node can hear
the other fine while the reply disappears into noise. Until now everything
was blended into a single average SNR and judged by raw cutoffs that ignore
the LoRa modem preset: −15 dB is a solid link on LongFast (SF11) but dead
air on SF7. 

## What it affects
- How link quality is judged and displayed across the whole app.
- New settings: `MALLA_LORA_PRESET` / `MALLA_LORA_SPREADING_FACTOR` (default LongFast).

## Changes
**Quality model (`utils/signal_quality.py`)**
- `resolve_spreading_factor()`: maps preset names (standard + regional like
  SFNarrow), "sfN" strings or raw SF integers to SF 7–12, falling back to
  the new settings.
- `get_demodulation_snr_limit()`: theoretical SX1262/SX1276 demodulation
  floor per spreading factor (−2.5 dB per SF step).
- `calculate_fade_margin()`: headroom above that floor.
- `classify_signal_quality()`: good (≥10 dB margin) / fair (≥4 dB) / marginal.
- `calculate_estimated_reliability()`: logistic curve margin→delivery rate
  (~99% at +10 dB, ~18% at the cliff).
- `classify_link_balance()`: balanced / asymmetric_marginal / marginal_both /
  unidirectional / unknown.
- `get_quality_color()`: one stable color per tier.

**Directional tracking**
- Forward/return SNR bucketed per link in `get_network_graph_data()`;
  LocationService passes fields through to map consumers.
- `/api/traceroute/link/<n1>/<n2>` reports `forward_avg_snr` / `return_avg_snr`
  relative to URL node order, uniform 1-decimal rounding, plus
  per-direction reliability.

**Scoring attached to every link**
- Graph, traceroute links and packet links all carry quality tiers, balance,
  estimated reliability, worst-direction SNR and observation count. Channel
  name from the MQTT topic (e.g. "LongFast") resolves the SF per link,
  falling back to the configured preset.
- Link strength redefined as pure observation volume (log-scaled count,
  clamped 1.5–8.0): thickness = how much data is behind the line; quality
  lives in the color tiers.

**UI**
- Map: each link drawn as two halves joined at the midpoint — the half near a
  node is colored by the quality of the signal that node receives; directions
  with no data render dashed/faded instead of being averaged away. Popup
  shows directional SNR/RSSI, counts, reliability, balance warnings. Packet
  links get a distinctive dash pattern.
- Hops page: "Total Hops Seen" → "Total Observations", per-direction quality
  tags, balance badges (balanced / asymmetric / fragile) and a reliability
  percentage colored by overall quality.

**Sentinel handling**
- The −32.0 "unknown SNR" sentinel no longer pollutes directional averages
  (it previously turned `[8.0, -32.0]` into −12.0 and a fake tier); sentinel
  hops still count as observations, they just contribute no SNR.
  Unclassified link halves render grey instead of falling back to green.

## Testing
- `test_rf_signal_quality.py`: preset resolution, demodulation limits, tier
  and reliability boundaries.
- `test_rf_hop_directional_snr.py`: graph aggregation, location mapping, link
  endpoint stats, link fields including per-link preset resolution (same
  SNR is good on LongFast, marginal on SFNarrow) and sentinel exclusion.

## Merge notes
No merge order is required — this PR is self-contained against `main`. It
does, however, restructure the same two functions as the traceroute data
pipeline PR (`fix/traceroute-data-pipeline`), so whichever of the two merges
second will show conflicts in `src/malla/routes/api_routes.py` and
`src/malla/services/traceroute_service.py`. The intended resolution is the
union of both: this PR's `matching_hops` loop keeps the pipeline's
`(traceroute_id, from_node_id, to_node_id)` dedup guard, and the graph
builder keeps both the dedup recency check and this PR's per-direction SNR
bucketing. That exact combination has been merged locally and passes the
full test suite — I'm happy to push a rebase onto whichever lands first.

## Commits
- feat(rf): add preset-aware link quality model
- feat(traceroute): track forward and return SNR separately per RF hop
- feat(api): attach quality, reliability and balance scores to RF links
- feat(ui): render per-direction link quality on the map
- feat(ui): add link balance and reliability badges to the hops page
- fix(traceroute): keep unknown-SNR sentinel out of directional metrics
